### PR TITLE
Add test for ES256

### DIFF
--- a/tests/jwt_encode.c
+++ b/tests/jwt_encode.c
@@ -250,6 +250,45 @@ START_TEST(test_jwt_encode_hs512)
 }
 END_TEST
 
+START_TEST(test_jwt_encode_es256)
+{
+	const char res[] = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE"
+		"0NzU5ODA1NDUsImlzcyI6ImZpbGVzLmN5cGhyZS5jb20iLCJyZWYiOiJYWF"
+		"hYLVlZWVktWlpaWi1BQUFBLUNDQ0MiLCJzdWIiOiJ1c2VyMCJ9.B0a9gqWg"
+		"PuuIx-EFXXSHQByCMHCzs0gjvY3-60oV4TY";
+	unsigned char key256[32] = "012345678901234567890123456789XY";
+	jwt_t *jwt = NULL;
+	int ret = 0;
+	char *out;
+
+	ALLOC_JWT(&jwt);
+
+	ret = jwt_add_grant(jwt, "iss", "files.cyphre.com");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant(jwt, "sub", "user0");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_add_grant_int(jwt, "iat", TS_CONST);
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_set_alg(jwt, JWT_ALG_ES256, key256, sizeof(key256));
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_encode_str(jwt);
+	ck_assert_ptr_ne(out, NULL);
+
+	ck_assert_str_eq(out, res);
+
+	jwt_free_str(out);
+
+	jwt_free(jwt);
+}
+END_TEST
+
 START_TEST(test_jwt_encode_change_alg)
 {
 	const char res[] = "eyJhbGciOiJub25lIn0.eyJpYXQiOjE0NzU5ODA1NDUsIm"
@@ -354,6 +393,7 @@ static Suite *libjwt_suite(void)
 	tcase_add_test(tc_core, test_jwt_encode_hs256);
 	tcase_add_test(tc_core, test_jwt_encode_hs384);
 	tcase_add_test(tc_core, test_jwt_encode_hs512);
+	tcase_add_test(tc_core, test_jwt_encode_es256);
 	tcase_add_test(tc_core, test_jwt_encode_change_alg);
 	tcase_add_test(tc_core, test_jwt_encode_invalid);
 


### PR DESCRIPTION
This test fails in jwt_encode_str as described in issue https://github.com/benmcollins/libjwt/issues/101

libjwt fails in jwt_encode_str(jwt) when used with ES256 alg
and 32 byte key unsigned char key256[32] = "012345678901234567890123456789XY";
set with:

jwt_set_alg(jwt, JWT_ALG_ES256, key256, sizeof(key256));

The reason is that key cannot be retrieved through BIO in jwt_sign_sha_pem:

202 bufkey = BIO_new_mem_buf(jwt->key, jwt->key_len);
203 if (bufkey == NULL)
204 SIGN_ERROR(ENOMEM);
205
206 /* This uses OpenSSL's default passphrase callback if needed. The
207 * library caller can override this in many ways, all of which are
208 * outside of the scope of LibJWT and this is documented in jwt.h. */
209 pkey = PEM_read_bio_PrivateKey(bufkey, NULL, NULL, NULL);
210 if (pkey == NULL)
211 SIGN_ERROR(EINVAL); <<<< THIS is called
TEST case:

255     const char res[] = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE"
256         "0NzU5ODA1NDUsImlzcyI6ImZpbGVzLmN5cGhyZS5jb20iLCJyZWYiOiJYWF"
257         "hYLVlZWVktWlpaWi1BQUFBLUNDQ0MiLCJzdWIiOiJ1c2VyMCJ9.B0a9gqWg"
258         "PuuIx-EFXXSHQByCMHCzs0gjvY3-60oV4TY";
259     unsigned char key256[32] = "012345678901234567890123456789XY";
260     jwt_t *jwt = NULL; 
261     int ret = 0;
262     char *out;
263         
264     ALLOC_JWT(&jwt);
265     
266     ret = jwt_add_grant(jwt, "iss", "files.cyphre.com");
267     ck_assert_int_eq(ret, 0);
268 
269     ret = jwt_add_grant(jwt, "sub", "user0");
270     ck_assert_int_eq(ret, 0);
271     
272     ret = jwt_add_grant(jwt, "ref", "XXXX-YYYY-ZZZZ-AAAA-CCCC");
273     ck_assert_int_eq(ret, 0);
274     
275     ret = jwt_add_grant_int(jwt, "iat", TS_CONST);
276     ck_assert_int_eq(ret, 0); 
277     
278     ret = jwt_set_alg(jwt, JWT_ALG_ES256, key256, sizeof(key256));
279     ck_assert_int_eq(ret, 0);
280     
281     out = jwt_encode_str(jwt);
282     ck_assert_ptr_ne(out, NULL);