### PR TITLE
Added a function to get integer types (like exp and iat)

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -145,7 +145,7 @@ const char *jwt_get_grant(jwt_t *jwt, const char *grant);
 int jwt_get_grant_int(jwt_t *jwt, const char *grant);
 
 /**
- * Add a new grant to this JWT object.
+ * Add a new string grant to this JWT object.
  *
  * Creates a new grant for this object. The string for grant and val
  * are copied internally, so do not require that the pointer or string
@@ -159,6 +159,21 @@ int jwt_get_grant_int(jwt_t *jwt, const char *grant);
  * @return Returns 0 on success, valid errno otherwise.
  */
 int jwt_add_grant(jwt_t *jwt, const char *grant, const char *val);
+
+/**
+ * Add a new integer grant to this JWT object.
+ *
+ * Creates a new grant for this object. The string for grant
+ * is copied internally, so do not require that the pointer or string
+ * remain valid for the lifetime of this object. It is an error if you
+ * try to add a grant that already exists.
+ *
+ * @param jwt Pointer to a JWT object.
+ * @param grant String containing the name of the grant to add.
+ * @param val int containing the value to be saved for grant.
+ * @return Returns 0 on success, valid errno otherwise.
+ */
+int jwt_add_grant_int(jwt_t *jwt, const char *grant, int val);
 
 /**
  * Delete a grant from this JWT object.

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -133,6 +133,18 @@ jwt_t *jwt_dup(jwt_t *jwt);
 const char *jwt_get_grant(jwt_t *jwt, const char *grant);
 
 /**
+ * Return the value of a grant
+ * Reutnrs the int value for a grant (e.g. "exp"). If it does not exist,
+ * 0 will be returned.
+ *
+ * @param jwt Pointer to a JWT object.
+ * @param grant String containing the name of the grant to return a value
+ *     for.
+ * @return Returns an int for the value, or 0 when not found.
+ */
+int jwt_get_grant_int(jwt_t *jwt, const char *grant);
+
+/**
  * Add a new grant to this JWT object.
  *
  * Creates a new grant for this object. The string for grant and val

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -142,7 +142,7 @@ const char *jwt_get_grant(jwt_t *jwt, const char *grant);
  *     for.
  * @return Returns an int for the value, or 0 when not found.
  */
-int jwt_get_grant_int(jwt_t *jwt, const char *grant);
+long jwt_get_grant_int(jwt_t *jwt, const char *grant);
 
 /**
  * Add a new string grant to this JWT object.
@@ -173,7 +173,7 @@ int jwt_add_grant(jwt_t *jwt, const char *grant, const char *val);
  * @param val int containing the value to be saved for grant.
  * @return Returns 0 on success, valid errno otherwise.
  */
