### PR TITLE
Fix dll support on MinGW-w64 and fix test cases on Win32

### DIFF
--- a/libjwt/Makefile.am
+++ b/libjwt/Makefile.am
@@ -9,7 +9,7 @@ libjwt_la_SOURCES += jwt-gnutls.c
 endif
 
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-libjwt_la_LDFLAGS = -version-info 5:1:5 $(OPENSSL_LDFLAGS) $(GNUTLS_LDFLAGS) $(JANSSON_LDFLAGS)
+libjwt_la_LDFLAGS = -version-info 5:1:5 $(OPENSSL_LDFLAGS) $(GNUTLS_LDFLAGS) $(JANSSON_LDFLAGS) -no-undefined
 libjwt_la_CPPFLAGS = -I$(top_srcdir)/include $(OPENSSL_INCLUDES) $(GNUTLS_INCLUDES) $(CODE_COVERAGE_CPPFLAGS) -Wall
 libjwt_la_CFLAGS = $(JANSSON_CFLAGS) $(OPENSSL_CFLAGS) $(GNUTLS_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 libjwt_la_LIBADD = $(JANSSON_LIBS) $(OPENSSL_LIBS) $(GNUTLS_LIBS) $(CODE_COVERAGE_LDFLAGS)

--- a/tests/jwt_dump.c
+++ b/tests/jwt_dump.c
@@ -32,8 +32,13 @@ START_TEST(test_jwt_dump_fp)
 	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
+#ifdef _WIN32
+	out = fopen("nul", "w");
+	ck_assert(out != NULL);
+#else
 	out = fopen("/dev/null", "w");
 	ck_assert(out != NULL);
+#endif
 
 	ret = jwt_dump_fp(jwt, out, 1);
 	ck_assert_int_eq(ret, 0);

--- a/tests/jwt_encode.c
+++ b/tests/jwt_encode.c
@@ -46,8 +46,13 @@ START_TEST(test_jwt_encode_fp)
 	ck_assert_int_eq(ret, 0);
 
 	/* TODO Write to actual file and read back to validate output. */
+#ifdef _WIN32
+	out = fopen("nul", "w");
+	ck_assert_ptr_ne(out, NULL);
+#else
 	out = fopen("/dev/null", "w");
 	ck_assert_ptr_ne(out, NULL);
+#endif
 
 	ret = jwt_encode_fp(jwt, out);
 	ck_assert_int_eq(ret, 0);


### PR DESCRIPTION
This fixes `.dll` support on MinGW-w64 by adding the `-no-undefined` flag to `LDFLAGS`, and fixes 2 test cases on Windows involving the null device, which is named `nul` rather than `/dev/null`.