### PR TITLE
Allow for custom value of 'typ' header

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -503,6 +503,12 @@ JWT_EXPORT int jwt_del_headers(jwt_t *jwt, const char *header);
  * not compute the signature or encryption (if such an algorithm were being
  * used).
  *
+ * Note, this may change the content of JWT header if algorithm is set
+ * on the JWT object. If algorithm is set (jwt_set_alg was called
+ * on the jwt object) then dumping JWT attempts to append 'typ' header.
+ * If the 'typ' header already exists, then it is left untouched,
+ * otherwise it is added with default value of "JWT".
+ *
  * @param jwt Pointer to a JWT object.
  * @param fp Valid FILE pointer to write data to.
  * @param pretty Enables better visual formatting of output. Generally only
@@ -516,6 +522,12 @@ JWT_EXPORT int jwt_dump_fp(jwt_t *jwt, FILE *fp, int pretty);
  *
  * Similar to jwt_dump_fp() except that a string is returned. The string
  * must be freed by the caller.
+ *
+ * Note, this may change the content of JWT header if algorithm is set
+ * on the JWT object. If algorithm is set (jwt_set_alg was called
+ * on the jwt object) then dumping JWT attempts to append 'typ' header.
+ * If the 'typ' header already exists, then it is left untouched,
+ * otherwise it is added with default value of "JWT".
  *
  * @param jwt Pointer to a JWT object.
  * @param pretty Enables better visual formatting of output. Generally only

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -932,11 +932,16 @@ static int jwt_write_head(jwt_t *jwt, char **buf, int pretty)
 	int ret = 0;
 
 	if (jwt->alg != JWT_ALG_NONE) {
-		if ((ret = jwt_del_headers(jwt, "typ")))
-			return ret;
 
-		if ((ret = jwt_add_header(jwt, "typ", "JWT")))
-			return ret;
+		/* Only add default 'typ' header if it has not been defined,
+		 * allowing for any value of it. This allows for signaling
+		 * of application specific extentions to JWT, such as PASSporT,
+		 * RFC 8225. */
+		if ((ret = jwt_add_header(jwt, "typ", "JWT"))) {
+			if (ret != EEXIST) {
+				return ret;
+			}
+		}
 	}
 
 	if ((ret = jwt_del_headers(jwt, "alg")))

--- a/tests/jwt_dump.c
+++ b/tests/jwt_dump.c
@@ -102,6 +102,7 @@ START_TEST(test_jwt_dump_str)
 	jwt_t *jwt = NULL;
 	int ret = 0;
 	char *out;
+	const char *val = NULL;
 
 	ret = test_set_alloc();
 	ck_assert_int_eq(ret, 0);
@@ -122,13 +123,25 @@ START_TEST(test_jwt_dump_str)
 	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
 	ck_assert_int_eq(ret, 0);
 
+	/* Test 'typ' header: should not be present, cause 'alg' is JWT_ALG_NONE. */
+	val = jwt_get_header(jwt, "typ");
+	ck_assert(val == NULL);
+
 	out = jwt_dump_str(jwt, 1);
 	ck_assert(out != NULL);
+
+	/* Test 'typ' header: should not be present, cause 'alg' is JWT_ALG_NONE. */
+	val = jwt_get_header(jwt, "typ");
+	ck_assert(val == NULL);
 
 	jwt_free_str(out);
 
 	out = jwt_dump_str(jwt, 0);
 	ck_assert(out != NULL);
+
+	/* Test 'typ' header: should not be present, cause 'alg' is JWT_ALG_NONE. */
+	val = jwt_get_header(jwt, "typ");
+	ck_assert(val == NULL);
 
 	jwt_free_str(out);
 
@@ -136,12 +149,13 @@ START_TEST(test_jwt_dump_str)
 }
 END_TEST
 
-START_TEST(test_jwt_dump_str_alg)
+START_TEST(test_jwt_dump_str_alg_default_typ_header)
 {
 	jwt_t *jwt = NULL;
 	const char key[] = "My Passphrase";
 	int ret = 0;
 	char *out;
+	const char *val = NULL;
 
 	ret = test_set_alloc();
 	ck_assert_int_eq(ret, 0);
@@ -166,13 +180,98 @@ START_TEST(test_jwt_dump_str_alg)
 			  strlen(key));
 	ck_assert_int_eq(ret, 0);
 
+	/* Test 'typ' header: should not be present, cause jwt's header has not been touched yet
+	 * by jwt_write_head, this is only called as a result of calling jwt_dump* methods. */
+	val = jwt_get_header(jwt, "typ");
+	ck_assert(val == NULL);
+
 	out = jwt_dump_str(jwt, 1);
 	ck_assert(out != NULL);
