### PR TITLE
Separate JWT parsing from verification + decoding with a key obtained from the properties of incoming JWT tokens

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -85,6 +85,15 @@ typedef void *(*jwt_malloc_t)(size_t);
 typedef void *(*jwt_realloc_t)(void *, size_t);
 typedef void (*jwt_free_t)(void *);
 
+/** Structure used by key provider to return a key */
+typedef struct {
+    const unsigned char *jwt_key;
+    int jwt_key_len;
+} jwt_key_t;
+
+/** Key provider - inspects the JWT to obtain the key used to verify the signature */
+typedef int (*jwt_key_p_t)(const jwt_t *, jwt_key_t *);
+
 /**
  * @defgroup jwt_new JWT Object Creation
  * Functions used to create and destroy JWT objects.
@@ -139,6 +148,24 @@ JWT_EXPORT int jwt_new(jwt_t **jwt);
  */
 JWT_EXPORT int jwt_decode(jwt_t **jwt, const char *token,
 	                 const unsigned char *key, int key_len);
+
+/**
+ * Like jwt_decode(), but the key will be obtained via the key provider.
+ * Key providers may use all sorts of key management techniques, e.g.
+ * can check the "kid" header parameter or download the key pointed to 
+ * in "x5u"
+ *
+ * @param jwt Pointer to a JWT object pointer. Will be allocated on
+ *     success.
+ * @param token Pointer to a valid JWT string, null terminated.
+ * @param key_provider Pointer to a function that will obtain the key for the given JWT. 
+ *      Returns 0 on success or any other value on failure.
+ *      In the case of an error, the same error value will be returned to the caller.
+ * @return 0 on success, valid errno otherwise.
+ *
+ * @remark See jwt_decode()
+ */
+JWT_EXPORT int jwt_decode_2(jwt_t **jwt, const char *token, jwt_key_p_t key_provider);
 
 /**
  * Free a JWT object and any other resources it is using.

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -37,13 +37,13 @@ void *jwt_b64_decode(const char *src, int *ret_len);
 
 /* These routines are implemented by the crypto backend. */
 int jwt_sign_sha_hmac(jwt_t *jwt, char **out, unsigned int *len,
-		      const char *str);
+		      const char *str, unsigned int str_len);
 
-int jwt_verify_sha_hmac(jwt_t *jwt, const char *head, const char *sig);
+int jwt_verify_sha_hmac(jwt_t *jwt, const char *head, unsigned int head_len, const char *sig);
 
 int jwt_sign_sha_pem(jwt_t *jwt, char **out, unsigned int *len,
-		     const char *str);
+		     const char *str, unsigned int str_len);
 
-int jwt_verify_sha_pem(jwt_t *jwt, const char *head, const char *sig_b64);
+int jwt_verify_sha_pem(jwt_t *jwt, const char *head, unsigned int head_len, const char *sig_b64);
 
 #endif /* JWT_PRIVATE_H */


### PR DESCRIPTION
The current JWT decoding scheme where the key has to be known upfront is in many cases less than ideal.
For example, if the token is obtained from an external provider, the public key typically changes over time. The JWT standard solves these chicken-and-egg problems by allowing various parameters that can hint at the appropriate key, such as "kid" (Key Id), "x5u" (URL where the current key resides). In fact, any parameter can be used for this purpose (eg, combination of "iss", "kid" and "x5u"). Furthermore, the key can be embedded in the token. All these schemes are hard (impossible?) to implement using the current API which insists on knowing the key before decoding. In this PR, I've proposed a new API (jwt_decode_2) that parses the token first (without any cryptographic verification) and only then calls the user-defined function - passing the parsed token - expecting the correct key back, and finally resuming the verification. 

To avoid duplication I made a small refactor first - hence the 2 commits.