### PR TITLE
Add json-c as alternative JSON backend

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,3 +67,22 @@ jobs:
     - name: Memcheck
       working-directory: ${{github.workspace}}/build
       run: ctest -T memcheck
+
+  build-linux-json-c:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ConorMacBride/install-package@v1
+      with:
+        apt: gnutls-dev libssl-dev libjson-c-dev pkg-config check libcurl4-openssl-dev bats jq
+
+    - name: Build and Test with json-c
+      uses: threeal/cmake-action@v2.1.0
+      with:
+        options: |
+          WITH_JSON_C=YES
+          WITH_LIBCURL=YES
+        build-args: |
+          --
+          all
+          check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,13 @@ include(GNUInstallDirs)
 # Find all the things we need for the library
 find_package(PkgConfig REQUIRED)
 
+option(WITH_JSON_C "Whether to use json-c instead of jansson (default is OFF)" OFF)
+
+if (WITH_JSON_C)
+	pkg_check_modules(JSONC json-c>=0.16 REQUIRED IMPORTED_TARGET)
+else()
 pkg_check_modules(JANSSON jansson>=2.0 REQUIRED IMPORTED_TARGET)
+endif()
 
 if (NOT DEFINED WITH_GNUTLS)
 	set(GNUTLS_AUTO TRUE)
@@ -121,8 +127,18 @@ generate_export_header(jwt ${NO_BUILD_DEPRECATED})
 include_directories(${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}
 		    ${CMAKE_SOURCE_DIR}/libjwt)
 
-target_link_libraries(jwt PUBLIC PkgConfig::JANSSON)
-target_link_libraries(jwt_static PUBLIC PkgConfig::JANSSON)
+if (WITH_JSON_C)
+	add_definitions(-DHAVE_JSON_C)
+	target_link_libraries(jwt PUBLIC PkgConfig::JSONC)
+	target_link_libraries(jwt_static PUBLIC PkgConfig::JSONC)
+	list(APPEND JWT_SOURCES
+	     libjwt/json-c/jwt-json-c.c)
+else()
+	target_link_libraries(jwt PUBLIC PkgConfig::JANSSON)
+	target_link_libraries(jwt_static PUBLIC PkgConfig::JANSSON)
+	list(APPEND JWT_SOURCES
+	     libjwt/jansson/jwt-jansson.c)
+endif()
 
 # Process the detected packages
 set(HAVE_CRYPTO FALSE)
@@ -239,7 +255,12 @@ install(EXPORT ${LIBJWT_PROJECT}Targets
 
 # For pkg-config users
 unset(LIBJWT_LDFLAGS)
-foreach (FLAG ${JANSSON_LDFLAGS} ${OPENSSL_LDFLAGS} ${GNUTLS_LDFLAGS}
+if (WITH_JSON_C)
+	set(_JSON_LDFLAGS ${JSONC_LDFLAGS})
+else()
+	set(_JSON_LDFLAGS ${JANSSON_LDFLAGS})
+endif()
+foreach (FLAG ${_JSON_LDFLAGS} ${OPENSSL_LDFLAGS} ${GNUTLS_LDFLAGS}
 		${MBEDTLS_LDFLAGS} ${LIBCURL_LDFLAGS})
 	string(APPEND LIBJWT_LDFLAGS " " ${FLAG})
 endforeach()

--- a/libjwt/gnutls/jwk-parse.c
+++ b/libjwt/gnutls/jwk-parse.c
@@ -22,21 +22,21 @@
 static const char not_implemented[] = "GnuTLS does not yet implement JWK";
 
 JWT_NO_EXPORT
-int gnutls_process_eddsa(json_t *jwk, jwk_item_t *item)
+int gnutls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item)
 {
 	jwt_write_error(item, not_implemented);
 	return -1;
 }
 
 JWT_NO_EXPORT
-int gnutls_process_rsa(json_t *jwk, jwk_item_t *item)
+int gnutls_process_rsa(jwt_json_t *jwk, jwk_item_t *item)
 {
 	jwt_write_error(item, not_implemented);
 	return -1;
 }
 
 JWT_NO_EXPORT
-int gnutls_process_ec(json_t *jwk, jwk_item_t *item)
+int gnutls_process_ec(jwt_json_t *jwk, jwk_item_t *item)
 {
 	jwt_write_error(item, not_implemented);
 	return -1;

--- a/libjwt/gnutls/jwt-gnutls.h
+++ b/libjwt/gnutls/jwt-gnutls.h
@@ -10,14 +10,14 @@
 #define JWT_GNUTLS_H
 
 /* Until we have our own routines, we rely on OpenSSL */
-int openssl_process_eddsa(json_t *jwk, jwk_item_t *item);
-int openssl_process_rsa(json_t *jwk, jwk_item_t *item);
-int openssl_process_ec(json_t *jwk, jwk_item_t *item);
+int openssl_process_eddsa(jwt_json_t *jwk, jwk_item_t *item);
+int openssl_process_rsa(jwt_json_t *jwk, jwk_item_t *item);
+int openssl_process_ec(jwt_json_t *jwk, jwk_item_t *item);
 void openssl_process_item_free(jwk_item_t *item);
 
-int gnutls_process_eddsa(json_t *jwk, jwk_item_t *item);
-int gnutls_process_rsa(json_t *jwk, jwk_item_t *item);
-int gnutls_process_ec(json_t *jwk, jwk_item_t *item);
+int gnutls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item);
+int gnutls_process_rsa(jwt_json_t *jwk, jwk_item_t *item);
+int gnutls_process_ec(jwt_json_t *jwk, jwk_item_t *item);
 void gnutls_process_item_free(jwk_item_t *item);
 
 #endif /* JWT_GNUTLS_H */

--- a/libjwt/jansson/jwt-jansson.c
+++ b/libjwt/jansson/jwt-jansson.c
@@ -112,11 +112,6 @@ void jwt_json_release(jwt_json_t *json)
 	json_decref(to_json(json));
 }
 
-jwt_json_t *jwt_json_retain(jwt_json_t *json)
-{
-	return from_json(json_incref(to_json(json)));
-}
-
 /* ================================================================
  * Object creation
  * ================================================================ */
@@ -202,11 +197,6 @@ int jwt_json_arr_append(jwt_json_t *array, jwt_json_t *value)
 /* ================================================================
  * Type checking
  * ================================================================ */
