### PR TITLE
Avoid error messages when stdio.h is not included

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -23,6 +23,8 @@
 #ifndef JWT_H
 #define JWT_H
 
+#include <stdio.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -16,7 +16,6 @@
    <http://www.gnu.org/licenses/>.  */
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 #include <errno.h>
 


### PR DESCRIPTION
Since functions `jwt_dump_fp` and `jwt_encode_fp` use a `FILE` parameter in their description, we need to include `stdio.h` in the project.

But this fie is included in `jwt.c`, which means that if I include `jwt.h` in other projects, I will need to include `stdio.h` too, even if I don't need it, otherwise I will have a compilation error.