### PR TITLE
Add RFC 7515 §4.1.11 "crit" header support (closes #157)

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -414,6 +414,28 @@ JWT_EXPORT
 void *jwt_builder_getctx(jwt_builder_t *builder);
 
 /**
+ * @brief Mark a header parameter as critical (@rfc{7515,4.1.11})
+ *
+ * Registers a header parameter name to be listed in the ``crit`` (Critical)
+ * header parameter of generated tokens. Use this when your application adds a
+ * custom (extension) header that a recipient MUST understand and process; per
+ * RFC 7515, a recipient that does not understand a listed parameter MUST reject
+ * the token.
+ *
+ * Call this once for each name. The named header parameter must be present in
+ * the header when the token is generated (typically set in your callback), and
+ * it must not be a Header Parameter name defined by RFC 7515 or JWA (such as
+ * ``alg`` or ``typ``); otherwise generation will fail. If no names are
+ * registered, no ``crit`` header is emitted.
+ *
+ * @param builder Pointer to a builder object
+ * @param header Name of the header parameter to mark as critical
+ * @return 0 on success, non-zero otherwise with error set in the builder
+ */
+JWT_EXPORT
+int jwt_builder_setcrit(jwt_builder_t *builder, const char *header);
+
+/**
  * @brief Generate a token
  *
  * The result of this function is to generate a string containing a JWT. A
@@ -622,6 +644,28 @@ int jwt_checker_setcb(jwt_checker_t *checker, jwt_callback_t cb, void *ctx);
  */
 JWT_EXPORT
 void *jwt_checker_getctx(jwt_checker_t *checker);
+
+/**
+ * @brief Declare a critical header parameter as understood (@rfc{7515,4.1.11})
+ *
+ * Per RFC 7515, if a token's ``crit`` (Critical) header parameter lists a
+ * header name, the recipient MUST understand and process that header or else
+ * reject the token. LibJWT understands no extension header parameters on its
+ * own, so by default any token carrying a ``crit`` header will fail
+ * verification.
+ *
+ * Use this function to declare each extension header parameter that your
+ * application is prepared to handle (typically inspected in your verify
+ * callback). During verification, every name listed in ``crit`` must both be
+ * present in the header and have been declared here; otherwise the token is
+ * rejected.
+ *
+ * @param checker Pointer to a checker object
+ * @param header Name of the critical header parameter the application understands
+ * @return 0 on success, non-zero otherwise with error set in the checker
+ */
+JWT_EXPORT
+int jwt_checker_understands(jwt_checker_t *checker, const char *header);
 
 /**
  * @brief Verify a token

--- a/libjwt/json-c/jwt-json-c.c
+++ b/libjwt/json-c/jwt-json-c.c
@@ -116,9 +116,22 @@ jwt_json_t *jwt_json_obj_get(const jwt_json_t *object, const char *key)
 
 int jwt_json_obj_set(jwt_json_t *object, const char *key, jwt_json_t *value)
 {
+	int ret;
+
 	if (!object || !key || !value)
 		return -1;
-	return json_object_object_add(to_jc(object), key, to_jc(value));
+
+	ret = json_object_object_add(to_jc(object), key, to_jc(value));
+
+	/* json_object_object_add only absorbs the reference on success.
+	 * Steal it on failure too so callers have a single ownership
+	 * contract (matching Jansson's json_object_set_new): obj_set always
+	 * consumes value. The failure path is an internal json-c allocation
+	 * failure, not reachable from input. */
+	if (ret)
+		json_object_put(to_jc(value)); // LCOV_EXCL_LINE
+
+	return ret;
 }
 
 int jwt_json_obj_del(jwt_json_t *object, const char *key)
@@ -196,15 +209,21 @@ int jwt_json_obj_merge_new(jwt_json_t *object, jwt_json_t *other)
 
 size_t jwt_json_arr_size(const jwt_json_t *array)
 {
-	if (!array)
+	/* json_object_array_length() asserts if not an array; guard it so
+	 * this matches Jansson's json_array_size() (returns 0 otherwise). */
+	if (!array || !json_object_is_type(to_jc(array), json_type_array))
 		return 0;
 	return json_object_array_length(to_jc(array));
 }
 
 jwt_json_t *jwt_json_arr_get(const jwt_json_t *array, size_t index)
 {
-	if (!array)
-		return NULL;
+	/* Guard the type as json_object_array_get_idx() also asserts on a
+	 * non-array. Callers reach this only via jwt_json_arr_foreach, which
+	 * first checks jwt_json_arr_size (0 for non-arrays), so this guard is
+	 * defensive and not hit by current callers. */
+	if (!array || !json_object_is_type(to_jc(array), json_type_array))
+		return NULL; // LCOV_EXCL_LINE
 	return from_jc(json_object_array_get_idx(to_jc(array), index));
 }
 

--- a/libjwt/jwt-common.c
+++ b/libjwt/jwt-common.c
@@ -34,6 +34,14 @@ void FUNC(free)(jwt_common_t *__cmd)
 	jwt_json_release(__cmd->c.payload);
 	jwt_json_release(__cmd->c.headers);
 
