### PR TITLE
Replaced tricky platform-specific weak aliases with just direct function call

### DIFF
--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -654,24 +654,10 @@ int jwt_del_grants(jwt_t *jwt, const char *grant)
 	return 0;
 }
 
-#ifdef _MSC_VER
-
-int jwt_del_grant(jwt_t *jwt, const char *grant);
-#pragma comment(linker, "/alternatename:jwt_del_grant=jwt_del_grants")
-
-#else
-
-#ifdef NO_WEAK_ALIASES
 int jwt_del_grant(jwt_t *jwt, const char *grant)
 {
 	return jwt_del_grants(jwt, grant);
 }
-#else
-int jwt_del_grant(jwt_t *jwt, const char *grant)
-	__attribute__ ((weak, alias ("jwt_del_grants")));
-#endif
-
-#endif /* _MSC_VER */
 
 static int __append_str(char **buf, const char *str)
 {


### PR DESCRIPTION
Hi. It seems like all this stuff with weak aliases are very tricky and platform specific. I removed all this and replaced all alias-specific stuff with just direct function call.
Wish you best of luck, Roman.