### PR TITLE
Enhancement/cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Makefile
 /doxygen-doc/*
 /libjwt/libjwt.pc
 /dist/libjwt.spec
+
+# Cmake
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required (VERSION 3.7)
+cmake_minimum_required (VERSION 3.7...3.15)
+
+if (${CMAKE_VERSION} VERSION_LESS 3.14.7 AND ${CMAKE_GENERATOR} STREQUAL "Visual Studio 16 2019")
+	message(FATAL_ERROR "Please update your version of CMake to version 3.14.7 or greater in order to use Visual Studio 2019")
+endif()
 
 if (MSVC)
 	set (CMAKE_SYSTEM_VERSION 8.1 CACHE TYPE INTERNAL FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ string(REPLACE "\\" "/" CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 
 option (ENABLE_DEBUG_INFO_IN_RELEASE "Enable adding debug info to release build." OFF)
 option (ENABLE_LTO "Enable link time optimizations." OFF)
+option (BUILD_EXAMPLES "Build example projects." ON)
 
 if (MSVC)
 	option (STATIC_RUNTIME "Link runtome library statically." OFF)
@@ -64,7 +65,10 @@ if (ENABLE_LTO)
 endif ()
 
 add_subdirectory (libjwt)
-add_subdirectory (examples)
+
+if (${BUILD_EXAMPLES})
+	add_subdirectory (examples)
+endif()
 
 if (${BUILD_TESTS})
 	add_subdirectory (tests)


### PR DESCRIPTION
I believe 3.7 is pretty old. A better version syntax uses 3.7... to allow cmake to behave more optimally if the environments support it.