### PR TITLE
(add|get)_grant_json functions

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -161,7 +161,7 @@ int jwt_add_grant(jwt_t *jwt, const char *grant, const char *val);
 int jwt_del_grant(jwt_t *jwt, const char *grant);
 
 /**
- * Add grants from a JSON encoded object string.
+ * Replace grants from a JSON encoded object string.
  *
  * Loads grants from an existing JSON encoded object string (the body
  * portion). Overwrites any existing grants. Should be used on a jwt_new()
@@ -171,7 +171,7 @@ int jwt_del_grant(jwt_t *jwt, const char *grant);
  * @param json String containing a JSON encoded object of grants.
  * @return Returns 0 on success, valid errno otherwise.
  */
-int jwt_add_grants_json(jwt_t *jwt, const char *json);
+int jwt_replace_grants(jwt_t *jwt, const char *json);
 
 /** @} */
 

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -20,6 +20,8 @@
  * @brief JWT C Library
  */
 
+#include <jansson.h>
+
 #ifndef JWT_H
 #define JWT_H
 
@@ -159,6 +161,20 @@ int jwt_add_grant(jwt_t *jwt, const char *grant, const char *val);
  * @return Returns 0 on success, valid errno otherwise.
  */
 int jwt_del_grant(jwt_t *jwt, const char *grant);
+
+/**
+ * Return the value of a grant as a json_t.
+ *
+ * Returns the json_t value for a grant. If it does not exit, NULL
+ * will be returned. The returned json_t is only borrowed and will be
+ * freed when the JWT object is freed with jwt_free().
+ *
+ * @param jwt Pointer to a JWT object.
+ * @param grant String containing the name of the grant to return a value
+ *     for.
+ * @return Returns a json_t for the value, or NULL when not found.
+ */
+const json_t *jwt_get_grant_json(jwt_t *jwt, const char *grant);
 
 /**
  * Replace grants from a JSON encoded object string.

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -177,6 +177,22 @@ int jwt_del_grant(jwt_t *jwt, const char *grant);
 const json_t *jwt_get_grant_json(jwt_t *jwt, const char *grant);
 
 /**
+ * Add a new grant to this JWT object.
+ *
+ * Creates a new grant for this object. The json_t for grant and the
+ * string for val are copied internally, so do not require that the
+ * pointer or string remain valid for the lifetime of this object. It
+ * is an error if you try to add a grant that already exists.
+ *
+ * @param jwt Pointer to a JWT object.
+ * @param grant String containing the name of the grant to add.
+ * @param val json_t containing the value to be saved for
+ *     grant. Cannot be NULL.
+ * @return Returns 0 on success, valid errno otherwise.
+ */
+int jwt_add_grant_json(jwt_t *jwt, const char *grant, json_t *val);
+
+/**
  * Replace grants from a JSON encoded object string.
  *
  * Loads grants from an existing JSON encoded object string (the body

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -25,8 +25,6 @@
 #include <openssl/hmac.h>
 #include <openssl/buffer.h>
 
-#include <jansson.h>
-
 #include <jwt.h>
 
 #include "config.h"
@@ -551,6 +549,18 @@ int jwt_add_grant(jwt_t *jwt, const char *grant, const char *val)
 		return EINVAL;
 
 	return 0;
+}
+
+const json_t *jwt_get_grant_json(jwt_t *jwt, const char *grant)
+{
+	if (!jwt || !grant || !strlen(grant)) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	errno = 0;
+
+	return json_object_get(jwt->grants, grant);
 }
 
 int jwt_replace_grants(jwt_t *jwt, const char *json)

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -553,7 +553,7 @@ int jwt_add_grant(jwt_t *jwt, const char *grant, const char *val)
 	return 0;
 }
 
-int jwt_add_grants_json(jwt_t *jwt, const char *json)
+int jwt_replace_grants(jwt_t *jwt, const char *json)
 {
 	json_t *grants = json_loads(json, JSON_REJECT_DUPLICATES, NULL);
 	int ret;

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -563,6 +563,20 @@ const json_t *jwt_get_grant_json(jwt_t *jwt, const char *grant)
 	return json_object_get(jwt->grants, grant);
 }
 
+int jwt_add_grant_json(jwt_t *jwt, const char *grant, json_t *val)
+{
+	if (!jwt || !grant || !strlen(grant) || !val)
+		return EINVAL;
+
+	if (json_object_get(jwt->grants, grant) != NULL)
+		return EEXIST;
+
+	if (json_object_set(jwt->grants, grant, val))
+		return EINVAL;
+
+	return 0;
+}
+
 int jwt_replace_grants(jwt_t *jwt, const char *json)
 {
 	json_t *grants = json_loads(json, JSON_REJECT_DUPLICATES, NULL);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ TESTS =			\
 
 check_PROGRAMS = $(TESTS)
 
-AM_CPPFLAGS = -I$(top_srcdir)/include
-AM_CFLAGS = -Wall $(CHECK_CFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir)/include `pkg-config --cflags jansson`
+AM_CFLAGS = -Wall $(CHECK_CFLAGS) -g
 AM_LDFLAGS = -L$(top_srcdir)/libjwt
 LDADD = -ljwt $(CHECK_LIBS)

--- a/tests/jwt_grant.c
+++ b/tests/jwt_grant.c
@@ -103,7 +103,7 @@ START_TEST(test_jwt_grant_invalid)
 }
 END_TEST
 
-START_TEST(test_jwt_grants_json)
+START_TEST(test_jwt_replace_grants)
 {
 	const char *json = "{\"ref\":\"385d6518-fb73-45fc-b649-0527d8576130\""
 		",\"id\":\"FVvGYTr3FhiURCFebsBOpBqTbzHdX/DvImiA2yheXr8=\","
@@ -117,7 +117,7 @@ START_TEST(test_jwt_grants_json)
 	ck_assert_int_eq(ret, 0);
 	ck_assert(jwt != NULL);
 
-	ret = jwt_add_grants_json(jwt, json);
+	ret = jwt_replace_grants(jwt, json);
 	ck_assert_int_eq(ret, 0);
 
 	val = jwt_get_grant(jwt, "ref");
@@ -141,7 +141,7 @@ Suite *libjwt_suite(void)
 	tcase_add_test(tc_core, test_jwt_get_grant);
 	tcase_add_test(tc_core, test_jwt_del_grant);
 	tcase_add_test(tc_core, test_jwt_grant_invalid);
-	tcase_add_test(tc_core,test_jwt_grants_json);
+	tcase_add_test(tc_core,test_jwt_replace_grants);
 
 	suite_add_tcase(s, tc_core);
 


### PR DESCRIPTION
Following the discussion on [pull/4](https://github.com/benmcollins/libjwt/pull/4), here's a first draft of new add / get grant manipulating json_t objects.

This branch contains breaking changes:
* jwt_add_grants_json is renamed to jwt_replace_grants
* jwt.h now includes jansson.h. Proper compilation flags are required when building a project using libjwt  (for example: pkg-config --cflags jansson)
