### PR TITLE
Downgrade required CMake Version (3.9 => 3.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.9)
+cmake_minimum_required (VERSION 3.7)
 
 if (MSVC)
 	set (CMAKE_SYSTEM_VERSION 8.1 CACHE TYPE INTERNAL FORCE)


### PR DESCRIPTION
 With this change we can build in Debian stretch.

Signed-off-by: Nelson Castillo <nelsoneci@gmail.com>