### PR TITLE
Allow for any value of 'typ' header when decoding

### DIFF
--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -496,11 +496,6 @@ static int jwt_verify_head(jwt_t *jwt, char *head)
 	}
 
 	if (jwt->alg != JWT_ALG_NONE) {
-		/* If alg is not NONE, there may be a typ. */
-		val = get_js_string(jwt->headers, "typ");
-		if (val && strcasecmp(val, "JWT"))
-			ret = EINVAL;
-
 		if (jwt->key) {
 			if (jwt->key_len <= 0)
 				ret = EINVAL;

--- a/tests/jwt_new.c
+++ b/tests/jwt_new.c
@@ -147,7 +147,7 @@ START_TEST(test_jwt_decode_invalid_alg)
 }
 END_TEST
 
-START_TEST(test_jwt_decode_invalid_typ)
+START_TEST(test_jwt_decode_ignore_typ)
 {
 	const char token[] = "eyJ0eXAiOiJBTEwiLCJhbGciOiJIUzI1NiJ9."
 			     "eyJpc3MiOiJmaWxlcy5jeXBocmUuY29tIiwic"
@@ -156,8 +156,8 @@ START_TEST(test_jwt_decode_invalid_typ)
 	int ret;
 
 	ret = jwt_decode(&jwt, token, NULL, 0);
-	ck_assert_int_eq(ret, EINVAL);
-	ck_assert(jwt == NULL);
+	ck_assert_int_eq(ret, 0);
+	ck_assert(jwt);
 
 	jwt_free(jwt);
 }
@@ -325,7 +325,7 @@ static Suite *libjwt_suite(void)
 	tcase_add_test(tc_core, test_jwt_dup_signed);
 	tcase_add_test(tc_core, test_jwt_decode);
 	tcase_add_test(tc_core, test_jwt_decode_invalid_alg);
-	tcase_add_test(tc_core, test_jwt_decode_invalid_typ);
+	tcase_add_test(tc_core, test_jwt_decode_ignore_typ);
 	tcase_add_test(tc_core, test_jwt_decode_invalid_head);
 	tcase_add_test(tc_core, test_jwt_decode_alg_none_with_key);
 	tcase_add_test(tc_core, test_jwt_decode_invalid_body);


### PR DESCRIPTION
This relaxes condition requiring 'typ' header
to always be 'JWT', allowing applications extending
JWT to signal that through 'typ' header.