-int jwt_add_grant_int(jwt_t *jwt, const char *grant, int val);
+int jwt_add_grant_int(jwt_t *jwt, const char *grant, long val);
 
 /**
  * Delete a grant from this JWT object.

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -240,14 +240,14 @@ static const char *get_js_string(json_t *js, const char *key)
 	return val;
 }
 
-static int get_js_int(json_t *js, const char *key)
+static long get_js_int(json_t *js, const char *key)
 {
-	int val = -1;
+	long val = -1;
 	json_t *js_val;
 
 	js_val = json_object_get(js, key);
 	if (js_val)
-		val = (int)json_integer_value(js_val);
+		val = (long)json_integer_value(js_val);
 
 	return val;
 }
@@ -558,7 +558,7 @@ const char *jwt_get_grant(jwt_t *jwt, const char *grant)
 	return get_js_string(jwt->grants, grant);
 }
 
-int jwt_get_grant_int(jwt_t *jwt, const char *grant)
+long jwt_get_grant_int(jwt_t *jwt, const char *grant)
 {
 	if (!jwt || !grant || !strlen(grant)) {
 		errno = EINVAL;
@@ -584,7 +584,7 @@ int jwt_add_grant(jwt_t *jwt, const char *grant, const char *val)
 	return 0;
 }
 
-int jwt_add_grant_int(jwt_t *jwt, const char *grant, int val)
+int jwt_add_grant_int(jwt_t *jwt, const char *grant, long val)
 {
 	if (!jwt || !grant || !strlen(grant))
 		return EINVAL;
@@ -592,7 +592,7 @@ int jwt_add_grant_int(jwt_t *jwt, const char *grant, int val)
 	if (get_js_int(jwt->grants, grant) != -1)
 		return EEXIST;
 
-	if (json_object_set_new(jwt->grants, grant, json_integer(val)))
+	if (json_object_set_new(jwt->grants, grant, json_integer((json_int_t)val)))
 		return EINVAL;
 
 	return 0;

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -250,7 +250,6 @@ static int get_js_int(json_t *js, const char *key)
 		val = (int)json_integer_value(js_val);
 
 	return val;
-	return 0;
 }
 
 static json_t *jwt_b64_decode(char *src)
@@ -590,7 +589,7 @@ int jwt_add_grant_int(jwt_t *jwt, const char *grant, int val)
 	if (!jwt || !grant || !strlen(grant))
 		return EINVAL;
 
-	if (get_js_string(jwt->grants, grant) != NULL)
+	if (get_js_int(jwt->grants, grant) != -1)
 		return EEXIST;
 
 	if (json_object_set_new(jwt->grants, grant, json_integer(val)))

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -585,6 +585,20 @@ int jwt_add_grant(jwt_t *jwt, const char *grant, const char *val)
 	return 0;
 }
 
+int jwt_add_grant_int(jwt_t *jwt, const char *grant, int val)
+{
+	if (!jwt || !grant || !strlen(grant))
+		return EINVAL;
+
+	if (get_js_string(jwt->grants, grant) != NULL)
+		return EEXIST;
+
+	if (json_object_set_new(jwt->grants, grant, json_integer(val)))
+		return EINVAL;
+
+	return 0;
+}
+
 int jwt_add_grants_json(jwt_t *jwt, const char *json)
 {
 	json_t *grants = json_loads(json, JSON_REJECT_DUPLICATES, NULL);

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -240,6 +240,19 @@ static const char *get_js_string(json_t *js, const char *key)
 	return val;
 }
 
+static int get_js_int(json_t *js, const char *key)
+{
+	int val = -1;
+	json_t *js_val;
+
+	js_val = json_object_get(js, key);
+	if (js_val)
+		val = (int)json_integer_value(js_val);
+
+	return val;
+	return 0;
+}
+
 static json_t *jwt_b64_decode(char *src)
 {
 	BIO *b64, *bmem;
@@ -544,6 +557,18 @@ const char *jwt_get_grant(jwt_t *jwt, const char *grant)
 	errno = 0;
 
 	return get_js_string(jwt->grants, grant);
+}
+
+int jwt_get_grant_int(jwt_t *jwt, const char *grant)
+{
+	if (!jwt || !grant || !strlen(grant)) {
+		errno = EINVAL;
+		return 0;
+	}
+
+	errno = 0;
+
+	return get_js_int(jwt->grants, grant);
 }
 
 int jwt_add_grant(jwt_t *jwt, const char *grant, const char *val)

--- a/tests/jwt_dump.c
+++ b/tests/jwt_dump.c
@@ -29,7 +29,7 @@ START_TEST(test_jwt_dump_fp)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	out = fopen("/dev/null", "w");
@@ -66,7 +66,7 @@ START_TEST(test_jwt_dump_str)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	out = jwt_dump_str(jwt, 1);

--- a/tests/jwt_dump.c
+++ b/tests/jwt_dump.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 
 #include <check.h>
 
@@ -26,6 +27,9 @@ START_TEST(test_jwt_dump_fp)
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	out = fopen("/dev/null", "w");
@@ -62,6 +66,9 @@ START_TEST(test_jwt_dump_str)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ck_assert_int_eq(ret, 0);
+
 	out = jwt_dump_str(jwt, 1);
 	ck_assert(out != NULL);
 
@@ -93,7 +100,7 @@ Suite *libjwt_suite(void)
 	return s;
 }
 
-int main(int argc, char *argv[])
+int main(int __unused argc, char __unused *argv[])
 {
 	int number_failed;
 	Suite *s;

--- a/tests/jwt_dump.c
+++ b/tests/jwt_dump.c
@@ -100,7 +100,7 @@ Suite *libjwt_suite(void)
 	return s;
 }
 
-int main(int __unused argc, char __unused *argv[])
+int main(int argc, char *argv[])
 {
 	int number_failed;
 	Suite *s;

--- a/tests/jwt_encode.c
+++ b/tests/jwt_encode.c
@@ -289,7 +289,7 @@ Suite *libjwt_suite(void)
 	return s;
 }
 
-int main(int __unused argc, char __unused *argv[])
+int main(int argc, char *argv[])
 {
 	int number_failed;
 	Suite *s;

--- a/tests/jwt_encode.c
+++ b/tests/jwt_encode.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 
 #include <check.h>
 
@@ -26,6 +27,9 @@ START_TEST(test_jwt_encode_fp)
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	out = fopen("/dev/null", "w");
@@ -59,6 +63,9 @@ START_TEST(test_jwt_encode_str)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ck_assert_int_eq(ret, 0);
+
 	out = jwt_encode_str(jwt);
 	ck_assert(out != NULL);
 
@@ -86,6 +93,9 @@ START_TEST(test_jwt_encode_hs256)
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_set_alg(jwt, JWT_ALG_HS256, key256, sizeof(key256));
@@ -121,6 +131,9 @@ START_TEST(test_jwt_encode_hs384)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ck_assert_int_eq(ret, 0);
+
 	ret = jwt_set_alg(jwt, JWT_ALG_HS384, key384, sizeof(key384));
 	ck_assert_int_eq(ret, 0);
 
@@ -152,6 +165,9 @@ START_TEST(test_jwt_encode_hs512)
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_set_alg(jwt, JWT_ALG_HS512, key512, sizeof(key512));
@@ -187,6 +203,9 @@ START_TEST(test_jwt_encode_change_alg)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ck_assert_int_eq(ret, 0);
+
 	ret = jwt_set_alg(jwt, JWT_ALG_HS512, key512, sizeof(key512));
 	ck_assert_int_eq(ret, 0);
 
@@ -220,6 +239,9 @@ START_TEST(test_jwt_encode_invalid)
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_set_alg(jwt, JWT_ALG_HS512, key512, 32);
@@ -267,7 +289,7 @@ Suite *libjwt_suite(void)
 	return s;
 }
 
-int main(int argc, char *argv[])
+int main(int __unused argc, char __unused *argv[])
 {
 	int number_failed;
 	Suite *s;

--- a/tests/jwt_encode.c
+++ b/tests/jwt_encode.c
@@ -29,7 +29,7 @@ START_TEST(test_jwt_encode_fp)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	out = fopen("/dev/null", "w");
@@ -63,7 +63,7 @@ START_TEST(test_jwt_encode_str)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	out = jwt_encode_str(jwt);
@@ -95,7 +95,7 @@ START_TEST(test_jwt_encode_hs256)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_set_alg(jwt, JWT_ALG_HS256, key256, sizeof(key256));
@@ -131,7 +131,7 @@ START_TEST(test_jwt_encode_hs384)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_set_alg(jwt, JWT_ALG_HS384, key384, sizeof(key384));
@@ -167,7 +167,7 @@ START_TEST(test_jwt_encode_hs512)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_set_alg(jwt, JWT_ALG_HS512, key512, sizeof(key512));
@@ -203,7 +203,7 @@ START_TEST(test_jwt_encode_change_alg)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_set_alg(jwt, JWT_ALG_HS512, key512, sizeof(key512));
@@ -241,7 +241,7 @@ START_TEST(test_jwt_encode_invalid)
 	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
 	ck_assert_int_eq(ret, 0);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
 	ret = jwt_set_alg(jwt, JWT_ALG_HS512, key512, 32);

--- a/tests/jwt_grant.c
+++ b/tests/jwt_grant.c
@@ -148,7 +148,7 @@ Suite *libjwt_suite(void)
 	return s;
 }
 
-int main(int __unused argc, char __unused *argv[])
+int main(int argc, char *argv[])
 {
 	int number_failed;
 	Suite *s;

--- a/tests/jwt_grant.c
+++ b/tests/jwt_grant.c
@@ -148,7 +148,7 @@ Suite *libjwt_suite(void)
 	return s;
 }
 
-int main(int argc, char *argv[])
+int main(int __unused argc, char __unused *argv[])
 {
 	int number_failed;
 	Suite *s;

--- a/tests/jwt_grant.c
+++ b/tests/jwt_grant.c
@@ -27,10 +27,10 @@ START_TEST(test_jwt_add_grant)
 	ck_assert_int_eq(ret, EEXIST);
 
 	/* No duplicates for int */
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, EEXIST);
 
 	jwt_free(jwt);
