### PR TITLE
Fix benmcollins/libjwt#76 where gnutls verification fails for ecdsa signatures

### DIFF
--- a/libjwt/jwt-gnutls.c
+++ b/libjwt/jwt-gnutls.c
@@ -274,16 +274,22 @@ int jwt_verify_sha_pem(jwt_t *jwt, const char *head, const char *sig_b64)
 
 	switch (jwt->alg) {
 	case JWT_ALG_RS256:
-	case JWT_ALG_ES256:
 		alg = GNUTLS_DIG_SHA256;
 		break;
+	case JWT_ALG_ES256:
+		alg = GNUTLS_SIGN_ECDSA_SHA256;
+		break;
 	case JWT_ALG_RS384:
-	case JWT_ALG_ES384:
 		alg = GNUTLS_DIG_SHA384;
 		break;
+	case JWT_ALG_ES384:
+		alg = GNUTLS_SIGN_ECDSA_SHA384;
+		break;
 	case JWT_ALG_RS512:
-	case JWT_ALG_ES512:
 		alg = GNUTLS_DIG_SHA512;
+		break;
+	case JWT_ALG_ES512:
+		alg = GNUTLS_SIGN_ECDSA_SHA512;
 		break;
 	default:
 		return EINVAL;


### PR DESCRIPTION
Thanks to upstream help, I was able to fix ecdsa signature with gnutls 3.6.
It wasn't an upstream bug, but a me bug :p