+	if (__cmd->c.understood) {
+		int i;
+
+		for (i = 0; __cmd->c.understood[i] != NULL; i++)
+			jwt_freemem(__cmd->c.understood[i]);
+		jwt_freemem(__cmd->c.understood);
+	}
+
 	memset(__cmd, 0, sizeof(*__cmd));
 
 	jwt_freemem(__cmd);
@@ -197,6 +205,73 @@ void *FUNC(getctx)(jwt_common_t *__cmd)
 		return NULL;
 
 	return __cmd->c.cb_ctx;
+}
+
+/* @rfc{7515,4.1.11} Register a "crit" (Critical) header parameter name.
+ *
+ * For the builder, this is a header the producer wants to mark as critical
+ * (emitted in the "crit" array at generation). For the checker, this is a
+ * critical header the application understands and is prepared to process.
+ *
+ * The names are kept in a NULL-terminated, dynamically grown list on the
+ * common object. Duplicate registrations are a no-op success.
+ */
+#ifdef JWT_BUILDER
+int FUNC(setcrit)(jwt_common_t *__cmd, const char *header)
+#endif
+#ifdef JWT_CHECKER
+int FUNC(understands)(jwt_common_t *__cmd, const char *header)
+#endif
+{
+	char **grown, *dup;
+	size_t count = 0, len;
+
+	if (__cmd == NULL)
+		return 1;
+
+	if (header == NULL || !strlen(header)) {
+		jwt_write_error(__cmd, "Must pass a header name");
+		return 1;
+	}
+
+	/* Count existing entries and skip duplicates. */
+	if (__cmd->c.understood) {
+		for (count = 0; __cmd->c.understood[count] != NULL; count++) {
+			if (!strcmp(__cmd->c.understood[count], header))
+				return 0;
+		}
+	}
+
+	/* Grow the list by one (plus the NULL terminator). */
+	grown = jwt_malloc((count + 2) * sizeof(char *));
+	if (grown == NULL) {
+		// LCOV_EXCL_START
+		jwt_write_error(__cmd, "Error allocating memory");
+		return 1;
+		// LCOV_EXCL_STOP
+	}
+
+	len = strlen(header) + 1;
+	dup = jwt_malloc(len);
+	if (dup == NULL) {
+		// LCOV_EXCL_START
+		jwt_freemem(grown);
+		jwt_write_error(__cmd, "Error allocating memory");
+		return 1;
+		// LCOV_EXCL_STOP
+	}
+	memcpy(dup, header, len);
+
+	if (__cmd->c.understood) {
+		memcpy(grown, __cmd->c.understood, count * sizeof(char *));
+		jwt_freemem(__cmd->c.understood);
+	}
+
+	grown[count] = dup;
+	grown[count + 1] = NULL;
+	__cmd->c.understood = grown;
+
+	return 0;
 }
 
 typedef enum {
@@ -413,6 +488,14 @@ int FUNC(verify)(jwt_common_t *__cmd, const char *token)
 		return 1;
 	}
 
+	/* @rfc{7515,4.1.11} Enforce the "crit" header. Done after the
+	 * callback so the application has a chance to inspect the header,
+	 * but before any signature work. */
+	if (jwt_check_crit(jwt, __cmd->c.understood)) {
+		jwt_copy_error(__cmd, jwt);
+		return 1;
+	}
+
 	/* Callback may have changed this */
         if (__setkey_check(__cmd, config.alg, config.key))
 		return 1;
@@ -491,6 +574,13 @@ char *FUNC(generate)(jwt_common_t *__cmd)
 
 	jwt->alg = config.alg;
 	jwt->key = config.key;
+
+	/* @rfc{7515,4.1.11} Emit the "crit" header if any were registered.
+	 * Done after the callback so it can add the headers being marked. */
+	if (jwt_write_crit(jwt, __cmd->c.understood)) {
+		jwt_copy_error(__cmd, jwt);
+		return NULL;
+	}
 
 	if (jwt_head_setup(jwt))
 		return NULL; // LCOV_EXCL_LINE

--- a/libjwt/jwt-encode.c
+++ b/libjwt/jwt-encode.c
@@ -21,6 +21,159 @@ static int write_js(const jwt_json_t *js, char **buf)
 	return *buf == NULL ? 1 : 0;
 }
 
