### PR TITLE
Fix compilation

### DIFF
--- a/libjwt/jwt-openssl.c
+++ b/libjwt/jwt-openssl.c
@@ -16,6 +16,7 @@
 #include <openssl/buffer.h>
 #include <openssl/pem.h>
 #include <openssl/bn.h>
+#include <openssl/rsa.h>
 
 #include <jwt.h>
 

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -1606,7 +1606,7 @@ static jwt_exception_dict_t jwt_exceptions[] = {
 
 char *jwt_exception_str(unsigned int exceptions)
 {
-	int rc;
+	int rc, i;
 	char *str = NULL;
 
 	if (exceptions == JWT_VALIDATION_SUCCESS) {
@@ -1615,7 +1615,7 @@ char *jwt_exception_str(unsigned int exceptions)
 		return str;
 	}
 
-	for (int i = 0; i < ARRAY_SIZE(jwt_exceptions); i++) {
+	for (i = 0; i < ARRAY_SIZE(jwt_exceptions); i++) {
 		if (!(jwt_exceptions[i].error & exceptions))
 			continue;
 


### PR DESCRIPTION
```
jwt-openssl.c:192:27: error: ‘RSA_PKCS1_PSS_PADDING’ undeclared (first use in this function)
  192 |                 padding = RSA_PKCS1_PSS_PADDING;
      |                           ^~~~~~~~~~~~~~~~~~~~~

jwt.c:1620: error: 'for' loop initial declaration used outside C99 mode
```