-
-int jwt_json_is_object(const jwt_json_t *json)
-{
-	return json_is_object(to_json(json));
-}
 
 int jwt_json_is_array(const jwt_json_t *json)
 {

--- a/libjwt/jansson/jwt-jansson.c
+++ b/libjwt/jansson/jwt-jansson.c
@@ -1,0 +1,314 @@
+/* Copyright (C) 2026 Ramin Seyed Moussavi, Yacoub Automation GmbH <ramin.moussavi@yacoub.de>
+   This file is part of the JWT C Library
+
+   SPDX-License-Identifier:  MPL-2.0
+   This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Jansson JSON backend for libjwt.
+ *
+ * Implements the jwt_json_* abstraction using jansson.
+ */
+
+#include <jansson.h>
+#include "jwt-json-ops.h"
+
+#include <string.h>
+
+/* ================================================================
+ * Memory allocator override
+ * ================================================================ */
+
+void jwt_json_set_alloc(void *(*alloc_func)(size_t),
+			void (*free_func)(void *))
+{
+	json_set_alloc_funcs(alloc_func, free_func);
+}
+
+/* ================================================================
+ * Internal helpers: cast between opaque jwt_json_t and json_t
+ * ================================================================ */
+
+static inline json_t *to_json(const jwt_json_t *j)
+{
+	return (json_t *)j;
+}
+
+static inline jwt_json_t *from_json(json_t *j)
+{
+	return (jwt_json_t *)j;
+}
+
+/* ================================================================
+ * Internal: translate jwt_json flags to native jansson flags
+ * ================================================================ */
+
+static size_t encode_flags(size_t flags)
+{
+	size_t jflags = 0;
+
+	int indent = flags & 0x1F;
+	if (indent > 0)
+		jflags |= JSON_INDENT(indent);
+	if (flags & JWT_JSON_COMPACT)
+		jflags |= JSON_COMPACT;
+	if (flags & JWT_JSON_SORT_KEYS)
+		jflags |= JSON_SORT_KEYS;
+
+	return jflags;
+}
+
+static size_t decode_flags(size_t flags)
+{
+	size_t jflags = 0;
+
+	if (flags & JWT_JSON_REJECT_DUPLICATES)
+		jflags |= JSON_REJECT_DUPLICATES;
+	if (flags & JWT_JSON_DECODE_ANY)
+		jflags |= JSON_DECODE_ANY;
+
+	return jflags;
+}
+
+/* ================================================================
+ * Internal: map jansson json_error_t to jwt_json_error_t
+ * ================================================================ */
+
+static void map_error(jwt_json_error_t *dst, const json_error_t *src)
+{
+	if (!dst)
+		return;
+
+	memset(dst, 0, sizeof(*dst));
+
+	if (src) {
+		snprintf(dst->text, JWT_JSON_ERROR_TEXT_LENGTH,
+			 "%s", src->text);
+		snprintf(dst->source, JWT_JSON_ERROR_SOURCE_LENGTH,
+			 "%s", src->source);
+		dst->line = src->line;
+		dst->column = src->column;
+		dst->position = src->position;
+	}
+}
+
+/* ================================================================
+ * Reference counting
+ * ================================================================ */
+
+void jwt_json_releasep(jwt_json_t **json)
+{
+	if (json) {
+		json_t *j = to_json(*json);
+		json_decref(j);
+		*json = NULL;
+	}
+}
+
+void jwt_json_release(jwt_json_t *json)
+{
+	json_decref(to_json(json));
+}
+
+jwt_json_t *jwt_json_retain(jwt_json_t *json)
+{
+	return from_json(json_incref(to_json(json)));
+}
+
+/* ================================================================
+ * Object creation
+ * ================================================================ */
+
+jwt_json_t *jwt_json_create(void)
+{
+	return from_json(json_object());
+}
+
+jwt_json_t *jwt_json_create_arr(void)
+{
+	return from_json(json_array());
+}
+
+jwt_json_t *jwt_json_create_str(const char *value)
+{
+	return from_json(json_string(value));
+}
+
+jwt_json_t *jwt_json_create_int(jwt_json_int_t value)
+{
+	return from_json(json_integer(value));
+}
+
+jwt_json_t *jwt_json_create_bool(int value)
+{
+	return from_json(json_boolean(value));
+}
+
+/* ================================================================
+ * Object operations
+ * ================================================================ */
+
+jwt_json_t *jwt_json_obj_get(const jwt_json_t *object, const char *key)
+{
+	return from_json(json_object_get(to_json(object), key));
+}
+
+int jwt_json_obj_set(jwt_json_t *object, const char *key, jwt_json_t *value)
+{
+	return json_object_set_new(to_json(object), key, to_json(value));
+}
+
+int jwt_json_obj_del(jwt_json_t *object, const char *key)
+{
+	return json_object_del(to_json(object), key);
+}
+
+int jwt_json_obj_clear(jwt_json_t *object)
+{
+	return json_object_clear(to_json(object));
+}
+
+int jwt_json_obj_merge(jwt_json_t *object, jwt_json_t *other)
+{
+	return json_object_update(to_json(object), to_json(other));
+}
+
+int jwt_json_obj_merge_new(jwt_json_t *object, jwt_json_t *other)
+{
+	return json_object_update_missing(to_json(object), to_json(other));
+}
+
+/* ================================================================
+ * Array operations
+ * ================================================================ */
+
+size_t jwt_json_arr_size(const jwt_json_t *array)
+{
+	return json_array_size(to_json(array));
+}
+
+jwt_json_t *jwt_json_arr_get(const jwt_json_t *array, size_t index)
+{
+	return from_json(json_array_get(to_json(array), index));
+}
+
+int jwt_json_arr_append(jwt_json_t *array, jwt_json_t *value)
+{
+	return json_array_append_new(to_json(array), to_json(value));
+}
+
+/* ================================================================
+ * Type checking
+ * ================================================================ */
+
+int jwt_json_is_object(const jwt_json_t *json)
+{
+	return json_is_object(to_json(json));
+}
+
+int jwt_json_is_array(const jwt_json_t *json)
+{
+	return json_is_array(to_json(json));
+}
+
+int jwt_json_is_string(const jwt_json_t *json)
+{
+	return json_is_string(to_json(json));
+}
+
+int jwt_json_is_int(const jwt_json_t *json)
+{
+	return json_is_integer(to_json(json));
+}
+
+int jwt_json_is_bool(const jwt_json_t *json)
+{
+	return json_is_boolean(to_json(json));
+}
+
+int jwt_json_is_true(const jwt_json_t *json)
+{
+	return json_is_true(to_json(json));
+}
+
+/* ================================================================
+ * Value extraction
+ * ================================================================ */
+
+const char *jwt_json_str_val(const jwt_json_t *json)
+{
+	return json_string_value(to_json(json));
+}
+
+jwt_json_int_t jwt_json_int_val(const jwt_json_t *json)
+{
+	return json_integer_value(to_json(json));
+}
+
+/* ================================================================
+ * Deep copy
+ * ================================================================ */
+
+jwt_json_t *jwt_json_clone(const jwt_json_t *value)
+{
+	return from_json(json_deep_copy(to_json(value)));
+}
+
+/* ================================================================
+ * Serialization / Parsing
+ * ================================================================ */
+
+char *jwt_json_serialize(const jwt_json_t *json, size_t flags)
+{
+	return json_dumps(to_json(json), encode_flags(flags));
+}
+
+jwt_json_t *jwt_json_parse(const char *input, size_t flags,
+			   jwt_json_error_t *error)
+{
+	json_error_t jerr;
+	json_t *obj = json_loads(input, decode_flags(flags), &jerr);
+
+	if (!obj && error)
+		map_error(error, &jerr);
+
+	return from_json(obj);
+}
+
+jwt_json_t *jwt_json_parse_buf(const char *buffer, size_t buflen,
+			       size_t flags, jwt_json_error_t *error)
+{
+	json_error_t jerr;
+	json_t *obj = json_loadb(buffer, buflen, decode_flags(flags), &jerr);
+
+	if (!obj && error)
+		map_error(error, &jerr);
+
+	return from_json(obj);
+}
+
+jwt_json_t *jwt_json_parse_file(const char *path, size_t flags,
+				jwt_json_error_t *error)
+{
+	json_error_t jerr;
+	json_t *obj = json_load_file(path, decode_flags(flags), &jerr);
+
+	if (!obj && error)
+		map_error(error, &jerr);
+
+	return from_json(obj);
+}
+
+jwt_json_t *jwt_json_parse_fp(FILE *input, size_t flags,
+			      jwt_json_error_t *error)
+{
+	json_error_t jerr;
+	json_t *obj = json_loadf(input, decode_flags(flags), &jerr);
+
+	if (!obj && error)
+		map_error(error, &jerr);
+
+	return from_json(obj);
+}

--- a/libjwt/json-c/jwt-json-c.c
+++ b/libjwt/json-c/jwt-json-c.c
@@ -1,0 +1,713 @@
+/* Copyright (C) 2026 Ramin Seyed Moussavi, Yacoub Automation GmbH <ramin.moussavi@yacoub.de>
+   This file is part of the JWT C Library
+
+   SPDX-License-Identifier:  MPL-2.0
+   This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * json-c JSON backend for libjwt.
+ *
+ * Implements the jwt_json_* abstraction using json-c.
+ */
+
+#include <json-c/json.h>
+#include "jwt-json-ops.h"
+
+#include <limits.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* From jwt-memory.c - declared here to avoid pulling in jwt-private.h
+ * which requires the full jwt.h public header. */
+extern void *jwt_malloc(size_t size);
+
+/* ================================================================
+ * Internal helpers: cast between opaque jwt_json_t and json_object
+ * ================================================================ */
+
+static inline struct json_object *to_jc(const jwt_json_t *j)
+{
+	return (struct json_object *)j;
+}
+
+static inline jwt_json_t *from_jc(struct json_object *j)
+{
+	return (jwt_json_t *)j;
+}
+
+/* ================================================================
+ * Memory allocator override
+ * ================================================================ */
+
+void jwt_json_set_alloc(void *(*alloc_func)(size_t),
+			void (*free_func)(void *))
+{
+	/* json-c does not support custom allocators */
+	(void)alloc_func;
+	(void)free_func;
+}
+
+/* Internal flag masks - must match jwt-json-ops.h */
+#define INDENT_MASK	0x1F
+#define FLAG_COMPACT	0x20
+#define FLAG_SORT_KEYS	0x80
+
+/* ================================================================
+ * Reference counting
+ * ================================================================ */
+
+void jwt_json_releasep(jwt_json_t **json)
+{
+	if (json && *json) {
+		json_object_put(to_jc(*json));
+		*json = NULL;
+	}
+}
+
+void jwt_json_release(jwt_json_t *json)
+{
+	if (json)
+		json_object_put(to_jc(json));
+}
+
+jwt_json_t *jwt_json_retain(jwt_json_t *json)
+{
+	if (json)
+		return from_jc(json_object_get(to_jc(json)));
+	return NULL;
+}
+
+/* ================================================================
+ * Object creation
+ * ================================================================ */
+
+jwt_json_t *jwt_json_create(void)
+{
+	return from_jc(json_object_new_object());
+}
+
+jwt_json_t *jwt_json_create_arr(void)
+{
+	return from_jc(json_object_new_array());
+}
+
+jwt_json_t *jwt_json_create_str(const char *value)
+{
+	if (!value)
+		return NULL;
+	return from_jc(json_object_new_string(value));
+}
+
+jwt_json_t *jwt_json_create_int(jwt_json_int_t value)
+{
+	return from_jc(json_object_new_int64(value));
+}
+
+jwt_json_t *jwt_json_create_bool(int value)
+{
+	return from_jc(json_object_new_boolean(value));
+}
+
+/* ================================================================
+ * Object operations
+ * ================================================================ */
+
+jwt_json_t *jwt_json_obj_get(const jwt_json_t *object, const char *key)
+{
+	if (!object || !key)
+		return NULL;
+	return from_jc(json_object_object_get(to_jc(object), key));
+}
+
+int jwt_json_obj_set(jwt_json_t *object, const char *key, jwt_json_t *value)
+{
+	if (!object || !key || !value)
+		return -1;
+	return json_object_object_add(to_jc(object), key, to_jc(value));
+}
+
+int jwt_json_obj_del(jwt_json_t *object, const char *key)
+{
+	if (!object || !key)
+		return -1;
+	json_object_object_del(to_jc(object), key);
+	return 0;
+}
+
+int jwt_json_obj_clear(jwt_json_t *object)
+{
+	const char **keys;
+	int n = 0, i = 0;
+
+	if (!object)
+		return -1;
+
+	json_object_object_foreach(to_jc(object), key, val) {
+		(void)key;
+		(void)val;
+		n++;
+	}
+
+	if (n == 0)
+		return 0;
+
+	keys = malloc(n * sizeof(char *));
+	if (!keys)
+		return -1;
+
+	json_object_object_foreach(to_jc(object), key2, val2) {
+		(void)val2;
+		keys[i++] = key2;
+	}
+
+	for (i = 0; i < n; i++)
+		json_object_object_del(to_jc(object), keys[i]);
+
+	free(keys);
+	return 0;
+}
+
+int jwt_json_obj_merge(jwt_json_t *object, jwt_json_t *other)
+{
+	if (!object || !other)
+		return -1;
+
+	json_object_object_foreach(to_jc(other), key, val) {
+		json_object_object_add(to_jc(object), key,
+				       json_object_get(val));
+	}
+
+	return 0;
+}
+
+int jwt_json_obj_merge_new(jwt_json_t *object, jwt_json_t *other)
+{
+	if (!object || !other)
+		return -1;
+
+	json_object_object_foreach(to_jc(other), key, val) {
+		struct json_object *existing;
+		if (!json_object_object_get_ex(to_jc(object), key, &existing))
+			json_object_object_add(to_jc(object), key,
+					       json_object_get(val));
+	}
+
+	return 0;
+}
+
+/* ================================================================
+ * Array operations
+ * ================================================================ */
+
+size_t jwt_json_arr_size(const jwt_json_t *array)
+{
+	if (!array)
+		return 0;
+	return json_object_array_length(to_jc(array));
+}
+
+jwt_json_t *jwt_json_arr_get(const jwt_json_t *array, size_t index)
+{
+	if (!array)
+		return NULL;
+	return from_jc(json_object_array_get_idx(to_jc(array), index));
+}
+
+int jwt_json_arr_append(jwt_json_t *array, jwt_json_t *value)
+{
+	if (!array)
+		return -1;
+	return json_object_array_add(to_jc(array), to_jc(value));
+}
+
+/* ================================================================
+ * Type checking
+ * ================================================================ */
+
+int jwt_json_is_object(const jwt_json_t *json)
+{
+	return json && json_object_is_type(to_jc(json), json_type_object);
+}
+
+int jwt_json_is_array(const jwt_json_t *json)
+{
+	return json && json_object_is_type(to_jc(json), json_type_array);
+}
+
+int jwt_json_is_string(const jwt_json_t *json)
+{
+	return json && json_object_is_type(to_jc(json), json_type_string);
+}
+
+int jwt_json_is_int(const jwt_json_t *json)
+{
+	return json && json_object_is_type(to_jc(json), json_type_int);
+}
+
+int jwt_json_is_bool(const jwt_json_t *json)
+{
+	return json && json_object_is_type(to_jc(json), json_type_boolean);
+}
+
+int jwt_json_is_true(const jwt_json_t *json)
+{
+	return json && json_object_is_type(to_jc(json), json_type_boolean) &&
+	       json_object_get_boolean(to_jc(json));
+}
+
+/* ================================================================
+ * Value extraction
+ * ================================================================ */
+
+const char *jwt_json_str_val(const jwt_json_t *json)
+{
+	if (!json)
+		return NULL;
+	return json_object_get_string(to_jc(json));
+}
+
+jwt_json_int_t jwt_json_int_val(const jwt_json_t *json)
+{
+	if (!json)
+		return 0;
+	return json_object_get_int64(to_jc(json));
+}
+
+/* ================================================================
+ * Deep copy
+ * ================================================================ */
+
+jwt_json_t *jwt_json_clone(const jwt_json_t *value)
+{
+	struct json_object *dst = NULL;
+
+	if (!value)
+		return NULL;
+
+	if (json_object_deep_copy(to_jc(value), &dst, NULL) != 0)
+		return NULL;
+
+	return from_jc(dst);
+}
+
+/* ================================================================
+ * Sorted-key serialization
+ *
+ * json-c does not support sorted keys natively. We implement it
+ * here because JWT requires deterministic output (RFC 7515).
+ * ================================================================ */
+
+static int key_cmp(const void *a, const void *b)
+{
+	return strcmp(*(const char **)a, *(const char **)b);
+}
+
+static int append_str(char **buf, size_t *len, size_t *cap, const char *str)
+{
+	size_t slen = strlen(str);
+
+	while (*len + slen + 1 > *cap) {
+		*cap *= 2;
+		char *tmp = realloc(*buf, *cap);
+		if (!tmp)
+			return -1;
+		*buf = tmp;
+	}
+	memcpy(*buf + *len, str, slen);
+	*len += slen;
+	(*buf)[*len] = '\0';
+	return 0;
+}
+
+static int serialize_value_sorted(struct json_object *json, int compact,
+				  char **buf, size_t *len, size_t *cap)
+{
+	if (!json)
+		return append_str(buf, len, cap, "null");
+
+	enum json_type type = json_object_get_type(json);
+
+	if (type == json_type_object) {
+		int n = json_object_object_length(json);
+		const char **keys = NULL;
+		int i = 0;
+
+		if (append_str(buf, len, cap, "{"))
+			return -1;
+
+		if (n > 0) {
+			keys = malloc(n * sizeof(char *));
+			if (!keys)
+				return -1;
+
+			json_object_object_foreach(json, key, val) {
+				(void)val;
+				keys[i++] = key;
+			}
+
+			qsort(keys, n, sizeof(char *), key_cmp);
+
+			for (i = 0; i < n; i++) {
+				struct json_object *v;
+				const char *escaped;
+				struct json_object *str_obj;
+
+				if (i > 0) {
+					if (append_str(buf, len, cap,
+						       compact ? "," : ", ")) {
+						free(keys);
+						return -1;
+					}
+				}
+
+				str_obj = json_object_new_string(keys[i]);
+				escaped = json_object_to_json_string_ext(
+					str_obj, JSON_C_TO_STRING_PLAIN);
+				if (append_str(buf, len, cap, escaped)) {
+					json_object_put(str_obj);
+					free(keys);
+					return -1;
+				}
+				json_object_put(str_obj);
+
+				if (append_str(buf, len, cap,
+					       compact ? ":" : ": ")) {
+					free(keys);
+					return -1;
+				}
+
+				json_object_object_get_ex(json, keys[i], &v);
+				if (serialize_value_sorted(v, compact, buf,
+							   len, cap)) {
+					free(keys);
+					return -1;
+				}
+			}
+
+			free(keys);
+		}
+
+		return append_str(buf, len, cap, "}");
+
+	} else if (type == json_type_array) {
+		size_t arr_len = json_object_array_length(json);
+
+		if (append_str(buf, len, cap, "["))
+			return -1;
+
+		for (size_t idx = 0; idx < arr_len; idx++) {
+			struct json_object *elem;
+
+			if (idx > 0) {
+				if (append_str(buf, len, cap,
+					       compact ? "," : ", "))
+					return -1;
+			}
+
+			elem = json_object_array_get_idx(json, idx);
+			if (serialize_value_sorted(elem, compact, buf,
+						   len, cap))
+				return -1;
+		}
+
+		return append_str(buf, len, cap, "]");
+
+	} else {
+		const char *str = json_object_to_json_string_ext(
+			json, JSON_C_TO_STRING_PLAIN);
+		return append_str(buf, len, cap, str);
+	}
+}
+
+static int serialize_sorted(const jwt_json_t *json, int compact, char **out)
+{
+	size_t len = 0;
+	size_t cap = 256;
+	char *buf = malloc(cap);
+
+	if (!buf)
+		return -1;
+
+	buf[0] = '\0';
+
+	if (serialize_value_sorted(to_jc(json), compact, &buf, &len, &cap)) {
+		free(buf);
+		return -1;
+	}
+
+	*out = buf;
+	return 0;
+}
+
+/* ================================================================
+ * Serialization / Parsing
+ * ================================================================ */
+
+/**
+ * Copy a libc-allocated string into a jwt_malloc-allocated buffer.
+ * The caller is expected to free the result with jwt_freemem().
+ */
+static char *to_jwt_alloc(char *libc_str)
+{
+	size_t len;
+	char *out;
+
+	if (!libc_str)
+		return NULL;
+
+	len = strlen(libc_str) + 1;
+	out = jwt_malloc(len);
+	if (!out) {
+		free(libc_str);
+		return NULL;
+	}
+
+	memcpy(out, libc_str, len);
+	free(libc_str);
+	return out;
+}
+
+char *jwt_json_serialize(const jwt_json_t *json, size_t flags)
+{
+	char *result;
+
+	if (!json)
+		return NULL;
+
+	if (flags & FLAG_SORT_KEYS) {
+		int compact = (flags & FLAG_COMPACT) ? 1 : 0;
+
+		if (serialize_sorted(json, compact, &result))
+			return NULL;
+		return to_jwt_alloc(result);
+	}
+
+	int jc_flags = JSON_C_TO_STRING_PLAIN;
+	int indent = flags & INDENT_MASK;
+
+	if (indent > 0)
+		jc_flags = JSON_C_TO_STRING_PRETTY;
+
+	const char *str = json_object_to_json_string_ext(to_jc(json), jc_flags);
+	if (!str)
+		return NULL;
+
+	size_t len = strlen(str) + 1;
+	result = jwt_malloc(len);
+	if (!result)
+		return NULL;
+
+	memcpy(result, str, len);
+	return result;
+}
+
+static void set_error(jwt_json_error_t *error, const char *source,
+		      const char *text)
+{
+	if (!error)
+		return;
+
+	memset(error, 0, sizeof(*error));
+
+	if (text)
+		snprintf(error->text, JWT_JSON_ERROR_TEXT_LENGTH, "%s", text);
+	if (source)
+		snprintf(error->source, JWT_JSON_ERROR_SOURCE_LENGTH,
+			 "%s", source);
+}
+
+/*
+ * NOTE: json-c does not support JWT_JSON_REJECT_DUPLICATES.
+ * Duplicate keys are silently accepted (last value wins).
+ * This only affects jwt_set_json() where users manually set
+ * JSON claims - it does not affect JWT verification of
+ * received tokens.
+ */
+
+/**
+ * Common post-parse validation for all parse functions.
+ * Checks trailing garbage and enforces DECODE_ANY semantics.
+ */
+static jwt_json_t *validate_parsed(struct json_tokener *tok,
+				   struct json_object *obj,
+				   size_t input_len, size_t flags,
+				   const char *source,
+				   jwt_json_error_t *error)
+{
+	/* Reject trailing garbage */
+	if (json_tokener_get_parse_end(tok) < input_len) {
+		set_error(error, source, "Trailing data after JSON value");
+		json_tokener_free(tok);
+		if (obj)
+			json_object_put(obj);
+		return NULL;
+	}
+
+	json_tokener_free(tok);
+
+	/* Without DECODE_ANY, only accept objects and arrays
+	 * (matches jansson default behavior) */
+	if (!(flags & JWT_JSON_DECODE_ANY)) {
+		if (!json_object_is_type(obj, json_type_object) &&
+		    !json_object_is_type(obj, json_type_array)) {
+			set_error(error, source,
+				  "Expected JSON object or array");
+			json_object_put(obj);
+			return NULL;
+		}
+	}
+
+	return from_jc(obj);
+}
+
+jwt_json_t *jwt_json_parse(const char *input, size_t flags,
+			   jwt_json_error_t *error)
+{
+	struct json_tokener *tok;
+	struct json_object *obj;
+	enum json_tokener_error jerr;
+
+	if (!input) {
+		set_error(error, "<string>", "NULL input");
+		return NULL;
+	}
+
+	size_t slen = strlen(input);
+	if (slen > INT_MAX) {
+		set_error(error, "<string>", "Input too large");
+		return NULL;
+	}
+
+	tok = json_tokener_new();
+	if (!tok) {
+		set_error(error, "<string>", "Failed to create tokener");
+		return NULL;
+	}
+
+	obj = json_tokener_parse_ex(tok, input, (int)slen);
+	jerr = json_tokener_get_error(tok);
+
+	if (jerr != json_tokener_success) {
+		set_error(error, "<string>",
+			  json_tokener_error_desc(jerr));
+		json_tokener_free(tok);
+		if (obj)
+			json_object_put(obj);
+		return NULL;
+	}
+
+	return validate_parsed(tok, obj, slen, flags, "<string>", error);
+}
+
+jwt_json_t *jwt_json_parse_buf(const char *buffer, size_t buflen,
+			       size_t flags, jwt_json_error_t *error)
+{
+	struct json_tokener *tok;
+	struct json_object *obj;
+	enum json_tokener_error jerr;
+
+	if (!buffer) {
+		set_error(error, "<buffer>", "NULL buffer");
+		return NULL;
+	}
+
+	if (buflen > INT_MAX) {
+		set_error(error, "<buffer>", "Buffer too large");
+		return NULL;
+	}
+
+	tok = json_tokener_new();
+	if (!tok) {
+		set_error(error, "<buffer>", "Failed to create tokener");
+		return NULL;
+	}
+
+	obj = json_tokener_parse_ex(tok, buffer, (int)buflen);
+	jerr = json_tokener_get_error(tok);
+
+	if (jerr != json_tokener_success) {
+		set_error(error, "<buffer>",
+			  json_tokener_error_desc(jerr));
+		json_tokener_free(tok);
+		if (obj)
+			json_object_put(obj);
+		return NULL;
+	}
+
+	return validate_parsed(tok, obj, buflen, flags, "<buffer>", error);
+}
+
+jwt_json_t *jwt_json_parse_file(const char *path, size_t flags,
+				jwt_json_error_t *error)
+{
+	struct json_object *obj;
+
+	if (!path) {
+		set_error(error, "<file>", "NULL path");
+		return NULL;
+	}
+
+	obj = json_object_from_file(path);
+	if (!obj) {
+		set_error(error, path, "Failed to parse file");
+		return NULL;
+	}
+
+	if (!(flags & JWT_JSON_DECODE_ANY)) {
+		if (!json_object_is_type(obj, json_type_object) &&
+		    !json_object_is_type(obj, json_type_array)) {
+			set_error(error, path,
+				  "Expected JSON object or array");
+			json_object_put(obj);
+			return NULL;
+		}
+	}
+
+	return from_jc(obj);
+}
+
+jwt_json_t *jwt_json_parse_fp(FILE *input, size_t flags,
+			      jwt_json_error_t *error)
+{
+	char *buf = NULL;
+	size_t len = 0, cap = 0;
+	char chunk[4096];
+	size_t nread;
+	jwt_json_t *result;
+
+	if (!input) {
+		set_error(error, "<file>", "NULL FILE pointer");
+		return NULL;
+	}
+
+	while ((nread = fread(chunk, 1, sizeof(chunk), input)) > 0) {
+		if (len + nread + 1 > cap) {
+			cap = (cap == 0) ? 8192 : cap * 2;
+			if (cap < len + nread + 1)
+				cap = len + nread + 1;
+			char *tmp = realloc(buf, cap);
+			if (!tmp) {
+				free(buf);
+				set_error(error, "<file>",
+					  "Memory allocation failed");
+				return NULL;
+			}
+			buf = tmp;
+		}
+		memcpy(buf + len, chunk, nread);
+		len += nread;
+	}
+
+	if (!buf) {
+		set_error(error, "<file>", "Empty input");
+		return NULL;
+	}
+
+	buf[len] = '\0';
+	result = jwt_json_parse(buf, flags, error);
+	free(buf);
+
+	return result;
+}

--- a/libjwt/json-c/jwt-json-c.c
+++ b/libjwt/json-c/jwt-json-c.c
@@ -72,13 +72,6 @@ void jwt_json_release(jwt_json_t *json)
 		json_object_put(to_jc(json));
 }
 
