### PR TITLE
Fix OpenSSL 3 deprecation warnings

### DIFF
--- a/libjwt/jwt-openssl.c
+++ b/libjwt/jwt-openssl.c
@@ -17,6 +17,7 @@
 #include <openssl/pem.h>
 #include <openssl/bn.h>
 #include <openssl/rsa.h>
+#include <openssl/opensslv.h>
 
 #include <jwt.h>
 
@@ -153,6 +154,52 @@ jwt_verify_hmac_done:
 
 #define SIGN_ERROR(__err) { ret = __err; goto jwt_sign_sha_pem_done; }
 
+static int jwt_degree_for_key(EVP_PKEY *pkey)
+{
+	int degree = 0;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+	/* OpenSSL 3.0.0 and later has a new API for this. */
+	char groupNameBuffer[24] = {0};
+	size_t groupNameBufferLen = 0;
+	int curve_nid;
+	EC_GROUP *group;
+
+	if (!EVP_PKEY_get_group_name(pkey, groupNameBuffer, sizeof(groupNameBuffer), &groupNameBufferLen))
+		return -EINVAL;
+
+	groupNameBuffer[groupNameBufferLen] = '\0';
+
+	curve_nid = OBJ_txt2nid(groupNameBuffer);
+	if (curve_nid == NID_undef)
+		return -EINVAL;
+
+	group = EC_GROUP_new_by_curve_name(curve_nid);
+	if (group == NULL)
+		return -ENOMEM;
+
+	/* Get the degree of the curve */
+	degree = EC_GROUP_get_degree(group);
+
+	EC_GROUP_free(group);
+#else
+	EC_KEY *ec_key;
+
+	if (EVP_PKEY_id(pkey) != EVP_PKEY_EC)
+		return -EINVAL;
+
+	/* Get the actual ec_key */
+	ec_key = EVP_PKEY_get1_EC_KEY(pkey);
+	if (ec_key == NULL)
+		return -ENOMEM;
+
+	degree = EC_GROUP_get_degree(EC_KEY_get0_group(ec_key));
+
+	EC_KEY_free(ec_key);
+#endif
+
+	return degree;
+}
+
 int jwt_sign_sha_pem(jwt_t *jwt, char **out, unsigned int *len,
 		     const char *str, unsigned int str_len)
 {
@@ -271,20 +318,13 @@ int jwt_sign_sha_pem(jwt_t *jwt, char **out, unsigned int *len,
 		memcpy(*out, sig, slen);
 		*len = slen;
 	} else {
-		unsigned int degree, bn_len, r_len, s_len, buf_len;
+		unsigned int bn_len, r_len, s_len, buf_len;
 		unsigned char *raw_buf;
-		EC_KEY *ec_key;
 
 		/* For EC we need to convert to a raw format of R/S. */
-
-		/* Get the actual ec_key */
-		ec_key = EVP_PKEY_get1_EC_KEY(pkey);
-		if (ec_key == NULL)
-			SIGN_ERROR(ENOMEM);
-
-		degree = EC_GROUP_get_degree(EC_KEY_get0_group(ec_key));
-
-		EC_KEY_free(ec_key);
+		int degree = jwt_degree_for_key(pkey);
+		if (degree < 0)
+			SIGN_ERROR(-degree);
 
 		/* Get the sig from the DER encoded version. */
 		ec_sig = d2i_ECDSA_SIG(NULL, (const unsigned char **)&sig, slen);
@@ -418,22 +458,17 @@ int jwt_verify_sha_pem(jwt_t *jwt, const char *head, unsigned int head_len, cons
 
 	/* Convert EC sigs back to ASN1. */
 	if (pkey_type == EVP_PKEY_EC) {
-		unsigned int degree, bn_len;
+		unsigned int bn_len;
+		int degree;
 		unsigned char *p;
-		EC_KEY *ec_key;
 
 		ec_sig = ECDSA_SIG_new();
 		if (ec_sig == NULL)
 			VERIFY_ERROR(ENOMEM);
 
-		/* Get the actual ec_key */
-		ec_key = EVP_PKEY_get1_EC_KEY(pkey);
-		if (ec_key == NULL)
-			VERIFY_ERROR(ENOMEM);
-
-		degree = EC_GROUP_get_degree(EC_KEY_get0_group(ec_key));
-
-		EC_KEY_free(ec_key);
+		degree = jwt_degree_for_key(pkey);
+		if (degree < 0)
+			VERIFY_ERROR(-degree);
 
 		bn_len = (degree + 7) / 8;
 		if ((bn_len * 2) != slen)


### PR DESCRIPTION
```
jwt-openssl.c:281:17: warning: 'EVP_PKEY_get1_EC_KEY' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  281 |                 ec_key = EVP_PKEY_get1_EC_KEY(pkey);
      |                 ^~~~~~
jwt-openssl.c:285:17: warning: 'EC_KEY_get0_group' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
  285 |                 degree = EC_GROUP_get_degree(EC_KEY_get0_group(ec_key));
      |                 ^~~~~~
```