### PR TITLE
only run find_package on jansson if it is not installed

### DIFF
--- a/examples/main-gen.c
+++ b/examples/main-gen.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
 	size_t key_len = 0;
 	FILE *fp_priv_key;
 	int ret = 0;
-	jwt_t *jwt;
+	jwt_t *jwt = NULL;
 	struct kv {
 		char *key;
 		char *val;

--- a/libjwt/CMakeLists.txt
+++ b/libjwt/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(FetchContent)
+
 set (TARGET_NAME ${PROJECT_NAME})
 
 option (BUILD_SHARED_LIBS "Build libjwt as shared library instead as static one." OFF)
@@ -46,6 +48,15 @@ endif ()
 
 if (USE_INSTALLED_JANSSON)
     find_package (jansson REQUIRED)
+else()
+    FetchContent_Declare(
+    jansson
+    GIT_REPOSITORY https://github.com/akheron/jansson.git
+    GIT_TAG        v2.13.1
+    SOURCE_SUBDIR  cmake
+    )
+
+    FetchContent_MakeAvailable(jansson)
 endif()
 
 write_file(${CMAKE_CURRENT_BINARY_DIR}/config.h "")
@@ -57,8 +68,9 @@ add_library (${TARGET_NAME} ${LIBRARY_TYPE} ${SOURCE_FILES})
 
 target_include_directories (${TARGET_NAME} PRIVATE
 	${SSL_LIBRARY_INCLUDE_DIR}
-	${JANSSON_INCLUDE_DIRS}
-	${CMAKE_CURRENT_BINARY_DIR}
+       ${jansson_SOURCE_DIR}/src
+       ${jansson_SOURCE_DIR}/android
+       ${CMAKE_CURRENT_BINARY_DIR}
 	)
 
 # Need for using the project by add_subdirectory

--- a/libjwt/CMakeLists.txt
+++ b/libjwt/CMakeLists.txt
@@ -52,8 +52,7 @@ else()
     FetchContent_Declare(
     jansson
     GIT_REPOSITORY https://github.com/akheron/jansson.git
-    GIT_TAG        v2.13.1
-    SOURCE_SUBDIR  cmake
+    GIT_TAG        v2.14
     )
 
     FetchContent_MakeAvailable(jansson)

--- a/libjwt/CMakeLists.txt
+++ b/libjwt/CMakeLists.txt
@@ -3,6 +3,7 @@ set (TARGET_NAME ${PROJECT_NAME})
 option (BUILD_SHARED_LIBS "Build libjwt as shared library instead as static one." OFF)
 option (WITHOUT_OPENSSL "Use GnuTLS for encryption instead of OpenSSL" OFF)
 option (USE_WINSSL "Use Windows crypto API for encryption instead of OpenSSL" OFF)
+option (USE_INSTALLED_JANSSON "Use pre-installed jansson library" ON)
 
 if (UNIX)
 	option (ENABLE_PIC "Use position independent code in static library build." OFF)
@@ -43,7 +44,9 @@ else ()
 	set (SSL_LIBRARIES_OPTIMIZED ${OPENSSL_LIBRARIES})
 endif ()
 
-find_package (jansson REQUIRED)
+if (USE_INSTALLED_JANSSON)
+    find_package (jansson REQUIRED)
+endif()
 
 write_file(${CMAKE_CURRENT_BINARY_DIR}/config.h "")
 
@@ -87,7 +90,7 @@ endif ()
 
 target_link_libraries (${TARGET_NAME}
 	debug ${SSL_LIBRARIES_DEBUG} optimized ${SSL_LIBRARIES_OPTIMIZED}
-	jansson::jansson
+	jansson
 	)
 
 install (TARGETS ${TARGET_NAME}


### PR DESCRIPTION
- Allows users who are building jansson from source to use this JWT library.
- I wasn't sure why `jansson` was aliased as `jansson::jansson`. I don't typically pull in dependencies via `find_package` so I don't want to break anything with this change: https://github.com/benmcollins/libjwt/compare/master...lugehorsam:luke/cmake-fetchcontent-support?expand=1#diff-40f7f6521df07450ee749285035f76d6d884a728852df0a212a4bda03d260a9aR93

Could someone who is currently using `find_package` let me know why this `jansson::jansson` alias is done and if I am breaking backwards compatibility by changing it?