### PR TITLE
Add signature verification function.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.61])
-AC_INIT([libjwt], [1.12.0], [https://github.com/benmcollins/libjwt/issues])
+AC_INIT([libjwt], [1.12.0a], [https://github.com/benmcollins/libjwt/issues])
 AM_INIT_AUTOMAKE([foreign])
 LT_PREREQ([2.2])
 LT_INIT([])

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -141,6 +141,32 @@ JWT_EXPORT int jwt_decode(jwt_t **jwt, const char *token,
 	                 const unsigned char *key, int key_len);
 
 /**
+ * Check the signature of an already parsed JWT
+ *
+ * In some scenarios, it is hard to determine what key should
+ * be used for verifying a JWT signature. One example is in a
+ * system that needs to recognize JWT tokens signed by a set
+ * of issuers - to know which certificate to use for verifying
+ * the JWT signature, the issuer ('iss') field of the JWT needs
+ * to be consulted, and in order to access the issuer field, the
+ * JWT is first decoded without signature checking. After that,
+ * when the issuer is known, its certificate(s) can be used for
+ * signature checking. This function is introduced for usage in
+ * such a scenario - first the JWT is decoded with 'jwt_decode()',
+ * without signature checking, and after that, if a suitable
+ * certificate is found, it is used for only checking the already
+ * successfully parsed JWT by calling this routine.
+ *
+ * @param jwt Pointer to a JWT object that was returned from a
+ *     successfull JWT decoding step by jwt_decode()
+ * @param key Pointer to the key for validating the JWT signature
+ * @param key_len The length of the above key.
+ * @return 0 on success, valid errno otherwise.
+ */
+JWT_EXPORT int jwt_check_signature(jwt_t *jwt,
+	                 const unsigned char *key, int key_len);
+
+/**
  * Free a JWT object and any other resources it is using.
  *
  * After calling, the JWT object referenced will no longer be valid and

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -17,6 +17,23 @@ struct jwt {
 	int key_len;
 	json_t *grants;
 	json_t *headers;
+
+	/* This structure holds related data fields needed in case
+	 * a signature needs to be checked by jwt_check_signature(). */
+	struct {
+		/* A pointer to the token string as passed to 'jwt_decode()'.
+		 * This is needed in case a signature check is requested at
+		 * a later time, after 'jwt_decode()'. The 'head' and 'sig'
+		 * fields below point to the header and signature fields of the
+		 * token text, respectively, and are needed in case of a
+		 * signature verification request. */
+		unsigned char * token_data;
+		/* The size of the data block pointed to by the 'token_data' field. */
+		size_t data_len;
+		/* A pointer to the signature bytes, it points inside the 'token_data'
+		 * block above, and should not be individually 'free()'-d. */
+		const unsigned char * sig;
+	} sig_data;
 };
 
 struct jwt_valid {


### PR DESCRIPTION
This commit adds a signature verification function,
jwt_check_signature(), which makes it possible that the
signature of a JWT can be verified not only during decoding,
in jwt_decode(), but also at a later stage, after decoding
has been otherwise successful. This may be necessary in
certain scenarios, where, in order to determine which
certificate to use for checking the signature, certain fields
of the decoded JWT need to be consulted (for example, the 'iss'
field) - in such a case the signature checking cannot be done
directly in jwt_decode().