### PR TITLE
Fix RPM build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ Makefile
 /doxygen-doc/*
 /libjwt/libjwt.pc
 /dist/libjwt.spec
+/rpmbuild
 
 # Cmake
 /build

--- a/dist/Makefile.am
+++ b/dist/Makefile.am
@@ -8,9 +8,9 @@ check:
 	rpmlint -i dist/libjwt.spec
 
 rpm-prep:
-	cd .. && mkdir -p ./rpmbuild
-	cd ../rpmbuild && mkdir -p {SOURCES,SPECS,RPMS,SRPMS,BUILD}
-	cd .. && git archive --format=tar --prefix=libjwt-${VERSION}/ master | gzip > ./rpmbuild/SOURCES/v${VERSION}.tar.gz
+	cd ${abs_top_srcdir} && mkdir -p ./rpmbuild
+	cd ${abs_top_srcdir}/rpmbuild && mkdir -p {SOURCES,SPECS,RPMS,SRPMS,BUILD}
+	cd ${abs_top_srcdir} && git archive --format=tar --prefix=libjwt-${VERSION}/ master | gzip > ./rpmbuild/SOURCES/v${VERSION}.tar.gz
 
 rpm: rpm-prep
-	rpmbuild -ba  --define "_topdir ${PWD}/rpmbuild" libjwt.spec
+	rpmbuild -ba  --define "_topdir ${abs_top_srcdir}/rpmbuild" libjwt.spec

--- a/dist/libjwt.spec.in
+++ b/dist/libjwt.spec.in
@@ -23,7 +23,7 @@ It supports HS256/384/512, RS256/384/512 and ES256/384/512 digest algorithms.
 %package devel
 Summary:            JSON Web Token (C implementation) development kit
 Group:              Development/Libraries
-Requires:           c-jwt
+Requires:           libjwt
 
 %description devel
 Development files for the JWT C library.


### PR DESCRIPTION
Consistently use /rpmbuild if make is run from /dist
Also ignore the /rpmbuild directory