### PR TITLE
CMake change for OS X 10.13.6 compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ if (UNIX)
 	option (BUILD_TESTS "Build test projects." OFF)
 endif ()
 
+if (APPLE)
+	add_definitions(-DNO_WEAK_ALIASES)
+endif ()
 include_directories (include)
 
 if (MSVC)


### PR DESCRIPTION
This was necessary in order to compile the library on OS X 10.13.6. The compiler error (using a CMake build) would issue `alias are not supported on darwin`. We needed to set the `NO_WEAK_ALIASES` flag for Apple