-jwt_json_t *jwt_json_retain(jwt_json_t *json)
-{
-	if (json)
-		return from_jc(json_object_get(to_jc(json)));
-	return NULL;
-}
-
 /* ================================================================
  * Object creation
  * ================================================================ */
@@ -225,11 +218,6 @@ int jwt_json_arr_append(jwt_json_t *array, jwt_json_t *value)
 /* ================================================================
  * Type checking
  * ================================================================ */
-
-int jwt_json_is_object(const jwt_json_t *json)
-{
-	return json && json_object_is_type(to_jc(json), json_type_object);
-}
 
 int jwt_json_is_array(const jwt_json_t *json)
 {

--- a/libjwt/jwt-common.c
+++ b/libjwt/jwt-common.c
@@ -31,8 +31,8 @@ void FUNC(free)(jwt_common_t *__cmd)
 	if (__cmd == NULL)
 		return;
 
-	json_decref(__cmd->c.payload);
-	json_decref(__cmd->c.headers);
+	jwt_json_release(__cmd->c.payload);
+	jwt_json_release(__cmd->c.headers);
 
 	memset(__cmd, 0, sizeof(*__cmd));
 
@@ -48,8 +48,8 @@ jwt_common_t *FUNC(new)(void)
 
 	memset(__cmd, 0, sizeof(*__cmd));
 
-	__cmd->c.payload = json_object();
-	__cmd->c.headers = json_object();
+	__cmd->c.payload = jwt_json_create();
+	__cmd->c.headers = jwt_json_create();
 	__cmd->c.claims = CLAIMS_DEF;
 
 	if (!__cmd->c.payload || !__cmd->c.headers)
@@ -186,12 +186,12 @@ typedef enum {
 	__CLAIM,
 } _setget_type_t;
 
-typedef jwt_value_error_t (*__doer_t)(json_t *, jwt_value_t *);
+typedef jwt_value_error_t (*__doer_t)(jwt_json_t *, jwt_value_t *);
 
 static jwt_value_error_t __run_it(jwt_common_t *__cmd, _setget_type_t type,
 				  jwt_value_t *value, __doer_t doer)
 {
-	json_t *which = NULL;
+	jwt_json_t *which = NULL;
 #ifdef JWT_BUILDER
 	if (!__cmd || !value) {
 		if (value)
@@ -430,8 +430,8 @@ char *FUNC(generate)(jwt_common_t *__cmd)
 
 	memset(jwt, 0, sizeof(*jwt));
 
-	jwt->headers = json_deep_copy(__cmd->c.headers);
-	jwt->claims = json_deep_copy(__cmd->c.payload);
+	jwt->headers = jwt_json_clone(__cmd->c.headers);
+	jwt->claims = jwt_json_clone(__cmd->c.payload);
 
 	/* Our internal work first */
 	if (__cmd->c.claims & JWT_CLAIM_IAT) {

--- a/libjwt/jwt-encode.c
+++ b/libjwt/jwt-encode.c
@@ -14,9 +14,9 @@
 
 #include "jwt-private.h"
 
-static int write_js(const json_t *js, char **buf)
+static int write_js(const jwt_json_t *js, char **buf)
 {
-	*buf = json_dumps(js, JSON_SORT_KEYS | JSON_COMPACT);
+	*buf = jwt_json_serialize(js, JWT_JSON_SORT_KEYS | JWT_JSON_COMPACT);
 
 	return *buf == NULL ? 1 : 0;
 }

--- a/libjwt/jwt-json-ops.h
+++ b/libjwt/jwt-json-ops.h
@@ -1,0 +1,147 @@
+/* Copyright (C) 2026 Ramin Seyed Moussavi, Yacoub Automation GmbH <ramin.moussavi@yacoub.de>
+   This file is part of the JWT C Library
+
+   SPDX-License-Identifier:  MPL-2.0
+   This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * JSON backend abstraction for libjwt.
+ *
+ * Common interface header for all JSON backends (jansson, json-c).
+ * Each backend provides a .c file implementing these functions.
+ */
+
+#ifndef JWT_JSON_OPS_H
+#define JWT_JSON_OPS_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+/* ================================================================
+ * Types
+ * ================================================================ */
+
+/** Opaque JSON type - backends cast internally to the real lib struct */
+typedef struct jwt_json_s jwt_json_t;
+
+typedef int64_t jwt_json_int_t;
+
+#define JWT_JSON_ERROR_TEXT_LENGTH	160
+#define JWT_JSON_ERROR_SOURCE_LENGTH	80
+
+typedef struct {
+	char text[JWT_JSON_ERROR_TEXT_LENGTH];
+	char source[JWT_JSON_ERROR_SOURCE_LENGTH];
+	int line;
+	int column;
+	size_t position;
+} jwt_json_error_t;
+
+/* ================================================================
+ * Flags
+ * ================================================================ */
+
+/* Encoding */
+#define JWT_JSON_INDENT(n)		((n) & 0x1F)
+#define JWT_JSON_COMPACT		0x20
+#define JWT_JSON_SORT_KEYS		0x80
+
+/* Decoding */
+#define JWT_JSON_REJECT_DUPLICATES	0x01
+#define JWT_JSON_DECODE_ANY		0x08
+
+/* ================================================================
+ * Memory allocator override
+ * ================================================================ */
+
+void jwt_json_set_alloc(void *(*alloc_func)(size_t),
+			void (*free_func)(void *));
+
+/* ================================================================
+ * Reference counting & auto cleanup
+ * ================================================================ */
+
+void jwt_json_releasep(jwt_json_t **json);
+#define jwt_json_auto_t jwt_json_t __attribute__((cleanup(jwt_json_releasep)))
+
+jwt_json_t *jwt_json_retain(jwt_json_t *json);
+void jwt_json_release(jwt_json_t *json);
+
+/* ================================================================
+ * Object creation
+ * ================================================================ */
+
+jwt_json_t *jwt_json_create(void);
+jwt_json_t *jwt_json_create_arr(void);
+jwt_json_t *jwt_json_create_str(const char *value);
+jwt_json_t *jwt_json_create_int(jwt_json_int_t value);
+jwt_json_t *jwt_json_create_bool(int value);
+
+/* ================================================================
+ * Object operations
+ * ================================================================ */
+
+jwt_json_t *jwt_json_obj_get(const jwt_json_t *object, const char *key);
+int jwt_json_obj_set(jwt_json_t *object, const char *key, jwt_json_t *value);
+int jwt_json_obj_del(jwt_json_t *object, const char *key);
+int jwt_json_obj_clear(jwt_json_t *object);
+int jwt_json_obj_merge(jwt_json_t *object, jwt_json_t *other);
+int jwt_json_obj_merge_new(jwt_json_t *object, jwt_json_t *other);
+
+/* ================================================================
+ * Array operations
+ * ================================================================ */
+
+size_t jwt_json_arr_size(const jwt_json_t *array);
+jwt_json_t *jwt_json_arr_get(const jwt_json_t *array, size_t index);
+int jwt_json_arr_append(jwt_json_t *array, jwt_json_t *value);
+
+#define jwt_json_arr_foreach(array, index, value)		\
+	for ((index) = 0;					\
+	     (index) < jwt_json_arr_size(array) &&		\
+	     ((value) = jwt_json_arr_get((array), (index)));	\
+	     (index)++)
+
+/* ================================================================
+ * Type checking
+ * ================================================================ */
+
+int jwt_json_is_object(const jwt_json_t *json);
+int jwt_json_is_array(const jwt_json_t *json);
+int jwt_json_is_string(const jwt_json_t *json);
+int jwt_json_is_int(const jwt_json_t *json);
+int jwt_json_is_bool(const jwt_json_t *json);
+int jwt_json_is_true(const jwt_json_t *json);
+
+/* ================================================================
+ * Value extraction
+ * ================================================================ */
+
+const char *jwt_json_str_val(const jwt_json_t *json);
+jwt_json_int_t jwt_json_int_val(const jwt_json_t *json);
+
+/* ================================================================
+ * Deep copy
+ * ================================================================ */
+
+jwt_json_t *jwt_json_clone(const jwt_json_t *value);
+
+/* ================================================================
+ * Serialization / Parsing
+ * ================================================================ */
+
+char *jwt_json_serialize(const jwt_json_t *json, size_t flags);
+
+jwt_json_t *jwt_json_parse(const char *input, size_t flags,
+			   jwt_json_error_t *error);
+jwt_json_t *jwt_json_parse_buf(const char *buffer, size_t buflen,
+			       size_t flags, jwt_json_error_t *error);
+jwt_json_t *jwt_json_parse_file(const char *path, size_t flags,
+				jwt_json_error_t *error);
+jwt_json_t *jwt_json_parse_fp(FILE *input, size_t flags,
+			      jwt_json_error_t *error);
+
+#endif /* JWT_JSON_OPS_H */

--- a/libjwt/jwt-json-ops.h
+++ b/libjwt/jwt-json-ops.h
@@ -67,7 +67,6 @@ void jwt_json_set_alloc(void *(*alloc_func)(size_t),
 void jwt_json_releasep(jwt_json_t **json);
 #define jwt_json_auto_t jwt_json_t __attribute__((cleanup(jwt_json_releasep)))
 
-jwt_json_t *jwt_json_retain(jwt_json_t *json);
 void jwt_json_release(jwt_json_t *json);
 
 /* ================================================================
@@ -109,7 +108,6 @@ int jwt_json_arr_append(jwt_json_t *array, jwt_json_t *value);
  * Type checking
  * ================================================================ */
 
-int jwt_json_is_object(const jwt_json_t *json);
 int jwt_json_is_array(const jwt_json_t *json);
 int jwt_json_is_string(const jwt_json_t *json);
 int jwt_json_is_int(const jwt_json_t *json);

--- a/libjwt/jwt-memory.c
+++ b/libjwt/jwt-memory.c
@@ -31,8 +31,8 @@ int jwt_set_alloc(jwt_malloc_t pmalloc, jwt_free_t pfree)
 	pfn_malloc = pmalloc;
 	pfn_free = pfree;
 
-	/* Set same allocator functions for Jansson. */
-	json_set_alloc_funcs(jwt_malloc, __jwt_freemem);
+	/* Set same allocator functions for JSON backend. */
+	jwt_json_set_alloc(jwt_malloc, __jwt_freemem);
 
 	return 0;
 }

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -13,7 +13,7 @@
 #include "config.h"
 #endif
 
-#include <jansson.h>
+#include "jwt-json-ops.h"
 #include <time.h>
 #include <stdarg.h>
 
@@ -57,8 +57,8 @@ extern struct jwt_crypto_ops *jwt_ops;
 struct jwt_common {
 	jwt_alg_t alg;
 	const jwk_item_t *key;
-	json_t *payload;
-	json_t *headers;
+	jwt_json_t *payload;
+	jwt_json_t *headers;
 	jwt_claims_t claims;
 	jwt_callback_t cb;
 	void *cb_ctx;
@@ -86,8 +86,8 @@ struct jwt_checker {
 
 struct jwt {
 	const jwk_item_t *key;
-	json_t *claims;
-	json_t *headers;
+	jwt_json_t *claims;
+	jwt_json_t *headers;
 	jwt_alg_t alg;
 	int error;
 	char error_msg[JWT_ERR_LEN];
@@ -135,7 +135,7 @@ struct jwk_item {
 	jwk_key_op_t key_ops;	/**< @rfc{7517,4.3} Key operations supported		*/
 	jwt_alg_t alg;		/**< @rfc{7517,4.4} JWA Algorithm supported		*/
 	char *kid;		/**< @rfc{7517,4.5} Key ID				*/
-	json_t *json;		/**< The json_t for this key				*/
+	jwt_json_t *json;	/**< The jwt_json_t for this key			*/
 };
 
 /* Crypto operations */
@@ -156,9 +156,9 @@ struct jwt_crypto_ops {
 
 	/* Parsing a JWK to prepare it for use */
 	int jwk_implemented;
-	int (*process_eddsa)(json_t *jwk, jwk_item_t *item);
-	int (*process_rsa)(json_t *jwk, jwk_item_t *item);
-	int (*process_ec)(json_t *jwk, jwk_item_t *item);
+	int (*process_eddsa)(jwt_json_t *jwk, jwk_item_t *item);
+	int (*process_rsa)(jwt_json_t *jwk, jwk_item_t *item);
+	int (*process_ec)(jwt_json_t *jwk, jwk_item_t *item);
 	void (*process_item_free)(jwk_item_t *item);
 };
 
@@ -222,11 +222,11 @@ int jwt_sign(jwt_t *jwt, char **out, unsigned int *len, const char *str,
 	     unsigned int str_len);
 
 JWT_NO_EXPORT
-jwt_value_error_t __deleter(json_t *which, const char *field);
+jwt_value_error_t __deleter(jwt_json_t *which, const char *field);
 JWT_NO_EXPORT
-jwt_value_error_t __setter(json_t *which, jwt_value_t *value);
+jwt_value_error_t __setter(jwt_json_t *which, jwt_value_t *value);
 JWT_NO_EXPORT
-jwt_value_error_t __getter(json_t *which, jwt_value_t *value);
+jwt_value_error_t __getter(jwt_json_t *which, jwt_value_t *value);
 
 JWT_NO_EXPORT
 int jwt_parse(jwt_t *jwt, const char *token, unsigned int *len);

--- a/libjwt/jwt-verify.c
+++ b/libjwt/jwt-verify.c
@@ -14,9 +14,9 @@
 
 #include "jwt-private.h"
 
-static json_t *jwt_base64uri_decode_to_json(char *src)
+static jwt_json_t *jwt_base64uri_decode_to_json(char *src)
 {
-	json_t *js;
+	jwt_json_t *js;
 	char *buf;
 	int len;
 
@@ -27,7 +27,7 @@ static json_t *jwt_base64uri_decode_to_json(char *src)
 
 	buf[len] = '\0';
 
-	js = json_loads(buf, 0, NULL);
+	js = jwt_json_parse(buf, 0, NULL);
 
 	jwt_freemem(buf);
 
@@ -37,7 +37,7 @@ static json_t *jwt_base64uri_decode_to_json(char *src)
 static int jwt_parse_payload(jwt_t *jwt, char *payload)
 {
 	if (jwt->claims)
-		json_decrefp(&(jwt->claims));
+		jwt_json_releasep(&(jwt->claims));
 
 	jwt->claims = jwt_base64uri_decode_to_json(payload);
 	if (!jwt->claims) {
@@ -50,10 +50,10 @@ static int jwt_parse_payload(jwt_t *jwt, char *payload)
 
 static int jwt_parse_head(jwt_t *jwt, char *head)
 {
-	json_t *jalg;
+	jwt_json_t *jalg;
 
 	if (jwt->headers)
-		json_decrefp(&(jwt->headers));
+		jwt_json_releasep(&(jwt->headers));
 
 	jwt->headers = jwt_base64uri_decode_to_json(head);
 	if (!jwt->headers) {
@@ -63,9 +63,9 @@ static int jwt_parse_head(jwt_t *jwt, char *head)
 
 	jwt->alg = JWT_ALG_NONE;
 
-	jalg = json_object_get(jwt->headers, "alg");
-	if (jalg && json_is_string(jalg)) {
-		const char *alg = json_string_value(jalg);
+	jalg = jwt_json_obj_get(jwt->headers, "alg");
+	if (jalg && jwt_json_is_string(jalg)) {
+		const char *alg = jwt_json_str_val(jalg);
 
 		jwt->alg = jwt_str_alg(alg);
 

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -106,8 +106,8 @@ jwt_t *jwt_new(void)
 
 	memset(jwt, 0, sizeof(*jwt));
 
-	jwt->claims = json_object();
-	jwt->headers = json_object();
+	jwt->claims = jwt_json_create();
+	jwt->headers = jwt_json_create();
 
 	if (!jwt->claims || !jwt->headers)
 		jwt_freep(&jwt); // LCOV_EXCL_LINE
@@ -128,8 +128,8 @@ void jwt_free(jwt_t *jwt)
 	if (!jwt)
 		return;
 
-	json_decref(jwt->claims);
-	json_decref(jwt->headers);
+	jwt_json_release(jwt->claims);
+	jwt_json_release(jwt->headers);
 
 	memset(jwt, 0, sizeof(*jwt));
 

--- a/libjwt/mbedtls/jwk-parse.c
+++ b/libjwt/mbedtls/jwk-parse.c
@@ -13,21 +13,21 @@
 static const char not_implemented[] = "MBedTLS does not yet implement JWK";
 
 JWT_NO_EXPORT
-int mbedtls_process_eddsa(json_t *jwk, jwk_item_t *item)
+int mbedtls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item)
 {
 	jwt_write_error(item, not_implemented);
 	return -1;
 }
 
 JWT_NO_EXPORT
-int mbedtls_process_rsa(json_t *jwk, jwk_item_t *item)
+int mbedtls_process_rsa(jwt_json_t *jwk, jwk_item_t *item)
 {
 	jwt_write_error(item, not_implemented);
 	return -1;
 }
 
 JWT_NO_EXPORT
-int mbedtls_process_ec(json_t *jwk, jwk_item_t *item)
+int mbedtls_process_ec(jwt_json_t *jwk, jwk_item_t *item)
 {
 	jwt_write_error(item, not_implemented);
 	return -1;

--- a/libjwt/mbedtls/jwt-mbedtls.h
+++ b/libjwt/mbedtls/jwt-mbedtls.h
@@ -10,14 +10,14 @@
 #define JWT_MBEDTLS_H
 
 /* Until we have our own routines, we rely on OpenSSL */
-int openssl_process_eddsa(json_t *jwk, jwk_item_t *item);
-int openssl_process_rsa(json_t *jwk, jwk_item_t *item);
-int openssl_process_ec(json_t *jwk, jwk_item_t *item);
+int openssl_process_eddsa(jwt_json_t *jwk, jwk_item_t *item);
+int openssl_process_rsa(jwt_json_t *jwk, jwk_item_t *item);
+int openssl_process_ec(jwt_json_t *jwk, jwk_item_t *item);
 void openssl_process_item_free(jwk_item_t *item);
 
-int mbedtls_process_eddsa(json_t *jwk, jwk_item_t *item);
-int gmbedls_process_rsa(json_t *jwk, jwk_item_t *item);
-int mbedtls_process_ec(json_t *jwk, jwk_item_t *item);
+int mbedtls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item);
+int gmbedls_process_rsa(jwt_json_t *jwk, jwk_item_t *item);
+int mbedtls_process_ec(jwt_json_t *jwk, jwk_item_t *item);
 void mbedtls_process_item_free(jwk_item_t *item);
 
 #endif /* JWT_MBEDTLS_H */

--- a/libjwt/openssl/jwt-openssl.h
+++ b/libjwt/openssl/jwt-openssl.h
@@ -9,9 +9,9 @@
 #ifndef JWT_OPENSSL_H
 #define JWT_OPENSSL_H
 
-int openssl_process_eddsa(json_t *jwk, jwk_item_t *item);
-int openssl_process_rsa(json_t *jwk, jwk_item_t *item);
-int openssl_process_ec(json_t *jwk, jwk_item_t *item);
+int openssl_process_eddsa(jwt_json_t *jwk, jwk_item_t *item);
+int openssl_process_rsa(jwt_json_t *jwk, jwk_item_t *item);
+int openssl_process_ec(jwt_json_t *jwk, jwk_item_t *item);
 void openssl_process_item_free(jwk_item_t *item);
 
 #endif /* JWT_OPENSSL_H */

--- a/libjwt/wincrypt/sign-verify.c
+++ b/libjwt/wincrypt/sign-verify.c
@@ -958,9 +958,9 @@ jwt_verify_sha_pem_done:
 	return ret;
 }
 
-int wincrypt_process_eddsa(json_t *jwk, jwk_item_t *item);
-int wincrypt_process_rsa(json_t *jwk, jwk_item_t *item);
-int wincrypt_process_ec(json_t *jwk, jwk_item_t *item);
+int wincrypt_process_eddsa(jwt_json_t *jwk, jwk_item_t *item);
+int wincrypt_process_rsa(jwt_json_t *jwk, jwk_item_t *item);
+int wincrypt_process_ec(jwt_json_t *jwk, jwk_item_t *item);
 void wincrypt_process_item_free(jwk_item_t *item);
 
 /* Export our ops */

--- a/tools/key2jwk.c
+++ b/tools/key2jwk.c
@@ -493,7 +493,7 @@ int main(int argc, char **argv)
 	jwk_str = jwt_json_serialize(jwk_set, JWT_JSON_INDENT(2));
 	fprintf(outfp, "%s\n", jwk_str);
 
-	free(jwk_str);
+	jwt_freemem(jwk_str);
 
 	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Introduce a JSON abstraction layer (jwt-json-ops.h) with jwt_json_* API that decouples libjwt from any specific JSON library. Provide two backend implementations:

- libjwt/jansson/jwt-jansson.c: thin wrapper around jansson (default)
- libjwt/json-c/jwt-json-c.c: full json-c implementation

Select json-c at build time with: cmake -DWITH_JSON_C=ON

All library source files, crypto backends (openssl, gnutls, mbedtls, wincrypt) and tools are converted to the new abstraction.