+/* @rfc{7515,4.1.11} Header Parameter names defined by RFC 7515 (the JWS
+ * Protected Header) and JWA (RFC 7518). A producer MUST NOT list any of
+ * these in the "crit" header. The JWA names are JWE-related and not yet
+ * used by LibJWT, but are banned here for forward compatibility. */
+static const char * const jwt_registered_headers[] = {
+	/* RFC 7515 4.1 */
+	"alg", "jku", "jwk", "kid", "x5u", "x5c", "x5t", "x5t#S256",
+	"typ", "cty", "crit",
+	/* RFC 7518 (JWA) */
+	"enc", "zip", "epk", "apu", "apv", "iv", "tag", "p2s", "p2c",
+};
+
+static int jwt_crit_is_registered(const char *name)
+{
+	size_t j;
+
+	for (j = 0; j < ARRAY_SIZE(jwt_registered_headers); j++) {
+		if (!strcmp(jwt_registered_headers[j], name))
+			return 1;
+	}
+
+	return 0;
+}
+
+/* @rfc{7515,4.1.11} Validate the "crit" value now present in the header,
+ * regardless of how it got there (jwt_builder_setcrit() or set directly by
+ * the application). It must be a non-empty array of unique strings, each
+ * naming a header parameter that is present in the header and is not a
+ * Header Parameter name defined by RFC 7515 or JWA. */
+static int jwt_validate_crit(jwt_t *jwt, jwt_json_t *crit)
+{
+	jwt_json_t *ent;
+	size_t i;
+
+	if (!jwt_json_is_array(crit)) {
+		jwt_write_error(jwt, "\"crit\" header must be an array");
+		return 1;
+	}
+
+	if (jwt_json_arr_size(crit) == 0) {
+		jwt_write_error(jwt, "\"crit\" header must not be empty");
+		return 1;
+	}
+
+	jwt_json_arr_foreach(crit, i, ent) {
+		const char *name;
+		size_t k;
+
+		if (!jwt_json_is_string(ent)) {
+			jwt_write_error(jwt,
+				"\"crit\" header entries must be strings");
+			return 1;
+		}
+
+		name = jwt_json_str_val(ent);
+
+		if (jwt_crit_is_registered(name)) {
+			jwt_write_error(jwt,
+				"\"crit\" cannot list registered header \"%s\"",
+				name);
+			return 1;
+		}
+
+		if (jwt_json_obj_get(jwt->headers, name) == NULL) {
+			jwt_write_error(jwt,
+				"\"crit\" lists \"%s\" which is not in the header",
+				name);
+			return 1;
+		}
+
+		/* Names must not be duplicated. */
+		for (k = 0; k < i; k++) {
+			jwt_json_t *prev = jwt_json_arr_get(crit, k);
+
+			if (!strcmp(jwt_json_str_val(prev), name)) {
+				jwt_write_error(jwt,
+					"\"crit\" lists \"%s\" more than once",
+					name);
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+/* @rfc{7515,4.1.11} Emit and/or validate the "crit" (Critical) header.
+ *
+ * @crit is a NULL-terminated list of header parameter names the producer
+ * registered via jwt_builder_setcrit(); it may be NULL. Any registered name
+ * is appended to the header's "crit" array (created if needed). Regardless
+ * of whether anything was registered, if the header ends up with a "crit"
+ * value (e.g. the application set one directly) it is fully validated so a
+ * non-conforming "crit" is never emitted.
+ */
+int jwt_write_crit(jwt_t *jwt, char * const *crit)
+{
+	jwt_json_t *arr;
+	size_t i;
+
+	arr = jwt_json_obj_get(jwt->headers, "crit");
+
+	/* If the producer registered names, fold them into the header's
+	 * "crit" array (creating it if the application didn't set one). */
+	if (crit && crit[0]) {
+		if (arr == NULL) {
+			arr = jwt_json_create_arr();
+			if (arr == NULL) {
+				// LCOV_EXCL_START
+				jwt_write_error(jwt,
+					"Error allocating \"crit\" array");
+				return 1;
+				// LCOV_EXCL_STOP
+			}
+			/* obj_set steals the reference to arr (on success and,
+			 * per the backend contract, on failure too — so we do
+			 * not release it here, matching the rest of LibJWT). */
+			if (jwt_json_obj_set(jwt->headers, "crit", arr)) {
+				// LCOV_EXCL_START
+				jwt_write_error(jwt,
+					"Error setting \"crit\" in header");
+				return 1;
+				// LCOV_EXCL_STOP
+			}
+		} else if (!jwt_json_is_array(arr)) {
+			/* App set a non-array "crit"; can't append to it.
+			 * Let validation below report the error. */
+			return jwt_validate_crit(jwt, arr);
+		}
+
+		for (i = 0; crit[i] != NULL; i++) {
+			jwt_json_t *str = jwt_json_create_str(crit[i]);
+
+			if (str == NULL) {
+				// LCOV_EXCL_START
+				jwt_write_error(jwt,
+					"Error allocating \"crit\" entry");
+				return 1;
+				// LCOV_EXCL_STOP
+			}
+
+			/* Append steals the reference to str. */
+			jwt_json_arr_append(arr, str);
+		}
+	}
+
+	/* Nothing registered and the app set no "crit": nothing to do. */
+	if (arr == NULL)
+		return 0;
+
+	return jwt_validate_crit(jwt, arr);
+}
+
 int jwt_head_setup(jwt_t *jwt)
 {
 	jwt_value_t jval;

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -66,6 +66,10 @@ struct jwt_common {
 	jwt_callback_t cb;
 	void *cb_ctx;
 
+	/* NULL-terminated list of "crit" header parameter names that the
+	 * application understands. Only used by the checker. */
+	char **understood;
+
 	/* For builder, this is offset into the future.
 	 * For checker, this is the leeway.
 	 * Both are in seconds. */
@@ -241,6 +245,10 @@ jwt_value_error_t __getter(jwt_json_t *which, jwt_value_t *value);
 
 JWT_NO_EXPORT
 int jwt_parse(jwt_t *jwt, const char *token, unsigned int *len);
+JWT_NO_EXPORT
+int jwt_check_crit(jwt_t *jwt, char * const *understood);
+JWT_NO_EXPORT
+int jwt_write_crit(jwt_t *jwt, char * const *crit);
 JWT_NO_EXPORT
 jwt_t *jwt_verify_complete(jwt_t *jwt, const jwt_config_t *config,
 			   const char *token, unsigned int payload_len);

--- a/libjwt/jwt-verify.c
+++ b/libjwt/jwt-verify.c
@@ -82,6 +82,77 @@ static int jwt_parse_head(jwt_t *jwt, char *head)
 	return 1;
 }
 
+/* @rfc{7515,4.1.11} Process the "crit" (Critical) header parameter.
+ *
+ * If present, "crit" must be a non-empty array of strings. Each string
+ * names a header parameter that must (a) actually be present in the header
+ * and (b) be understood by the recipient. LibJWT understands no extension
+ * header parameters on its own, so the application must declare the ones it
+ * handles via jwt_checker_understands() (passed in as @understood, a
+ * NULL-terminated list which may itself be NULL). Any listed parameter not
+ * in that list makes the JWS invalid.
+ */
+int jwt_check_crit(jwt_t *jwt, char * const *understood)
+{
+	jwt_json_t *crit, *ent;
+	size_t i;
+
+	crit = jwt_json_obj_get(jwt->headers, "crit");
+	if (crit == NULL)
+		return 0;
+
+	if (!jwt_json_is_array(crit)) {
+		jwt_write_error(jwt, "\"crit\" header must be an array");
+		return 1;
+	}
+
+	if (jwt_json_arr_size(crit) == 0) {
+		jwt_write_error(jwt, "\"crit\" header must not be empty");
+		return 1;
+	}
+
+	jwt_json_arr_foreach(crit, i, ent) {
+		const char *name;
+		int found = 0;
+
+		if (!jwt_json_is_string(ent)) {
+			jwt_write_error(jwt,
+				"\"crit\" header entries must be strings");
+			return 1;
+		}
+
+		name = jwt_json_str_val(ent);
+
+		/* Must actually appear in the header. */
+		if (jwt_json_obj_get(jwt->headers, name) == NULL) {
+			jwt_write_error(jwt,
+				"\"crit\" lists \"%s\" which is not in the header",
+				name);
+			return 1;
+		}
+
+		/* Must be understood by the application. */
+		if (understood) {
+			size_t j;
+
+			for (j = 0; understood[j] != NULL; j++) {
+				if (!strcmp(understood[j], name)) {
+					found = 1;
+					break;
+				}
+			}
+		}
+
+		if (!found) {
+			jwt_write_error(jwt,
+				"Unsupported critical header: \"%s\"", name);
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
 int jwt_parse(jwt_t *jwt, const char *token, unsigned int *len)
 {
 	char_auto *head = NULL;

--- a/tests/jwt_builder.c
+++ b/tests/jwt_builder.c
@@ -846,6 +846,387 @@ START_TEST(sign_es256_bad_sig)
 }
 END_TEST
 
+/* @rfc{7515,4.1.11} "crit" header emission on the builder side. */
+
+START_TEST(crit_gen)
+{
+	/* {"alg":"none","crit":["foo"],"foo":"bar"} . {} . */
+	const char exp[] =
+		"eyJhbGciOiJub25lIiwiY3JpdCI6WyJmb28iXSwiZm9vIjoiYmFyIn0.e30.";
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+	jwt_value_t jval;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	ret = jwt_builder_enable_iat(builder, 0);
+	ck_assert_int_eq(ret, 1);
+
+	jwt_set_SET_STR(&jval, "foo", "bar");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_builder_setcrit(builder, "foo");
+	ck_assert_int_eq(ret, 0);
+	/* Duplicate registration is a no-op success. */
+	ret = jwt_builder_setcrit(builder, "foo");
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_nonnull(out);
+	ck_assert_str_eq(out, exp);
+}
+END_TEST
+
+START_TEST(crit_gen_two)
+{
+	/* {"alg":"none","baz":2,"crit":["foo","baz"],"foo":"bar"} . {} . */
+	const char exp[] = "eyJhbGciOiJub25lIiwiYmF6IjoyLCJjcml0IjpbImZvbyIsImJh"
+		"eiJdLCJmb28iOiJiYXIifQ.e30.";
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+	jwt_value_t jval;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	ret = jwt_builder_enable_iat(builder, 0);
+	ck_assert_int_eq(ret, 1);
+
+	jwt_set_SET_STR(&jval, "foo", "bar");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+	jwt_set_SET_INT(&jval, "baz", 2);
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+
+	/* Array preserves registration order; object keys are sorted. */
+	ret = jwt_builder_setcrit(builder, "foo");
+	ck_assert_int_eq(ret, 0);
+	ret = jwt_builder_setcrit(builder, "baz");
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_nonnull(out);
+	ck_assert_str_eq(out, exp);
+}
+END_TEST
+
+START_TEST(crit_gen_not_in_header)
+{
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	/* Mark "foo" critical but never add it to the header. */
+	ret = jwt_builder_setcrit(builder, "foo");
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_null(out);
+	ck_assert_str_eq(jwt_builder_error_msg(builder),
+			"\"crit\" lists \"foo\" which is not in the header");
+}
+END_TEST
+
+START_TEST(crit_gen_registered)
+{
+	/* Every RFC 7515 and JWA (RFC 7518) header name must be rejected. */
+	static const char * const names[] = {
+		"alg", "jku", "jwk", "kid", "x5u", "x5c", "x5t", "x5t#S256",
+		"typ", "cty", "crit",
+		"enc", "zip", "epk", "apu", "apv", "iv", "tag", "p2s", "p2c",
+	};
+	size_t n;
+
+	SET_OPS();
+
+	for (n = 0; n < sizeof(names) / sizeof(names[0]); n++) {
+		jwt_builder_auto_t *builder = NULL;
+		char_auto *out = NULL;
+		char expmsg[128];
+		int ret;
+
+		builder = jwt_builder_new();
+		ck_assert_ptr_nonnull(builder);
+		ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+		ret = jwt_builder_setcrit(builder, names[n]);
+		ck_assert_int_eq(ret, 0);
+
+		out = jwt_builder_generate(builder);
+		ck_assert_ptr_null(out);
+
+		snprintf(expmsg, sizeof(expmsg),
+			"\"crit\" cannot list registered header \"%s\"",
+			names[n]);
+		ck_assert_str_eq(jwt_builder_error_msg(builder), expmsg);
+	}
+}
+END_TEST
+
+START_TEST(crit_gen_none)
+{
+	/* No crit registered -> no "crit" header, baseline output. */
+	const char exp[] = "eyJhbGciOiJub25lIn0.";
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_nonnull(out);
+	ck_assert_mem_eq(out, exp, strlen(exp));
+}
+END_TEST
+
+START_TEST(crit_gen_dup)
+{
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+	jwt_value_t jval;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	/* App sets a "crit" array with a duplicate name directly. */
+	jwt_set_SET_JSON(&jval, "crit", "[\"foo\",\"foo\"]");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+	jwt_set_SET_STR(&jval, "foo", "bar");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_null(out);
+	ck_assert_str_eq(jwt_builder_error_msg(builder),
+			"\"crit\" lists \"foo\" more than once");
+}
+END_TEST
+
+/* An application can set "crit" directly in the header (bypassing
+ * jwt_builder_setcrit). It must still be validated, never emitted as-is. */
+
+START_TEST(crit_appset_valid)
+{
+	/* {"alg":"none","crit":["foo"],"foo":"bar"} . {} . */
+	const char exp[] =
+		"eyJhbGciOiJub25lIiwiY3JpdCI6WyJmb28iXSwiZm9vIjoiYmFyIn0.e30.";
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+	jwt_value_t jval;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	ret = jwt_builder_enable_iat(builder, 0);
+	ck_assert_int_eq(ret, 1);
+
+	jwt_set_SET_JSON(&jval, "crit", "[\"foo\"]");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+	jwt_set_SET_STR(&jval, "foo", "bar");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_nonnull(out);
+	ck_assert_str_eq(out, exp);
+}
+END_TEST
+
+START_TEST(crit_appset_not_array)
+{
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+	jwt_value_t jval;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	jwt_set_SET_STR(&jval, "crit", "foo");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_null(out);
+	ck_assert_str_eq(jwt_builder_error_msg(builder),
+			"\"crit\" header must be an array");
+}
+END_TEST
+
+START_TEST(crit_appset_not_array_setcrit)
+{
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+	jwt_value_t jval;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	/* App sets a non-array "crit" AND also registers a name; the
+	 * non-array value cannot be appended to and is reported. */
+	jwt_set_SET_STR(&jval, "crit", "foo");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_builder_setcrit(builder, "foo");
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_null(out);
+	ck_assert_str_eq(jwt_builder_error_msg(builder),
+			"\"crit\" header must be an array");
+}
+END_TEST
+
+START_TEST(crit_appset_empty)
+{
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+	jwt_value_t jval;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	jwt_set_SET_JSON(&jval, "crit", "[]");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_null(out);
+	ck_assert_str_eq(jwt_builder_error_msg(builder),
+			"\"crit\" header must not be empty");
+}
+END_TEST
+
+START_TEST(crit_appset_non_string)
+{
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+	jwt_value_t jval;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	jwt_set_SET_JSON(&jval, "crit", "[123]");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_null(out);
+	ck_assert_str_eq(jwt_builder_error_msg(builder),
+			"\"crit\" header entries must be strings");
+}
+END_TEST
+
+START_TEST(crit_merge)
+{
+	/* App-set "crit":["foo"] merges with setcrit("baz"). Array keeps the
+	 * app entry first then the registered one: ["foo","baz"]. */
+	const char exp[] = "eyJhbGciOiJub25lIiwiYmF6IjoyLCJjcml0IjpbImZvbyIsImJh"
+		"eiJdLCJmb28iOiJiYXIifQ.e30.";
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *out = NULL;
+	jwt_value_t jval;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwt_builder_error(builder), 0);
+
+	ret = jwt_builder_enable_iat(builder, 0);
+	ck_assert_int_eq(ret, 1);
+
+	jwt_set_SET_JSON(&jval, "crit", "[\"foo\"]");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+	jwt_set_SET_STR(&jval, "foo", "bar");
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+	jwt_set_SET_INT(&jval, "baz", 2);
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_builder_setcrit(builder, "baz");
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_nonnull(out);
+	ck_assert_str_eq(out, exp);
+}
+END_TEST
+
+START_TEST(crit_setcrit_null)
+{
+	jwt_builder_auto_t *builder = NULL;
+	int ret;
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	ret = jwt_builder_setcrit(NULL, "foo");
+	ck_assert_int_ne(ret, 0);
+
+	ret = jwt_builder_setcrit(builder, NULL);
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_builder_error_msg(builder),
+			"Must pass a header name");
+
+	jwt_builder_error_clear(builder);
+
+	ret = jwt_builder_setcrit(builder, "");
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_builder_error_msg(builder),
+			"Must pass a header name");
+}
+END_TEST
+
 static Suite *libjwt_suite(const char *title)
 {
 	Suite *s;
@@ -895,6 +1276,23 @@ static Suite *libjwt_suite(const char *title)
 	/* All of the code paths for str/int/bool/json have been covered. We
 	 * just run this to ensure set/get/del works on headers */
 	tcase_add_loop_test(tc_core, header_str_setgetdel, 0, i);
+	tcase_set_timeout(tc_core, 60);
+	suite_add_tcase(s, tc_core);
+
+	tc_core = tcase_create("Crit Header");
+	tcase_add_loop_test(tc_core, crit_gen, 0, i);
+	tcase_add_loop_test(tc_core, crit_gen_two, 0, i);
+	tcase_add_loop_test(tc_core, crit_gen_not_in_header, 0, i);
+	tcase_add_loop_test(tc_core, crit_gen_registered, 0, i);
+	tcase_add_loop_test(tc_core, crit_gen_none, 0, i);
+	tcase_add_loop_test(tc_core, crit_gen_dup, 0, i);
+	tcase_add_loop_test(tc_core, crit_appset_valid, 0, i);
+	tcase_add_loop_test(tc_core, crit_appset_not_array, 0, i);
+	tcase_add_loop_test(tc_core, crit_appset_not_array_setcrit, 0, i);
+	tcase_add_loop_test(tc_core, crit_appset_empty, 0, i);
+	tcase_add_loop_test(tc_core, crit_appset_non_string, 0, i);
+	tcase_add_loop_test(tc_core, crit_merge, 0, i);
+	tcase_add_loop_test(tc_core, crit_setcrit_null, 0, i);
 	tcase_set_timeout(tc_core, 60);
 	suite_add_tcase(s, tc_core);
 

--- a/tests/jwt_checker.c
+++ b/tests/jwt_checker.c
@@ -899,6 +899,314 @@ START_TEST(verify_es256_bad_sig)
 }
 END_TEST
 
+/* @rfc{7515,4.1.11} "crit" header handling on the checker side. */
+
+/* {"alg":"none","crit":["exp1"],"exp1":true} . {} . */
+#define CRIT_TOKEN_PRESENT \
+	"eyJhbGciOiJub25lIiwiY3JpdCI6WyJleHAxIl0sImV4cDEiOnRydWV9.e30."
+
+START_TEST(crit_unsupported)
+{
+	const char token[] = CRIT_TOKEN_PRESENT;
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwt_checker_error(checker), 0);
+
+	/* "exp1" is present in the header but not declared understood. */
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_checker_error_msg(checker),
+			"Unsupported critical header: \"exp1\"");
+}
+END_TEST
+
+START_TEST(crit_not_in_header)
+{
+	/* {"alg":"none","crit":["exp1"]} . {"iss":"disk.swissdisk.com"} . */
+	const char token[] = "eyJhbGciOiJub25lIiwiY3JpdCI6WyJleHAxIl19."
+		"eyJpc3MiOiJkaXNrLnN3aXNzZGlzay5jb20ifQ.";
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwt_checker_error(checker), 0);
+
+	/* We understand "exp1", but it's listed without being in the header.
+	 * The "present in header" check fires before the "understood" check. */
+	ret = jwt_checker_understands(checker, "exp1");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_checker_error_msg(checker),
+			"\"crit\" lists \"exp1\" which is not in the header");
+}
+END_TEST
+
+START_TEST(crit_understood)
+{
+	/* {"alg":"none","crit":["exp1"],"exp1":true} . {} . */
+	const char token[] =
+		"eyJhbGciOiJub25lIiwiY3JpdCI6WyJleHAxIl0sImV4cDEiOnRydWV9.e30.";
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwt_checker_error(checker), 0);
+
+	/* Declaring it understood and present in the header -> passes. */
+	ret = jwt_checker_understands(checker, "exp1");
+	ck_assert_int_eq(ret, 0);
+	/* Duplicate registration is a no-op success. */
+	ret = jwt_checker_understands(checker, "exp1");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_eq(ret, 0);
+}
+END_TEST
+
+START_TEST(crit_empty)
+{
+	/* {"alg":"none","crit":[]} . {} . */
+	const char token[] = "eyJhbGciOiJub25lIiwiY3JpdCI6W119.e30.";
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwt_checker_error(checker), 0);
+
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_checker_error_msg(checker),
+			"\"crit\" header must not be empty");
+}
+END_TEST
+
+START_TEST(crit_not_array)
+{
+	/* {"alg":"none","crit":"exp1"} . {} . */
+	const char token[] = "eyJhbGciOiJub25lIiwiY3JpdCI6ImV4cDEifQ.e30.";
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwt_checker_error(checker), 0);
+
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_checker_error_msg(checker),
+			"\"crit\" header must be an array");
+}
+END_TEST
+
+START_TEST(crit_non_string_entry)
+{
+	/* {"alg":"none","crit":[123]} . {} . */
+	const char token[] = "eyJhbGciOiJub25lIiwiY3JpdCI6WzEyM119.e30.";
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwt_checker_error(checker), 0);
+
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_checker_error_msg(checker),
+			"\"crit\" header entries must be strings");
+}
+END_TEST
+
+START_TEST(crit_absent)
+{
+	/* No "crit" header is the baseline and must still verify. */
+	const char token[] = "eyJhbGciOiJub25lIn0.eyJpc3MiOiJka"
+		"XNrLnN3aXNzZGlzay5jb20ifQ.";
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwt_checker_error(checker), 0);
+
+	/* Declaring understood names is harmless when no "crit" is present. */
+	ret = jwt_checker_understands(checker, "exp1");
+	ck_assert_int_eq(ret, 0);
+	ret = jwt_checker_understands(checker, "exp2");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_eq(ret, 0);
+}
+END_TEST
+
+START_TEST(crit_understands_null)
+{
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+
+	ret = jwt_checker_understands(NULL, "exp1");
+	ck_assert_int_ne(ret, 0);
+
+	ret = jwt_checker_understands(checker, NULL);
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_checker_error_msg(checker),
+			"Must pass a header name");
+
+	jwt_checker_error_clear(checker);
+
+	ret = jwt_checker_understands(checker, "");
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_checker_error_msg(checker),
+			"Must pass a header name");
+}
+END_TEST
+
+START_TEST(crit_roundtrip)
+{
+	jwt_builder_auto_t *builder = NULL;
+	jwt_checker_auto_t *checker = NULL;
+	char_auto *out = NULL;
+	jwt_value_t jval;
+	int ret;
+
+	SET_OPS();
+
+	/* Build a token that marks a custom header "exp1" as critical. */
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	ret = jwt_builder_enable_iat(builder, 0);
+	ck_assert_int_eq(ret, 1);
+
+	jwt_set_SET_BOOL(&jval, "exp1", 1);
+	ret = jwt_builder_header_set(builder, &jval);
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_builder_setcrit(builder, "exp1");
+	ck_assert_int_eq(ret, 0);
+
+	out = jwt_builder_generate(builder);
+	ck_assert_ptr_nonnull(out);
+
+	/* A checker that does NOT understand "exp1" must reject it. */
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ret = jwt_checker_verify(checker, out);
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_checker_error_msg(checker),
+			"Unsupported critical header: \"exp1\"");
+
+	/* Once it declares "exp1" understood, the same token verifies. */
+	jwt_checker_error_clear(checker);
+	ret = jwt_checker_understands(checker, "exp1");
+	ck_assert_int_eq(ret, 0);
+	ret = jwt_checker_verify(checker, out);
+	ck_assert_int_eq(ret, 0);
+}
+END_TEST
+
+/* {"alg":"none","crit":["exp1","exp2"],"exp1":true,"exp2":true} . {} . */
+#define CRIT_TOKEN_TWO \
+	"eyJhbGciOiJub25lIiwiY3JpdCI6WyJleHAxIiwiZXhwMiJdLCJleHAxIjp0cnVlLCJ" \
+	"leHAyIjp0cnVlfQ.e30."
+
+START_TEST(crit_second_unsupported)
+{
+	const char token[] = CRIT_TOKEN_TWO;
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwt_checker_error(checker), 0);
+
+	/* First entry understood, second is not: the loop must advance to
+	 * the second entry and reject it. */
+	ret = jwt_checker_understands(checker, "exp1");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_checker_error_msg(checker),
+			"Unsupported critical header: \"exp2\"");
+}
+END_TEST
+
+START_TEST(crit_both_understood)
+{
+	const char token[] = CRIT_TOKEN_TWO;
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwt_checker_error(checker), 0);
+
+	/* Both entries understood and present: full iteration succeeds. */
+	ret = jwt_checker_understands(checker, "exp1");
+	ck_assert_int_eq(ret, 0);
+	ret = jwt_checker_understands(checker, "exp2");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_eq(ret, 0);
+}
+END_TEST
+
+START_TEST(crit_understood_no_match)
+{
+	const char token[] = CRIT_TOKEN_PRESENT;
+	jwt_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwt_checker_error(checker), 0);
+
+	/* A populated understood list that does NOT contain the listed crit
+	 * name: the inner match loop must run to completion and reject. */
+	ret = jwt_checker_understands(checker, "other");
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_ne(ret, 0);
+	ck_assert_str_eq(jwt_checker_error_msg(checker),
+			"Unsupported critical header: \"exp1\"");
+}
+END_TEST
+
 static Suite *libjwt_suite(const char *title)
 {
 	Suite *s;
@@ -953,6 +1261,21 @@ static Suite *libjwt_suite(const char *title)
 	tcase_add_loop_test(tc_core, verify_ps256_bad_b64_sig_255, 0, i);
 	tcase_add_loop_test(tc_core, verify_ps256_bad_sig, 0, i);
 	tcase_add_loop_test(tc_core, verify_es256_bad_sig, 0, i);
+	suite_add_tcase(s, tc_core);
+
+	tc_core = tcase_create("Crit Header");
+	tcase_add_loop_test(tc_core, crit_unsupported, 0, i);
+	tcase_add_loop_test(tc_core, crit_not_in_header, 0, i);
+	tcase_add_loop_test(tc_core, crit_understood, 0, i);
+	tcase_add_loop_test(tc_core, crit_empty, 0, i);
+	tcase_add_loop_test(tc_core, crit_not_array, 0, i);
+	tcase_add_loop_test(tc_core, crit_non_string_entry, 0, i);
+	tcase_add_loop_test(tc_core, crit_absent, 0, i);
+	tcase_add_loop_test(tc_core, crit_understands_null, 0, i);
+	tcase_add_loop_test(tc_core, crit_roundtrip, 0, i);
+	tcase_add_loop_test(tc_core, crit_second_unsupported, 0, i);
+	tcase_add_loop_test(tc_core, crit_both_understood, 0, i);
+	tcase_add_loop_test(tc_core, crit_understood_no_match, 0, i);
 	suite_add_tcase(s, tc_core);
 
 	return s;


### PR DESCRIPTION
Implements the JOSE `crit` (Critical) header parameter (RFC 7515 §4.1.11) on **both** the checker and builder sides. Closes #157.

## Checker — verifying tokens
- New API: `int jwt_checker_understands(jwt_checker_t *, const char *header)` — declare an extension header the application is prepared to process.
- `jwt_checker_verify()` now enforces `crit`: it must be a non-empty array of strings, each naming a header that is present in the JOSE header **and** declared understood. LibJWT understands no extension headers natively, so a token carrying `crit` is rejected unless the app opts in via `jwt_checker_understands()`.

## Builder — generating tokens
- New API: `int jwt_builder_setcrit(jwt_builder_t *, const char *header)` — mark a header critical; the names are emitted in the `crit` array.
- The emitted `crit` is **always validated regardless of how it was populated** (via `setcrit`, `jwt_builder_header_set`, or a callback): non-empty array of unique strings, each present in the header, and none a Header Parameter name defined by RFC 7515 or JWA (RFC 7518). A producer can never emit a non-conforming `crit`.

## json-c backend hardening
- `jwt_json_arr_size()` / `jwt_json_arr_get()` now type-check before calling json-c's `json_object_array_length()` / `_get_idx()`, which **assert (abort)** on a non-array (Jansson returns 0/NULL). This also fixes a **pre-existing abort** in JWKS parsing when `"keys"` is not an array — surfaced by `tests/jwt_security.c::test_jwks_keys_not_array`, which aborted under `WITH_JSON_C=ON` before this change.
- `jwt_json_obj_set()` now releases the value on failure too, giving callers a single steal-always ownership contract matching Jansson's `json_object_set_new`.

## Testing
- New tests in `tests/jwt_builder.c` and `tests/jwt_checker.c` cover every non-defensive branch (structure errors, not-in-header, unsupported, duplicates, registered/JWA names, app-set `crit`, merge, multi-entry, build→verify round-trip, NULL/empty API args with exact messages).
- Verified with **both** JSON backends: Jansson and json-c — **12/12 suites pass, warning-free** (`-Wall -Werror -Wextra`), **valgrind clean** (0 errors / 0 leaks) on the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)