### PR TITLE
Fix Conditionals in Automake Build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_ARG_WITH([openssl],
 	[],
 	[with_openssl=check])
 
-[AM_CONDITIONAL([HAVE_GNUTLS], [false])]
+AM_CONDITIONAL([HAVE_GNUTLS], [false])
 AS_IF([test "x$with_gnutls" != xno],
 	[PKG_CHECK_MODULES([GNUTLS], [gnutls >= 3.6.0],
 	[AM_CONDITIONAL([HAVE_GNUTLS], [true])]
@@ -31,7 +31,7 @@ AS_IF([test "x$with_gnutls" != xno],
 		AC_MSG_FAILURE([--with-gnutls was given but GnuTLS not found])
 	))])
 
-[AM_CONDITIONAL([HAVE_OPENSSL], [false])]
+AM_CONDITIONAL([HAVE_OPENSSL], [false])
 AS_IF([test "x$with_openssl" != xno],
 	[PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.1.0],
         [AM_CONDITIONAL([HAVE_OPENSSL], [true])]

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ AC_ARG_WITH([openssl],
 	[],
 	[with_openssl=check])
 
-
+[AM_CONDITIONAL([HAVE_GNUTLS], [false])]
 AS_IF([test "x$with_gnutls" != xno],
 	[PKG_CHECK_MODULES([GNUTLS], [gnutls >= 3.6.0],
 	[AM_CONDITIONAL([HAVE_GNUTLS], [true])]
@@ -29,8 +29,9 @@ AS_IF([test "x$with_gnutls" != xno],
 	[HAVE_CRYPTO=true],
 	AS_IF([test "x$with_gnutls" != xcheck],
 		AC_MSG_FAILURE([--with-gnutls was given but GnuTLS not found])
-	))], [AM_CONDITIONAL([HAVE_GNUTLS], [false])])
+	))])
 
+[AM_CONDITIONAL([HAVE_OPENSSL], [false])]
 AS_IF([test "x$with_openssl" != xno],
 	[PKG_CHECK_MODULES([OPENSSL], [openssl >= 1.1.0],
         [AM_CONDITIONAL([HAVE_OPENSSL], [true])]
@@ -38,7 +39,7 @@ AS_IF([test "x$with_openssl" != xno],
 	[HAVE_CRYPTO=true],
         AS_IF([test "x$with_openssl" != xcheck],
 		AC_MSG_FAILURE([--with-openssl was given but OpenSSL not found])
-	))], [AM_CONDITIONAL([HAVE_OPENSSL], [false])])
+	))])
 
 AS_IF([test -z "$HAVE_CRYPTO"],
 	[AC_MSG_ERROR([no crypto library detected], [1])], [])


### PR DESCRIPTION
  - make sure default conditionals for `HAVE_GNUTLS` and `HAVE_OPENSSL` are always run