@@ -91,7 +91,7 @@ START_TEST(test_jwt_grant_invalid)
 {
 	jwt_t *jwt = NULL;
 	const char *val;
-	int valint = 0;
+	long valint = 0;
 	int ret = 0;
 
 	ret = jwt_new(&jwt);
@@ -101,7 +101,7 @@ START_TEST(test_jwt_grant_invalid)
 	ret = jwt_add_grant(jwt, "iss", NULL);
 	ck_assert_int_eq(ret, EINVAL);
 
-	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(errno, EINVAL);
 	ck_assert(valint == 0);
 

--- a/tests/jwt_grant.c
+++ b/tests/jwt_grant.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 
 #include <check.h>
 
@@ -23,6 +24,13 @@ START_TEST(test_jwt_add_grant)
 
 	/* No duplicates */
 	ret = jwt_add_grant(jwt, "iss", "other");
+	ck_assert_int_eq(ret, EEXIST);
+
+	/* No duplicates for int */
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
 	ck_assert_int_eq(ret, EEXIST);
 
 	jwt_free(jwt);
@@ -83,6 +91,7 @@ START_TEST(test_jwt_grant_invalid)
 {
 	jwt_t *jwt = NULL;
 	const char *val;
+	int valint = 0;
 	int ret = 0;
 
 	ret = jwt_new(&jwt);
@@ -92,12 +101,20 @@ START_TEST(test_jwt_grant_invalid)
 	ret = jwt_add_grant(jwt, "iss", NULL);
 	ck_assert_int_eq(ret, EINVAL);
 
+	ret = jwt_add_grant_int(jwt, "iat", time(NULL));
+	ck_assert_int_eq(errno, EINVAL);
+	ck_assert(valint == 0);
+
 	ret = jwt_del_grant(jwt, "");
 	ck_assert_int_eq(ret, EINVAL);
 
 	val = jwt_get_grant(jwt, NULL);
 	ck_assert_int_eq(errno, EINVAL);
 	ck_assert(val == NULL);
+
+	valint = jwt_get_grant_int(jwt, NULL);
+	ck_assert_int_eq(errno, EINVAL);
+	ck_assert(valint == 0);
 
 	jwt_free(jwt);
 }

--- a/tests/jwt_new.c
+++ b/tests/jwt_new.c
@@ -289,7 +289,7 @@ Suite *libjwt_suite(void)
 	return s;
 }
 
