### PR TITLE
Support for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.8)
+project(jwt)
+
+set(CMAKE_C_STANDARD 99)
+
+include_directories(include)
+
+include_directories(${OPENSSL_INCLUDE_DIR})
+include_directories(${JANSSON_HOME}/src)
+
+set(SOURCE_FILES
+        include/jwt.h
+        libjwt/base64.c
+        libjwt/base64.h
+        libjwt/jwt.c
+        libjwt/jwt-openssl.c
+        libjwt/jwt-private.h)
+
+add_library(jwt ${SOURCE_FILES})

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -29,6 +29,12 @@
 extern "C" {
 #endif
 
+#ifdef __GNUC__
+    #define JWT_DEPRECATED __attribute__ ((deprecated))
+#else
+    #define JWT_DEPRECATED
+#endif
+
 /** Opaque JWT object. */
 typedef struct jwt jwt_t;
 
@@ -299,8 +305,8 @@ int jwt_del_grants(jwt_t *jwt, const char *grant);
  * @param grant String containing the name of the grant to delete.
  * @return Returns 0 on success, valid errno otherwise.
  */
-int jwt_del_grant(jwt_t *jwt, const char *grant)
-	__attribute__ ((deprecated));
+JWT_DEPRECATED
+int jwt_del_grant(jwt_t *jwt, const char *grant);
 
 /** @} */
 

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -29,10 +29,19 @@
 extern "C" {
 #endif
 
+// under GNU compiler collection we have __attribute__, otherwise we don't
 #ifdef __GNUC__
     #define JWT_DEPRECATED __attribute__ ((deprecated))
 #else
     #define JWT_DEPRECATED
+#endif
+
+// on windows we need to redefine alloca and strcasecmp, because they're not exist there
+#ifdef _MSC_VER
+    #include <memory.h>
+
+    #define alloca _malloca
+    #define strcasecmp _stricmp
 #endif
 
 /** Opaque JWT object. */

--- a/libjwt/jwt-openssl.c
+++ b/libjwt/jwt-openssl.c
@@ -28,7 +28,6 @@
 #include <jwt.h>
 
 #include "jwt-private.h"
-#include "config.h"
 
 /* Routines to support crypto in LibJWT using OpenSSL. */
 
@@ -158,7 +157,7 @@ jwt_verify_hmac_done:
 	return ret;
 }
 
-#define SIGN_ERROR(__err) ({ ret = __err; goto jwt_sign_sha_pem_done; })
+#define SIGN_ERROR(__err) { ret = __err; goto jwt_sign_sha_pem_done; }
 
 int jwt_sign_sha_pem(jwt_t *jwt, char **out, unsigned int *len,
 		     const char *str)
@@ -314,7 +313,7 @@ jwt_sign_sha_pem_done:
 	return ret;
 }
 
-#define VERIFY_ERROR(__err) ({ ret = __err; goto jwt_verify_sha_pem_done; })
+#define VERIFY_ERROR(__err) { ret = __err; goto jwt_verify_sha_pem_done; }
 
 int jwt_verify_sha_pem(jwt_t *jwt, const char *head, const char *sig_b64)
 {

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -23,7 +23,6 @@
 
 #include "jwt-private.h"
 #include "base64.h"
-#include "config.h"
 
 
 static const char *jwt_alg_str(jwt_alg_t alg)
@@ -654,15 +653,10 @@ int jwt_del_grants(jwt_t *jwt, const char *grant)
 	return 0;
 }
 
-#ifdef NO_WEAK_ALIASES
 int jwt_del_grant(jwt_t *jwt, const char *grant)
 {
 	return jwt_del_grants(jwt, grant);
 }
-#else
-int jwt_del_grant(jwt_t *jwt, const char *grant)
-	__attribute__ ((weak, alias ("jwt_del_grants")));
-#endif
 
 static int __append_str(char **buf, const char *str)
 {


### PR DESCRIPTION
Hi, benmcollins. I added some initial support to build your library under Windows. I noticed that config file is pretty much unuses, so I removed reference to it for simplicity reasons. I also added a cmake project to generate visual studio solution (my CMakeLists is far from ideal now).
I plan to maintain this in future.