### PR TITLE
Fix description of returns from jwt_get_grant_int() and jwt_get_grant_bool().

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -220,7 +220,7 @@ JWT_EXPORT const char *jwt_get_grant(jwt_t *jwt, const char *grant);
  * Return the value of an integer grant.
  *
  * Returns the int value for a grant (e.g. "exp"). If it does not exist,
- * 0 will be returned.
+ * -1 will be returned.
  *
  * @param jwt Pointer to a JWT object.
  * @param grant String containing the name of the grant to return a value
@@ -238,7 +238,7 @@ JWT_EXPORT long jwt_get_grant_int(jwt_t *jwt, const char *grant);
  * Return the value of an boolean grant.
  *
  * Returns the int value for a grant (e.g. "exp"). If it does not exist,
- * 0 will be returned.
+ * -1 will be returned.
  *
  * @param jwt Pointer to a JWT object.
  * @param grant String containing the name of the grant to return a value

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -219,14 +219,13 @@ JWT_EXPORT const char *jwt_get_grant(jwt_t *jwt, const char *grant);
 /**
  * Return the value of an integer grant.
  *
- * Returns the int value for a grant (e.g. "exp"). If it does not exist,
- * -1 will be returned.
+ * Returns the int value for a grant (e.g. "exp").
  *
  * @param jwt Pointer to a JWT object.
  * @param grant String containing the name of the grant to return a value
  *     for.
- * @return Returns an int for the value. Sets errno to ENOENT when not
- * found.
+ * @return Returns an int for the value. Returns -1 and sets errno to ENOENT
+ *     when not found.
  *
  * Note, this will only return grants with JSON integer values. Use
  * jwt_get_grants_json() to get the JSON representation of more complex

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -236,14 +236,11 @@ JWT_EXPORT long jwt_get_grant_int(jwt_t *jwt, const char *grant);
 /**
  * Return the value of an boolean grant.
  *
- * Returns the int value for a grant (e.g. "exp"). If it does not exist,
- * -1 will be returned.
- *
  * @param jwt Pointer to a JWT object.
  * @param grant String containing the name of the grant to return a value
  *     for.
- * @return Returns a boolean for the value. Sets errno to ENOENT when not
- * found.
+ * @return Returns 1 (true) or 0 (false) for the value. Returns -1 and sets
+ *     errno to ENOENT when not found.
  *
  * Note, this will only return grants with JSON boolean values. Use
  * jwt_get_grants_json() to get the JSON representation of more complex


### PR DESCRIPTION
I discovered that the documented return for jwt_get_grant_int() and jwt_get_grant_bool() when the grant doesn't exist doesn't match the actual implementation. First commit is the minimal change, the next two tidy up the descriptions a bit further.