### PR TITLE
Allow for custom key

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -552,6 +552,11 @@ JWT_EXPORT int jwt_encode_fp(jwt_t *jwt, FILE *fp);
 JWT_EXPORT char *jwt_encode_str(jwt_t *jwt);
 
 /**
+ * Same as jwt_encode_str but using custom key if set.
+ */
+JWT_EXPORT char *jwt_encode_str_pkey(jwt_t *jwt, void *pkey);
+
+/**
  * Free a string returned from the library.
  *
  * @param str Pointer to a string previously created with

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -36,7 +36,7 @@ int jwt_sign_sha_hmac(jwt_t *jwt, char **out, unsigned int *len,
 int jwt_verify_sha_hmac(jwt_t *jwt, const char *head, const char *sig);
 
 int jwt_sign_sha_pem(jwt_t *jwt, char **out, unsigned int *len,
-		     const char *str);
+		     const char *str, void *pkey);
 
 int jwt_verify_sha_pem(jwt_t *jwt, const char *head, const char *sig_b64);
 


### PR DESCRIPTION
For elliptic curve derived keys one may have EVP_PKEY available but jwt needs char buffer to assign key to JWT. However in jwt_sign_sha_pem such char buffer gets converted to EVP_PKEY, so ultimately only EVP_PKEY is what is really matters.

This patch allows for passing any EVP_PKEY for signing. In order to not break existing interface, instead of changing jwt_encode_str which is high level interface, only added additional argument to lower level utilities such as jwt_sign, jwt_sign_sha_pem and introduced new function jwt_encode_str_pkey which can be called with csutom pkey.