### PR TITLE
Fix memory leak in jwt_verify_sha_pem

### DIFF
--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -573,6 +573,8 @@ jwt_verify_sha_pem_done:
 		EVP_PKEY_free(pkey);
 	if (mdctx)
 		EVP_MD_CTX_destroy(mdctx);
+	if (sig)
+		free(sig);
 
 	return ret;
 }

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -519,7 +519,7 @@ static int jwt_verify_sha_pem(jwt_t *jwt, const EVP_MD *alg, int type,
 	BIO *bufkey = NULL;
 	EVP_PKEY *pkey = NULL;
 	int ret = EINVAL;
-	unsigned char *sig;
+	unsigned char *sig = NULL;
 	int slen;
 
 	sig = jwt_b64_decode(sig_b64, &slen);


### PR DESCRIPTION
Buffer returned by jwt_b64_decode (jwt.c:525) must be freed

Signed-off-by: Tatiana Jamison <tjamison@jaguarlandrover.com>