### PR TITLE
Add function to query public key

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -645,12 +645,20 @@ JWT_EXPORT void jwt_free_str(char *str);
 JWT_EXPORT int jwt_set_alg(jwt_t *jwt, jwt_alg_t alg, const unsigned char *key, int len);
 
 /**
- * Get the jwt_alg_t set for this JWT object.
- *
- * Returns the jwt_alg_t type for this JWT object.
+ * Get the PEM formatted public key.
  *
  * @param jwt Pointer to a JWT object.
- * @returns Returns a jwt_alg_t type for this object.
+ * @returns PEM formatted string or NULL with errno set
+ */
+JWT_EXPORT char *jwt_get_alg_public_key(jwt_t *jwt);
+
+/**
+ * Get the PEM formatted PEM public key
+ *
+ * Returns the PEM for
+ *
+ * @param jwt Pointer to a JWT object.
+ * @returns PEM formatted string or NULL with errno set
  */
 JWT_EXPORT jwt_alg_t jwt_get_alg(const jwt_t *jwt);
 

--- a/libjwt/jwt-gnutls.c
+++ b/libjwt/jwt-gnutls.c
@@ -256,6 +256,11 @@ sign_clean_key:
 	return ret;
 }
 
+int jwt_get_public_key_pem(jwt_t *jwt, char **dest)
+{
+	return EOPNOTSUPP;
+}
+
 int jwt_verify_sha_pem(jwt_t *jwt, const char *head, unsigned int head_len, const char *sig_b64)
 {
 	gnutls_datum_t r, s;

--- a/libjwt/jwt-openssl.c
+++ b/libjwt/jwt-openssl.c
@@ -305,6 +305,11 @@ jwt_sign_sha_pem_done:
 	return ret;
 }
 
+int jwt_get_public_key_pem(jwt_t *jwt, char **dest)
+{
+	return EOPNOTSUPP;
+}
+
 #define VERIFY_ERROR(__err) { ret = __err; goto jwt_verify_sha_pem_done; }
 
 int jwt_verify_sha_pem(jwt_t *jwt, const char *head, unsigned int head_len, const char *sig_b64)

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -46,4 +46,6 @@ int jwt_sign_sha_pem(jwt_t *jwt, char **out, unsigned int *len,
 
 int jwt_verify_sha_pem(jwt_t *jwt, const char *head, unsigned int head_len, const char *sig_b64);
 
+int jwt_get_public_key_pem(jwt_t *jwt, char **dest);
+
 #endif /* JWT_PRIVATE_H */

--- a/libjwt/jwt-wincrypt.c
+++ b/libjwt/jwt-wincrypt.c
@@ -581,6 +581,11 @@ jwt_sign_sha_hmac_done:
 	return ret;
 }
 
+int jwt_get_public_key_pem(jwt_t *jwt, char **dest)
+{
+	return EOPNOTSUPP;
+}
+
 #define VERIFY_HMAC_ERROR(__err) { ret = __err; goto jwt_verify_hmac_done; }
 
 int jwt_verify_sha_hmac(jwt_t *jwt, const char *head, const char *sig)

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -177,6 +177,23 @@ int jwt_set_alg(jwt_t *jwt, jwt_alg_t alg, const unsigned char *key, int len)
 	return 0;
 }
 
+char *jwt_get_alg_public_key(jwt_t *jwt)
+{
+	char *key = NULL;
+	int rc = jwt_get_public_key_pem(jwt, &key);
+
+	if (!rc)
+		return key;
+
+	errno = rc;
+
+	if (key)
+		jwt_freemem(key);
+
+	return NULL;
+}
+
+
 jwt_alg_t jwt_get_alg(const jwt_t *jwt)
 {
 	return jwt->alg;


### PR DESCRIPTION
Ben

This is a POC to allow client libraries to get a public key(s) (if possible) from an already loaded jwt_t ptr. I have only implemented RSA with OpenSSL currently, but I will try to add ECC and the same for gnutls. I don't have a Windows dev box, so someone else will probably need to add that implementation.

Is this something you're willing to merge? I tried to mimic your style but thought I should start off with a POC before doing all of the code.

Thanks,
--Nate