### PR TITLE
Update libjwt.spec.in

### DIFF
--- a/dist/libjwt.spec.in
+++ b/dist/libjwt.spec.in
@@ -2,28 +2,30 @@ Summary:            JSON Web Token (C implementation)
 Name:               libjwt
 Version:            @VERSION@
 Release:            0%{?dist}
-License:            MPL v2
+License:            MPLv2.0
 Group:              Development/Tools
 Source:             https://github.com/benmcollins/libjwt/archive/v%{version}.tar.gz
 URL:                https://github.com/benmcollins/libjwt
 BuildRequires:      make libtool automake
 BuildRequires:      gcc doxygen
-Requires:           openssl jansson
+BuildRequires:      pkgconfig(openssl) >= 0.9.8
+BuildRequires:      pkgconfig(jansson)
 %if 0%{?rhel} >= 8
 BuildRequires:      check
 %endif
 
 
 %description
-JSON Web Tokens are an open, industry standard RFC 7519 method for representing claims
-securely between two parties. This package is a C library implementing JWT functionnality.
-It supports HS256/384/512, RS256/384/512 and ES256/384/512 digest algorithms.
+JSON Web Tokens are an open, industry standard RFC 7519 method for representing
+claims securely between two parties. This package is a C library implementing
+JWT functionality. It supports HS256/384/512, RS256/384/512 and ES256/384/512 
+digest algorithms.
 
 
 %package devel
 Summary:            JSON Web Token (C implementation) development kit
 Group:              Development/Libraries
-Requires:           libjwt
+Requires:           %{name}%{?_isa} = %{version}-%{release}
 
 %description devel
 Development files for the JWT C library.


### PR DESCRIPTION
- MPLv2.0 is the correct short license tag, see https://fedoraproject.org/wiki/Licensing:Main#Good_Licenses
- fixed "description line too long" (rpmlint)
- openssl-devel should be in BuildRequires (which brings in pkg-config), and *not* in Requires (rpmbuild takes care of library dependency)
- likewise, jansson-devel, and they both should be required through pkgconfig()