-int main(int __unused argc, char __unused *argv[])
+int main(int argc, char *argv[])
 {
 	int number_failed;
 	Suite *s;

--- a/tests/jwt_new.c
+++ b/tests/jwt_new.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 
 #include <check.h>
 
@@ -30,6 +31,8 @@ START_TEST(test_jwt_dup)
 	jwt_t *jwt = NULL, *new = NULL;
 	int ret = 0;
 	const char *val = NULL;
+	time_t now;
+	int valint;
 
 	new = jwt_dup(NULL);
 	ck_assert(new == NULL);
@@ -47,6 +50,13 @@ START_TEST(test_jwt_dup)
 	val = jwt_get_grant(new, "iss");
 	ck_assert(val != NULL);
 	ck_assert_str_eq(val, "test");
+
+	now = time(NULL);
+	ret = jwt_add_grant_int(jwt, "iat", now);
+	ck_assert_int_eq(ret, 0);
+
+	valint = jwt_get_grant_int(jwt, "iat");
+	ck_assert_int_eq(now, valint);
 
 	jwt_free(new);
 	jwt_free(jwt);
@@ -173,7 +183,7 @@ START_TEST(test_jwt_decode_alg_none_with_key)
 	jwt_t *jwt;
 	int ret;
 
-	ret = jwt_decode(&jwt, token, "key", 3);
+	ret = jwt_decode(&jwt, token, (const unsigned char *)"key", 3);
 	ck_assert_int_eq(ret, EINVAL);
 	ck_assert(jwt == NULL);
 
@@ -279,7 +289,7 @@ Suite *libjwt_suite(void)
 	return s;
 }
 
-int main(int argc, char *argv[])
+int main(int __unused argc, char __unused *argv[])
 {
 	int number_failed;
 	Suite *s;

--- a/tests/jwt_new.c
+++ b/tests/jwt_new.c
@@ -32,7 +32,7 @@ START_TEST(test_jwt_dup)
 	int ret = 0;
 	const char *val = NULL;
 	time_t now;
-	int valint;
+	long valint;
 
 	new = jwt_dup(NULL);
 	ck_assert(new == NULL);
@@ -52,11 +52,11 @@ START_TEST(test_jwt_dup)
 	ck_assert_str_eq(val, "test");
 
 	now = time(NULL);
-	ret = jwt_add_grant_int(jwt, "iat", now);
+	ret = jwt_add_grant_int(jwt, "iat", (long)now);
 	ck_assert_int_eq(ret, 0);
 
 	valint = jwt_get_grant_int(jwt, "iat");
-	ck_assert_int_eq(now, valint);
+	ck_assert(((long)now) == valint);
 
 	jwt_free(new);
 	jwt_free(jwt);


### PR DESCRIPTION
According to the JWT spec, exp and iat should be stored as integers, not strings.
Other libraries create exp and iat as integers.  To read and validate that
the JWT is not expired, we have to read the exp value.  Currently, this
library assumes all variables in the JWT are strings, and returns NULL when trying to get the grant for exp. This pull provides a getter for integer grants.

There's another more complex pull request out there, but this one is small and addresses just the core concern of validating that a JWT is not expired.