### PR TITLE
Add jwt_get_grant_json function

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -120,7 +120,7 @@ jwt_t *jwt_dup(jwt_t *jwt);
  */
 
 /**
- * Return the value of a grant.
+ * Return the value of a grant (must be a string).
  *
  * Returns the string value for a grant (e.g. "iss"). If it does not exit,
  * NULL will be returned.
@@ -131,6 +131,20 @@ jwt_t *jwt_dup(jwt_t *jwt);
  * @return Returns a string for the value, or NULL when not found.
  */
 const char *jwt_get_grant(jwt_t *jwt, const char *grant);
+
+/**
+ * Return the value of a grant (can be any object).
+ *
+ * Returns the plain text JSON representation of the value for a grant
+ * (e.g. "[ 42, 21, 48 ]"). If it does not exit, NULL will be
+ * returned. The returned string must be freed by the caller.
+ *
+ * @param jwt Pointer to a JWT object.
+ * @param grant String containing the name of the grant to return a value
+ *     for.
+ * @return Returns a string for the value, or NULL when not found.
+ */
+char *jwt_get_grant_json(jwt_t *jwt, const char *grant);
 
 /**
  * Add a new grant to this JWT object.

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -238,6 +238,19 @@ static const char *get_js_string(json_t *js, const char *key)
 	return val;
 }
 
+static char *get_js_object(json_t *js, const char *key)
+{
+	size_t flags = JSON_SORT_KEYS | JSON_COMPACT | JSON_ENCODE_ANY;
+	char *val = NULL;
+	json_t *js_val;
+
+	js_val = json_object_get(js, key);
+	if (js_val)
+		val = json_dumps(js_val, flags);
+
+	return val;
+}
+
 static json_t *jwt_b64_decode(char *src)
 {
 	BIO *b64, *bmem;

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -552,6 +552,16 @@ const char *jwt_get_grant(jwt_t *jwt, const char *grant)
 	return get_js_string(jwt->grants, grant);
 }
 
+char *jwt_get_grant_json(jwt_t *jwt, const char *grant)
+{
+	if (!jwt || !grant || !strlen(grant)) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	return get_js_object(jwt->grants, grant);
+}
+
 int jwt_add_grant(jwt_t *jwt, const char *grant, const char *val)
 {
 	if (!jwt || !grant || !strlen(grant) || !val)

--- a/tests/jwt_grant.c
+++ b/tests/jwt_grant.c
@@ -107,10 +107,11 @@ START_TEST(test_jwt_grants_json)
 {
 	const char *json = "{\"ref\":\"385d6518-fb73-45fc-b649-0527d8576130\""
 		",\"id\":\"FVvGYTr3FhiURCFebsBOpBqTbzHdX/DvImiA2yheXr8=\","
-		"\"iss\":\"localhost\",\"scopes\":\"storage\",\"sub\":"
-		"\"user0\"}";
+		"\"iss\":\"localhost\",\"scopes\":[\"storage\",\"email\","
+                "\"birthdate\"],\"sub\":{\"foo\":\"bar\",\"baz\":\"quux\"}}";
 	jwt_t *jwt = NULL;
 	const char *val;
+	char *val_json;
 	int ret = 0;
 
 	ret = jwt_new(&jwt);
@@ -123,6 +124,21 @@ START_TEST(test_jwt_grants_json)
 	val = jwt_get_grant(jwt, "ref");
 	ck_assert(val != NULL);
 	ck_assert_str_eq(val, "385d6518-fb73-45fc-b649-0527d8576130");
+
+	val_json = jwt_get_grant_json(jwt, "ref");
+	ck_assert(val_json != NULL);
+	ck_assert_str_eq(val_json, "\"385d6518-fb73-45fc-b649-0527d8576130\"");
+        free(val_json);
+
+	val_json = jwt_get_grant_json(jwt, "scopes");
+	ck_assert(val_json != NULL);
+	ck_assert_str_eq(val_json, "[\"storage\",\"email\",\"birthdate\"]");
+        free(val_json);
+
+	val_json = jwt_get_grant_json(jwt, "sub");
+	ck_assert(val_json != NULL);
+	ck_assert_str_eq(val_json, "{\"baz\":\"quux\",\"foo\":\"bar\"}");
+        free(val_json);
 
 	jwt_free(jwt);
 }


### PR DESCRIPTION
If the JWT stores grants that have a value different from a string (array, object, ...), libjwt can't handle it (returns NULL).

This merge requests adds the `jwt_get_grant_json` function that will return a JSON representation of the value as a string.
##### Example:

Body of the JWT:

``` json
{
    "foo": "bar",
    "bar": [ 21, 42, 84 ],
    "baz": {
        "quux": "foobar"
    }
}
```

Usage:

``` C
puts(jwt_get_grant_json(jwt, "foo"));
puts(jwt_get_grant_json(jwt, "bar"));
puts(jwt_get_grant_json(jwt, "baz"));
```

Output:

``` console
"bar"
[21,42,84]
{"quux":"foobar"}
```