+
+	/* Test 'typ' header: should be added with default value of 'JWT', cause 'alg' is set explicitly
+	 * and jwt's header has been processed by jwt_write_head. */
+	val = jwt_get_header(jwt, "typ");
+	ck_assert(val != NULL);
+	ck_assert_str_eq(val, "JWT");
 
 	jwt_free_str(out);
 
 	out = jwt_dump_str(jwt, 0);
 	ck_assert(out != NULL);
+
+	/* Test 'typ' header: should be added with default value of 'JWT', cause 'alg' is set explicitly
+	 * and jwt's header has been processed by jwt_write_head. */
+	val = jwt_get_header(jwt, "typ");
+	ck_assert(val != NULL);
+	ck_assert_str_eq(val, "JWT");
+
+	jwt_free_str(out);
+
+	jwt_free(jwt);
+}
+END_TEST
+
+START_TEST(test_jwt_dump_str_alg_custom_typ_header)
+{
+	jwt_t *jwt = NULL;
+	const char key[] = "My Passphrase";
+	int ret = 0;
+	char *out;
+	const char *val = NULL;
+
+	ret = test_set_alloc();
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_new(&jwt);
+	ck_assert_int_eq(ret, 0);
+	ck_assert(jwt != NULL);
+
+	ret = jwt_add_grant(jwt, "iss", "files.cyphre.com");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant(jwt, "sub", "user0");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant_int(jwt, "iat", (long)time(NULL));
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_header(jwt, "typ", "favourite");
+	ck_assert_int_eq(ret, 0);
+
+	/* Test that 'typ' header has been added. */
+	val = jwt_get_header(jwt, "typ");
+	ck_assert(val != NULL);
+	ck_assert_str_eq(val, "favourite");
+
+	ret = jwt_set_alg(jwt, JWT_ALG_HS256, (unsigned char *)key,
+			  strlen(key));
+	ck_assert_int_eq(ret, 0);
+
+	/* Test 'typ' header: should be left untouched. */
+	val = jwt_get_header(jwt, "typ");
+	ck_assert(val != NULL);
+	ck_assert_str_eq(val, "favourite");
+
+	out = jwt_dump_str(jwt, 1);
+	ck_assert(out != NULL);
+
+	/* Test 'typ' header: should be left untouched. */
+	val = jwt_get_header(jwt, "typ");
+	ck_assert(val != NULL);
+	ck_assert_str_eq(val, "favourite");
+
+	jwt_free_str(out);
+
+	out = jwt_dump_str(jwt, 0);
+	ck_assert(out != NULL);
+
+	/* Test 'typ' header: should be left untouched. */
+	val = jwt_get_header(jwt, "typ");
+	ck_assert(val != NULL);
+	ck_assert_str_eq(val, "favourite");
 
 	jwt_free_str(out);
 
@@ -192,7 +291,8 @@ static Suite *libjwt_suite(void)
 	tcase_add_test(tc_core, test_alloc_funcs);
 	tcase_add_test(tc_core, test_jwt_dump_fp);
 	tcase_add_test(tc_core, test_jwt_dump_str);
-	tcase_add_test(tc_core, test_jwt_dump_str_alg);
+	tcase_add_test(tc_core, test_jwt_dump_str_alg_default_typ_header);
+	tcase_add_test(tc_core, test_jwt_dump_str_alg_custom_typ_header);
 
 	tcase_set_timeout(tc_core, 30);
 


### PR DESCRIPTION
Intro
This extends JWT/JWS for applications which use custom 'typ' header, such as PASSporT JWT/JWS for STIR-Shaken.

Description
The 'typ' header describes the type of JWT. This is recommended to be "JWT" but can be different for applications which must signal presence of application specific information in JWT (see 1, 2). In particular PASSporT JWS requires typ param to be of value "passport" (see 3), but libjwt before this change would replace such header with typ="JWT" when printed with jwt_dump_str().

Solution
This change allows for any value of 'typ' header in jwt_write_head(). That function will now only attempt to add a header of type 'JWT' and will not unconditionally replace it, so it is added (with default value of 'JWT') only if it is not defined yet.

Compatibility
This behaviour is compatible with RFC 7515 4.1.9, RFC 7519 5.1 and will allow for implementation of extensions to JWT/JWS such as PASSporT RFC 8225 4.1.

References
[1] JWT - RFC 7515 4.1.9
[2] JWS - RFC 7519 5.1
[3] PASSporT - RFC 8225 4.1