### PR TITLE
Fix OSX build error

### DIFF
--- a/examples/main-auth.c
+++ b/examples/main-auth.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <errno.h>
 #include <time.h>
+#include <libgen.h>
 
 void usage(const char *name)
 {

--- a/examples/main-gen.c
+++ b/examples/main-gen.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <time.h>
 #include <string.h>
+#include <libgen.h>
 
 void usage(const char *name)
 {


### PR DESCRIPTION
Fix OSX building error
```
libjwt/examples/main-gen.c:86:10: error: implicit declaration of function 'basename' is invalid in
      C99 [-Werror,-Wimplicit-function-declaration]
                        usage(basename(argv[0]));
```