### PR TITLE
jwe: foundation — types, jwe_common, and crypto-ops table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,11 +95,27 @@ add_custom_command(
 		-o jwt-checker.i
 	DEPENDS libjwt/jwt-common.c)
 
+add_custom_command(
+	OUTPUT jwe-builder.i
+	COMMAND bash -c "${CMAKE_C_COMPILER} -E -DJWE_BUILDER ${CMAKE_SOURCE_DIR}/libjwt/jwe-common.c -o jwe-builder.i ${CMAKE_C_FLAGS}"
+		-o jwe-builder.i
+	DEPENDS libjwt/jwe-common.c)
+
+add_custom_command(
+	OUTPUT jwe-checker.i
+	COMMAND bash -c "${CMAKE_C_COMPILER} -E -DJWE_CHECKER ${CMAKE_SOURCE_DIR}/libjwt/jwe-common.c -o jwe-checker.i ${CMAKE_C_FLAGS}"
+		-o jwe-checker.i
+	DEPENDS libjwt/jwe-common.c)
+
 add_custom_target(gen_jwt_builder ALL DEPENDS jwt-builder.i)
 add_custom_target(gen_jwt_checker ALL DEPENDS jwt-checker.i)
+add_custom_target(gen_jwe_builder ALL DEPENDS jwe-builder.i)
+add_custom_target(gen_jwe_checker ALL DEPENDS jwe-checker.i)
 
-add_dependencies(jwt        gen_jwt_builder gen_jwt_checker)
-add_dependencies(jwt_static gen_jwt_builder gen_jwt_checker)
+add_dependencies(jwt        gen_jwt_builder gen_jwt_checker
+                            gen_jwe_builder gen_jwe_checker)
+add_dependencies(jwt_static gen_jwt_builder gen_jwt_checker
+                            gen_jwe_builder gen_jwe_checker)
 
 set(JWT_SOURCES libjwt/jwt-memory.c
 	libjwt/jwt.c
@@ -110,6 +126,9 @@ set(JWT_SOURCES libjwt/jwt-memory.c
 	libjwt/jwt-verify.c
 	libjwt/jwt-builder.c
 	libjwt/jwt-checker.c
+	libjwt/jwe-setget.c
+	libjwt/jwe-builder.c
+	libjwt/jwe-checker.c
 	libjwt/jwks-curl.c)
 
 # Allow building without deprecated functions (suggested)
@@ -327,6 +346,9 @@ if (CHECK_FOUND)
 
 	# Checker and Builder
 	list (APPEND UNIT_TESTS jwt_builder jwt_checker jwt_flipflop)
+
+	# JWE
+	list (APPEND UNIT_TESTS jwe_foundation)
 
 	# Claims
 	list (APPEND UNIT_TESTS jwt_claims)

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -74,6 +74,48 @@ typedef enum {
 	JWT_ALG_INVAL,		/**< An invalid algorithm from the caller or the token */
 } jwt_alg_t;
 
+/** @ingroup jwt_alg_grp
+ * @brief JWE key management algorithm types
+ *
+ * These are the supported JWE ``"alg"`` (key management) algorithm types for
+ * LibJWT. They determine how the Content Encryption Key (CEK) is produced for
+ * or recovered from a recipient. They are intentionally a separate type from
+ * @ref jwt_alg_t (which is JWS/signing only); the ``"alg"`` values used in JWE
+ * and JWS are not the same.
+ *
+ * @rfc{7518,4.1}
+ */
+typedef enum {
+	JWE_ALG_NONE = 0,	/**< No/unset key management algorithm */
+	JWE_ALG_DIR,		/**< Direct use of a shared symmetric key as the CEK */
+	JWE_ALG_A128KW,		/**< AES Key Wrap with 128-bit key */
+	JWE_ALG_A192KW,		/**< AES Key Wrap with 192-bit key */
+	JWE_ALG_A256KW,		/**< AES Key Wrap with 256-bit key */
+	JWE_ALG_RSA_OAEP,	/**< RSAES-OAEP using default (SHA-1) parameters */
+	JWE_ALG_RSA_OAEP_256,	/**< RSAES-OAEP using SHA-256 and MGF1 with SHA-256 */
+	JWE_ALG_INVAL,		/**< An invalid algorithm from the caller or the token */
+} jwe_key_alg_t;
+
+/** @ingroup jwt_alg_grp
+ * @brief JWE content encryption algorithm types
+ *
+ * These are the supported JWE ``"enc"`` (content encryption) algorithm types
+ * for LibJWT. They determine the authenticated encryption applied to the
+ * plaintext using the CEK.
+ *
+ * @rfc{7518,5.1}
+ */
+typedef enum {
+	JWE_ENC_NONE = 0,	/**< No/unset content encryption algorithm */
+	JWE_ENC_A128GCM,	/**< AES GCM using 128-bit key */
+	JWE_ENC_A192GCM,	/**< AES GCM using 192-bit key */
+	JWE_ENC_A256GCM,	/**< AES GCM using 256-bit key */
+	JWE_ENC_A128CBC_HS256,	/**< AES 128 CBC + HMAC SHA-256 (truncated) */
+	JWE_ENC_A192CBC_HS384,	/**< AES 192 CBC + HMAC SHA-384 (truncated) */
+	JWE_ENC_A256CBC_HS512,	/**< AES 256 CBC + HMAC SHA-512 (truncated) */
+	JWE_ENC_INVAL,		/**< An invalid algorithm from the caller or the token */
+} jwe_enc_t;
+
 /** @ingroup jwt_crypto_grp
  * @brief  Different providers for crypto operations
  *
@@ -1261,6 +1303,51 @@ JWT_EXPORT
 jwt_alg_t jwt_str_alg(const char *alg);
 
 /**
+ * Convert a JWE key management alg type to its string representation.
+ *
+ * @param alg A valid jwe_key_alg_t specifier.
+ * @returns Returns a string (e.g. "RSA-OAEP") matching the alg or NULL for
+ *     an invalid alg.
+ */
+JWT_EXPORT
+const char *jwe_alg_str(jwe_key_alg_t alg);
+
+/**
+ * Convert a JWE key management alg string to type.
+ *
+ * @rfc{7518,4.1}
+ *
+ * @param alg A valid string for a JWE key management algorithm (e.g. "A128KW").
+ * @returns Returns a @ref jwe_key_alg_t matching the string or
+ *  @ref JWE_ALG_INVAL if no matches were found.
+ */
+JWT_EXPORT
+jwe_key_alg_t jwe_str_alg(const char *alg);
+
+/**
+ * Convert a JWE content encryption enc type to its string representation.
+ *
+ * @param enc A valid jwe_enc_t specifier.
+ * @returns Returns a string (e.g. "A256GCM") matching the enc or NULL for
+ *     an invalid enc.
+ */
+JWT_EXPORT
+const char *jwe_enc_str(jwe_enc_t enc);
+
+/**
+ * Convert a JWE content encryption enc string to type.
+ *
+ * @rfc{7518,5.1}
+ *
+ * @param enc A valid string for a JWE content encryption algorithm
+ *  (e.g. "A256GCM").
+ * @returns Returns a @ref jwe_enc_t matching the string or
+ *  @ref JWE_ENC_INVAL if no matches were found.
+ */
+JWT_EXPORT
+jwe_enc_t jwe_str_enc(const char *enc);
+
+/**
  * @}
  * @noop jwt_alg_grp
  */
@@ -1268,6 +1355,204 @@ jwt_alg_t jwt_str_alg(const char *alg);
 /**
  * @}
  * @noop jwt_grp
+ */
+
+/**
+ * @defgroup jwe_grp JSON Web Encryption
+ *
+ * @brief Create and consume JSON Web Encryption (JWE) tokens
+ *
+ * JWE support is built around two objects that parallel the JWS
+ * @ref jwt_builder_t / @ref jwt_checker_t pair but are intentionally
+ * distinct types: a JWE is structurally and cryptographically different from
+ * a JWS, and keeping the types separate prevents accidentally treating one as
+ * the other.
+ *
+ * Unlike JWS, JWE requires two algorithms: a key management algorithm
+ * (@ref jwe_key_alg_t, the ``"alg"`` header) that produces or recovers the
+ * Content Encryption Key (CEK), and a content encryption algorithm
+ * (@ref jwe_enc_t, the ``"enc"`` header) that authenticates and encrypts the
+ * payload with that CEK.
+ *
+ * @rfc{7516}
+ * @{
+ */
+
+/**
+ * @defgroup jwe_builder_grp Builder
+ *
+ * Creating a JWE token mirrors the JWS builder: create a jwe_builder_t,
+ * configure it with a recipient key plus a key management (``"alg"``) and
+ * content encryption (``"enc"``) algorithm, then generate encrypted tokens.
+ * @{
+ */
+
+/**
+ * @brief Opaque JWE Builder (encryption) object
+ */
+typedef struct jwe_builder jwe_builder_t;
+
+/**
+ * @brief Create a new JWE builder instance
+ *
+ * @return Pointer to a JWE builder object on success, NULL on failure
+ */
+JWT_EXPORT
+jwe_builder_t *jwe_builder_new(void);
+
+/**
+ * @brief Free a previously created JWE builder object
+ *
+ * @param builder Pointer to a JWE builder object
+ */
+JWT_EXPORT
+void jwe_builder_free(jwe_builder_t *builder);
+
+#if defined(__GNUC__) || defined(__clang__)
+/**
+ * @brief Helper to free a JWE builder and set the pointer to NULL
+ * @param builder Pointer to a pointer for a jwe_builder_t object
+ */
+static inline void jwe_builder_freep(jwe_builder_t **builder) {
+	if (builder) {
+		jwe_builder_free(*builder);
+		*builder = NULL;
+	}
+}
+#define jwe_builder_auto_t jwe_builder_t \
+	__attribute__((cleanup(jwe_builder_freep)))
+#endif
+
+/**
+ * @brief Check error state of a JWE builder object
+ * @param builder Pointer to a JWE builder object
+ * @return 0 if no errors exist, non-zero otherwise
+ */
+JWT_EXPORT
+int jwe_builder_error(const jwe_builder_t *builder);
+
+/**
+ * @brief Get the error message contained in a JWE builder object
+ * @param builder Pointer to a JWE builder object
+ * @return Pointer to the error message string (empty if none). Never NULL.
+ */
+JWT_EXPORT
+const char *jwe_builder_error_msg(const jwe_builder_t *builder);
+
+/**
+ * @brief Clear error state in a JWE builder object
+ * @param builder Pointer to a JWE builder object
+ */
+JWT_EXPORT
+void jwe_builder_error_clear(jwe_builder_t *builder);
+
+/**
+ * @brief Set the key and algorithms for a JWE builder
+ *
+ * @param builder Pointer to a JWE builder object
+ * @param alg The JWE key management algorithm (``"alg"`` header)
+ * @param enc The JWE content encryption algorithm (``"enc"`` header)
+ * @param key The recipient key (a JWK) used for key management
+ * @return 0 on success, non-zero otherwise with error set in the builder
+ */
+JWT_EXPORT
+int jwe_builder_setkey(jwe_builder_t *builder, jwe_key_alg_t alg,
+		       jwe_enc_t enc, const jwk_item_t *key);
+
+/**
+ * @}
+ * @noop jwe_builder_grp
+ */
+
+/**
+ * @defgroup jwe_checker_grp Checker
+ *
+ * Consuming a JWE token mirrors the JWS checker: create a jwe_checker_t,
+ * configure it with the key and the expected algorithms, then decrypt and
+ * authenticate tokens.
+ * @{
+ */
+
+/**
+ * @brief Opaque JWE Checker (decryption) object
+ */
+typedef struct jwe_checker jwe_checker_t;
+
+/**
+ * @brief Create a new JWE checker instance
+ *
+ * @return Pointer to a JWE checker object on success, NULL on failure
+ */
+JWT_EXPORT
+jwe_checker_t *jwe_checker_new(void);
+
+/**
+ * @brief Free a previously created JWE checker object
+ *
+ * @param checker Pointer to a JWE checker object
+ */
+JWT_EXPORT
+void jwe_checker_free(jwe_checker_t *checker);
+
+#if defined(__GNUC__) || defined(__clang__)
+/**
+ * @brief Helper to free a JWE checker and set the pointer to NULL
+ * @param checker Pointer to a pointer for a jwe_checker_t object
+ */
+static inline void jwe_checker_freep(jwe_checker_t **checker) {
+	if (checker) {
+		jwe_checker_free(*checker);
+		*checker = NULL;
+	}
+}
+#define jwe_checker_auto_t jwe_checker_t \
+	__attribute__((cleanup(jwe_checker_freep)))
+#endif
+
+/**
+ * @brief Check error state of a JWE checker object
+ * @param checker Pointer to a JWE checker object
+ * @return 0 if no errors exist, non-zero otherwise
+ */
+JWT_EXPORT
+int jwe_checker_error(const jwe_checker_t *checker);
+
+/**
+ * @brief Get the error message contained in a JWE checker object
+ * @param checker Pointer to a JWE checker object
+ * @return Pointer to the error message string (empty if none). Never NULL.
+ */
+JWT_EXPORT
+const char *jwe_checker_error_msg(const jwe_checker_t *checker);
+
+/**
+ * @brief Clear error state in a JWE checker object
+ * @param checker Pointer to a JWE checker object
+ */
+JWT_EXPORT
+void jwe_checker_error_clear(jwe_checker_t *checker);
+
+/**
+ * @brief Set the key and algorithms for a JWE checker
+ *
+ * @param checker Pointer to a JWE checker object
+ * @param alg The expected JWE key management algorithm (``"alg"`` header)
+ * @param enc The expected JWE content encryption algorithm (``"enc"`` header)
+ * @param key The key (a JWK) used to recover the CEK
+ * @return 0 on success, non-zero otherwise with error set in the checker
+ */
+JWT_EXPORT
+int jwe_checker_setkey(jwe_checker_t *checker, jwe_key_alg_t alg,
+		       jwe_enc_t enc, const jwk_item_t *key);
+
+/**
+ * @}
+ * @noop jwe_checker_grp
+ */
+
+/**
+ * @}
+ * @noop jwe_grp
  */
 
 /**

--- a/libjwt/jwe-builder.c
+++ b/libjwt/jwe-builder.c
@@ -1,0 +1,16 @@
+/* Copyright (C) 2015-2025 maClara, LLC <info@maclara-llc.com>
+   This file is part of the JWT C Library
+
+   SPDX-License-Identifier:  MPL-2.0
+   This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <jwt.h>
+
+#include "jwt-private.h"
+
+#include "jwe-builder.i"

--- a/libjwt/jwe-checker.c
+++ b/libjwt/jwe-checker.c
@@ -1,0 +1,16 @@
+/* Copyright (C) 2015-2025 maClara, LLC <info@maclara-llc.com>
+   This file is part of the JWT C Library
+
+   SPDX-License-Identifier:  MPL-2.0
+   This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <jwt.h>
+
+#include "jwt-private.h"
+
+#include "jwe-checker.i"

--- a/libjwt/jwe-common.c
+++ b/libjwt/jwe-common.c
@@ -1,0 +1,124 @@
+/* Copyright (C) 2015-2025 maClara, LLC <info@maclara-llc.com>
+   This file is part of the JWT C Library
+
+   SPDX-License-Identifier:  MPL-2.0
+   This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* XXX This file is used to generate jwe-builder.i and jwe-checker.i */
+
+#ifdef JWE_BUILDER
+#define jwe_common_t	jwe_builder_t
+#define FUNC(__x)	jwe_builder_##__x
+#endif
+
+#ifdef JWE_CHECKER
+#define jwe_common_t	jwe_checker_t
+#define FUNC(__x)	jwe_checker_##__x
+#endif
+
+#ifndef jwe_common_t
+#error Must have target defined
+#endif
+
+void FUNC(free)(jwe_common_t *__cmd)
+{
+	if (__cmd == NULL)
+		return;
+
+	jwt_json_release(__cmd->c.payload);
+	jwt_json_release(__cmd->c.headers);
+
+	/* Scrub sensitive key material. The CEK is secret; the other
+	 * components are not, but free them all here. */
+	jwt_scrub_and_free(__cmd->c.cek, __cmd->c.cek_len);
+	jwt_freemem(__cmd->c.enckey);
+	jwt_freemem(__cmd->c.iv);
+	jwt_freemem(__cmd->c.ct);
+	jwt_freemem(__cmd->c.tag);
+
+	memset(__cmd, 0, sizeof(*__cmd));
+
+	jwt_freemem(__cmd);
+}
+
+jwe_common_t *FUNC(new)(void)
+{
+	jwe_common_t *__cmd = jwt_malloc(sizeof(*__cmd));
+
+	if (__cmd == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	memset(__cmd, 0, sizeof(*__cmd));
+
+	__cmd->c.payload = jwt_json_create();
+	__cmd->c.headers = jwt_json_create();
+
+	if (!__cmd->c.payload || !__cmd->c.headers) {
+		// LCOV_EXCL_START
+		jwt_json_release(__cmd->c.payload);
+		jwt_json_release(__cmd->c.headers);
+		jwt_freemem(__cmd);
+		return NULL;
+		// LCOV_EXCL_STOP
+	}
+
+	return __cmd;
+}
+
+int FUNC(error)(const jwe_common_t *__cmd)
+{
+	if (__cmd == NULL)
+		return 1;
+
+	return __cmd->error ? 1 : 0;
+}
+
+const char *FUNC(error_msg)(const jwe_common_t *__cmd)
+{
+	if (__cmd == NULL)
+		return NULL;
+
+	return __cmd->error_msg;
+}
+
+void FUNC(error_clear)(jwe_common_t *__cmd)
+{
+	if (__cmd == NULL)
+		return;
+
+	__cmd->error = 0;
+	__cmd->error_msg[0] = '\0';
+}
+
+int FUNC(setkey)(jwe_common_t *__cmd, jwe_key_alg_t alg, jwe_enc_t enc,
+		 const jwk_item_t *key)
+{
+	if (__cmd == NULL)
+		return 1;
+
+	if (alg == JWE_ALG_NONE || alg >= JWE_ALG_INVAL) {
+		jwt_write_error(__cmd, "Invalid JWE key management alg");
+		return 1;
+	}
+
+	if (enc == JWE_ENC_NONE || enc >= JWE_ENC_INVAL) {
+		jwt_write_error(__cmd, "Invalid JWE content encryption enc");
+		return 1;
+	}
+
+	if (key == NULL) {
+		jwt_write_error(__cmd, "JWE requires a key");
+		return 1;
+	}
+
+	/* TODO (#222): enforce key "use"/"key_ops"/"alg" gating and that the
+	 * key type matches the key management alg. */
+
+	__cmd->c.key_alg = alg;
+	__cmd->c.enc = enc;
+	__cmd->c.key = key;
+
+	return 0;
+}

--- a/libjwt/jwe-setget.c
+++ b/libjwt/jwe-setget.c
@@ -1,0 +1,98 @@
+/* Copyright (C) 2015-2025 maClara, LLC <info@maclara-llc.com>
+   This file is part of the JWT C Library
+
+   SPDX-License-Identifier:  MPL-2.0
+   This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <jwt.h>
+
+#include "jwt-private.h"
+
+/* @rfc{7518,4.1} JWE key management ("alg") <-> string. */
+const char *jwe_alg_str(jwe_key_alg_t alg)
+{
+	switch (alg) {
+	case JWE_ALG_DIR:
+		return "dir";
+	case JWE_ALG_A128KW:
+		return "A128KW";
+	case JWE_ALG_A192KW:
+		return "A192KW";
+	case JWE_ALG_A256KW:
+		return "A256KW";
+	case JWE_ALG_RSA_OAEP:
+		return "RSA-OAEP";
+	case JWE_ALG_RSA_OAEP_256:
+		return "RSA-OAEP-256";
+	default:
+		return NULL;
+	}
+}
+
+jwe_key_alg_t jwe_str_alg(const char *alg)
+{
+	if (alg == NULL)
+		return JWE_ALG_INVAL;
+
+	if (!strcmp(alg, "dir"))
+		return JWE_ALG_DIR;
+	else if (!strcmp(alg, "A128KW"))
+		return JWE_ALG_A128KW;
+	else if (!strcmp(alg, "A192KW"))
+		return JWE_ALG_A192KW;
+	else if (!strcmp(alg, "A256KW"))
+		return JWE_ALG_A256KW;
+	else if (!strcmp(alg, "RSA-OAEP"))
+		return JWE_ALG_RSA_OAEP;
+	else if (!strcmp(alg, "RSA-OAEP-256"))
+		return JWE_ALG_RSA_OAEP_256;
+
+	return JWE_ALG_INVAL;
+}
+
+/* @rfc{7518,5.1} JWE content encryption ("enc") <-> string. */
+const char *jwe_enc_str(jwe_enc_t enc)
+{
+	switch (enc) {
+	case JWE_ENC_A128GCM:
+		return "A128GCM";
+	case JWE_ENC_A192GCM:
+		return "A192GCM";
+	case JWE_ENC_A256GCM:
+		return "A256GCM";
+	case JWE_ENC_A128CBC_HS256:
+		return "A128CBC-HS256";
+	case JWE_ENC_A192CBC_HS384:
+		return "A192CBC-HS384";
+	case JWE_ENC_A256CBC_HS512:
+		return "A256CBC-HS512";
+	default:
+		return NULL;
+	}
+}
+
+jwe_enc_t jwe_str_enc(const char *enc)
+{
+	if (enc == NULL)
+		return JWE_ENC_INVAL;
+
+	if (!strcmp(enc, "A128GCM"))
+		return JWE_ENC_A128GCM;
+	else if (!strcmp(enc, "A192GCM"))
+		return JWE_ENC_A192GCM;
+	else if (!strcmp(enc, "A256GCM"))
+		return JWE_ENC_A256GCM;
+	else if (!strcmp(enc, "A128CBC-HS256"))
+		return JWE_ENC_A128CBC_HS256;
+	else if (!strcmp(enc, "A192CBC-HS384"))
+		return JWE_ENC_A192CBC_HS384;
+	else if (!strcmp(enc, "A256CBC-HS512"))
+		return JWE_ENC_A256CBC_HS512;
+
+	return JWE_ENC_INVAL;
+}

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -96,6 +96,46 @@ struct jwt_checker {
 	char error_msg[JWT_ERR_LEN];
 };
 
+/******************************/
+
+/* JWE is kept deliberately separate from JWS/JWT. A JWE is structurally and
+ * cryptographically different (5 parts, "alg"+"enc", a CEK), so it gets its
+ * own common struct rather than overloading struct jwt_common. */
+struct jwe_common {
+	jwe_key_alg_t key_alg;	/* @rfc{7516,4.1.1} "alg" key management	*/
+	jwe_enc_t enc;		/* @rfc{7516,4.1.2} "enc" content encryption	*/
+	const jwk_item_t *key;	/* Recipient key used for key management		*/
+	jwt_json_t *payload;	/* Claims/plaintext to encrypt (builder)	*/
+	jwt_json_t *headers;	/* Protected header				*/
+	jwt_callback_t cb;
+	void *cb_ctx;
+
+	/* The five JWE Compact Serialization components, populated during
+	 * encrypt (builder) or decrypt (checker). Owned by this struct. */
+	unsigned char *cek;	/* Content Encryption Key			*/
+	size_t cek_len;
+	unsigned char *enckey;	/* JWE Encrypted Key (wrapped CEK)		*/
+	size_t enckey_len;
+	unsigned char *iv;	/* JWE Initialization Vector			*/
+	size_t iv_len;
+	unsigned char *ct;	/* JWE Ciphertext				*/
+	size_t ct_len;
+	unsigned char *tag;	/* JWE Authentication Tag			*/
+	size_t tag_len;
+};
+
+struct jwe_builder {
+	struct jwe_common c;
+	int error;
+	char error_msg[JWT_ERR_LEN];
+};
+
+struct jwe_checker {
+	struct jwe_common c;
+	int error;
+	char error_msg[JWT_ERR_LEN];
+};
+
 /*****************************/
 
 struct jwt {
@@ -174,6 +214,65 @@ struct jwt_crypto_ops {
 	int (*process_rsa)(jwt_json_t *jwk, jwk_item_t *item);
 	int (*process_ec)(jwt_json_t *jwk, jwk_item_t *item);
 	void (*process_item_free)(jwk_item_t *item);
+
+	/* JWE (RFC 7516/7518). A backend may implement JWE crypto ops even if
+	 * it does not parse JWKs (JWK parsing always falls back to OpenSSL).
+	 * jwe_implemented is set once a backend provides the ops below; until
+	 * then, JWE operations on that backend fail cleanly. The ops are
+	 * declared here for all stages; each is filled in by its own stage and
+	 * left NULL otherwise. */
+	int jwe_implemented;
+
+	/* CSPRNG: fill out[0..len) with cryptographically random bytes.
+	 * Returns 0 on success. Backed by each backend's native RNG. */
+	int (*rng)(unsigned char *out, size_t len);
+
+	/* Content encryption (the "enc" algorithms). AAD is the ASCII bytes of
+	 * the encoded protected header. */
+	int (*encrypt_aes_gcm)(jwe_enc_t enc, const unsigned char *cek,
+		size_t cek_len, const unsigned char *iv, size_t iv_len,
+		const unsigned char *aad, size_t aad_len,
+		const unsigned char *pt, size_t pt_len,
+		unsigned char **ct, size_t *ct_len,
+		unsigned char **tag, size_t *tag_len);
+	int (*decrypt_aes_gcm)(jwe_enc_t enc, const unsigned char *cek,
+		size_t cek_len, const unsigned char *iv, size_t iv_len,
+		const unsigned char *aad, size_t aad_len,
+		const unsigned char *ct, size_t ct_len,
+		const unsigned char *tag, size_t tag_len,
+		unsigned char **pt, size_t *pt_len);
+	int (*encrypt_aes_cbc_hmac)(jwe_enc_t enc, const unsigned char *cek,
+		size_t cek_len, const unsigned char *iv, size_t iv_len,
+		const unsigned char *aad, size_t aad_len,
+		const unsigned char *pt, size_t pt_len,
+		unsigned char **ct, size_t *ct_len,
+		unsigned char **tag, size_t *tag_len);
+	int (*decrypt_aes_cbc_hmac)(jwe_enc_t enc, const unsigned char *cek,
+		size_t cek_len, const unsigned char *iv, size_t iv_len,
+		const unsigned char *aad, size_t aad_len,
+		const unsigned char *ct, size_t ct_len,
+		const unsigned char *tag, size_t tag_len,
+		unsigned char **pt, size_t *pt_len);
+
+	/* Key management: AES Key Wrap (RFC 3394). Key-mgmt shaped: a CEK goes
+	 * in, the wrapped key comes out (and the inverse). */
+	int (*wrap_aes_kw)(const jwk_item_t *key, const unsigned char *cek,
+		size_t cek_len, unsigned char **out, size_t *out_len);
+	int (*unwrap_aes_kw)(const jwk_item_t *key, const unsigned char *in,
+		size_t in_len, unsigned char **cek, size_t *cek_len);
+
+	/* Key management: RSAES-OAEP (and OAEP-256). */
+	int (*encrypt_cek_rsa)(jwe_key_alg_t alg, const jwk_item_t *key,
+		const unsigned char *cek, size_t cek_len,
+		unsigned char **out, size_t *out_len);
+	int (*decrypt_cek_rsa)(jwe_key_alg_t alg, const jwk_item_t *key,
+		const unsigned char *in, size_t in_len,
+		unsigned char **cek, size_t *cek_len);
+
+	/* ECDH-ES (reserved for the ECDH-ES stage). Ephemeral public key
+	 * generation/parsing for the "epk" header. */
+	int (*gen_epk)(const jwk_item_t *key, jwk_item_t **epk);
+	int (*parse_epk)(jwt_json_t *epk_json, jwk_item_t **epk);
 };
 
 #ifdef HAVE_OPENSSL
@@ -265,6 +364,9 @@ char *jwt_encode_str(jwt_t *jwt);
 
 JWT_NO_EXPORT
 int jwt_head_setup(jwt_t *jwt);
+
+/* JWE alg/enc <-> string maps (jwe-setget.c). These are exported as part of
+ * the public API (jwe_alg_str etc.), declared in jwt.h. */
 
 #define __trace() fprintf(stderr, "%s:%d\n", __func__, __LINE__)
 

--- a/tests/jwe_foundation.c
+++ b/tests/jwe_foundation.c
@@ -1,0 +1,241 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* Every defined jwe_key_alg_t value (excluding NONE/INVAL) with its string. */
+static const struct {
+	jwe_key_alg_t alg;
+	const char *str;
+} alg_map[] = {
+	{ JWE_ALG_DIR,		"dir" },
+	{ JWE_ALG_A128KW,	"A128KW" },
+	{ JWE_ALG_A192KW,	"A192KW" },
+	{ JWE_ALG_A256KW,	"A256KW" },
+	{ JWE_ALG_RSA_OAEP,	"RSA-OAEP" },
+	{ JWE_ALG_RSA_OAEP_256,	"RSA-OAEP-256" },
+};
+
+/* Every defined jwe_enc_t value (excluding NONE/INVAL) with its string. */
+static const struct {
+	jwe_enc_t enc;
+	const char *str;
+} enc_map[] = {
+	{ JWE_ENC_A128GCM,	"A128GCM" },
+	{ JWE_ENC_A192GCM,	"A192GCM" },
+	{ JWE_ENC_A256GCM,	"A256GCM" },
+	{ JWE_ENC_A128CBC_HS256, "A128CBC-HS256" },
+	{ JWE_ENC_A192CBC_HS384, "A192CBC-HS384" },
+	{ JWE_ENC_A256CBC_HS512, "A256CBC-HS512" },
+};
+
+START_TEST(alg_roundtrip)
+{
+	size_t j;
+
+	SET_OPS();
+
+	for (j = 0; j < ARRAY_SIZE(alg_map); j++) {
+		const char *s = jwe_alg_str(alg_map[j].alg);
+
+		ck_assert_ptr_nonnull(s);
+		ck_assert_str_eq(s, alg_map[j].str);
+		ck_assert_int_eq(jwe_str_alg(alg_map[j].str), alg_map[j].alg);
+	}
+
+	/* Unknown / invalid inputs */
+	ck_assert_ptr_null(jwe_alg_str(JWE_ALG_NONE));
+	ck_assert_ptr_null(jwe_alg_str(JWE_ALG_INVAL));
+	ck_assert_int_eq(jwe_str_alg(NULL), JWE_ALG_INVAL);
+	ck_assert_int_eq(jwe_str_alg("bogus"), JWE_ALG_INVAL);
+	ck_assert_int_eq(jwe_str_alg("RS256"), JWE_ALG_INVAL);
+}
+END_TEST
+
+START_TEST(enc_roundtrip)
+{
+	size_t j;
+
+	SET_OPS();
+
+	for (j = 0; j < ARRAY_SIZE(enc_map); j++) {
+		const char *s = jwe_enc_str(enc_map[j].enc);
+
+		ck_assert_ptr_nonnull(s);
+		ck_assert_str_eq(s, enc_map[j].str);
+		ck_assert_int_eq(jwe_str_enc(enc_map[j].str), enc_map[j].enc);
+	}
+
+	ck_assert_ptr_null(jwe_enc_str(JWE_ENC_NONE));
+	ck_assert_ptr_null(jwe_enc_str(JWE_ENC_INVAL));
+	ck_assert_int_eq(jwe_str_enc(NULL), JWE_ENC_INVAL);
+	ck_assert_int_eq(jwe_str_enc("bogus"), JWE_ENC_INVAL);
+	ck_assert_int_eq(jwe_str_enc("A128GCMKW"), JWE_ENC_INVAL);
+}
+END_TEST
+
+START_TEST(builder_new)
+{
+	jwe_builder_auto_t *builder = NULL;
+
+	SET_OPS();
+
+	builder = jwe_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ck_assert_int_eq(jwe_builder_error(builder), 0);
+	ck_assert_str_eq(jwe_builder_error_msg(builder), "");
+
+	/* NULL-safety */
+	ck_assert_int_eq(jwe_builder_error(NULL), 1);
+	ck_assert_ptr_null(jwe_builder_error_msg(NULL));
+	jwe_builder_free(NULL);
+	jwe_builder_error_clear(NULL);
+}
+END_TEST
+
+START_TEST(checker_new)
+{
+	jwe_checker_auto_t *checker = NULL;
+
+	SET_OPS();
+
+	checker = jwe_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ck_assert_int_eq(jwe_checker_error(checker), 0);
+	ck_assert_str_eq(jwe_checker_error_msg(checker), "");
+
+	ck_assert_int_eq(jwe_checker_error(NULL), 1);
+	ck_assert_ptr_null(jwe_checker_error_msg(NULL));
+	jwe_checker_free(NULL);
+	jwe_checker_error_clear(NULL);
+}
+END_TEST
+
+START_TEST(builder_setkey)
+{
+	jwe_builder_auto_t *builder = NULL;
+	int ret;
+
+	SET_OPS();
+
+	read_json("oct_key_256.json");
+
+	builder = jwe_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	/* Happy path */
+	ret = jwe_builder_setkey(builder, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 0);
+	ck_assert_int_eq(jwe_builder_error(builder), 0);
+
+	/* Bad alg */
+	ret = jwe_builder_setkey(builder, JWE_ALG_NONE, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	ck_assert_int_eq(jwe_builder_error(builder), 1);
+	jwe_builder_error_clear(builder);
+
+	ret = jwe_builder_setkey(builder, JWE_ALG_INVAL, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	jwe_builder_error_clear(builder);
+
+	/* Bad enc */
+	ret = jwe_builder_setkey(builder, JWE_ALG_A256KW, JWE_ENC_NONE,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	jwe_builder_error_clear(builder);
+
+	ret = jwe_builder_setkey(builder, JWE_ALG_A256KW, JWE_ENC_INVAL,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	jwe_builder_error_clear(builder);
+
+	/* No key */
+	ret = jwe_builder_setkey(builder, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 NULL);
+	ck_assert_int_eq(ret, 1);
+	jwe_builder_error_clear(builder);
+
+	/* NULL object */
+	ret = jwe_builder_setkey(NULL, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+
+	free_key();
+}
+END_TEST
+
+START_TEST(checker_setkey)
+{
+	jwe_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	read_json("oct_key_256.json");
+
+	checker = jwe_checker_new();
+	ck_assert_ptr_nonnull(checker);
+
+	ret = jwe_checker_setkey(checker, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwe_checker_setkey(checker, JWE_ALG_INVAL, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	jwe_checker_error_clear(checker);
+
+	ret = jwe_checker_setkey(checker, JWE_ALG_A256KW, JWE_ENC_INVAL,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	jwe_checker_error_clear(checker);
+
+	ret = jwe_checker_setkey(checker, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 NULL);
+	ck_assert_int_eq(ret, 1);
+	jwe_checker_error_clear(checker);
+
+	ret = jwe_checker_setkey(NULL, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+
+	free_key();
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+
+	tc_core = tcase_create("JWE Foundation");
+
+	/* The string maps and object lifecycle are crypto-backend
+	 * independent, but run them under every compiled provider for
+	 * consistency with the rest of the suite. */
+	tcase_add_loop_test(tc_core, alg_roundtrip, 0, i);
+	tcase_add_loop_test(tc_core, enc_roundtrip, 0, i);
+	tcase_add_loop_test(tc_core, builder_new, 0, i);
+	tcase_add_loop_test(tc_core, checker_new, 0, i);
+	tcase_add_loop_test(tc_core, builder_setkey, 0, i);
+	tcase_add_loop_test(tc_core, checker_setkey, 0, i);
+
+	tcase_set_timeout(tc_core, 30);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT JWE Foundation");
+}


### PR DESCRIPTION
First stage of JWE (RFC 7516) support — **types and plumbing only, no crypto logic** — so the subsequent stages (#222–#226, #242–#245) have stable interfaces to build against. Part of #158; scope decided in #221.

## What's here

**Public API (`include/jwt.h`)**
- New enums `jwe_key_alg_t` (`dir`, `A128/192/256KW`, `RSA-OAEP`, `RSA-OAEP-256`) and `jwe_enc_t` (`A128/192/256GCM`, `A128CBC-HS256`/`A192CBC-HS384`/`A256CBC-HS512`), kept separate from the signing-only `jwt_alg_t`.
- `jwe_alg_str`/`jwe_str_alg` and `jwe_enc_str`/`jwe_str_enc` string maps.
- A new top-level **"JSON Web Encryption"** Doxygen group with **Builder** and **Checker** subgroups, paralleling the JWT groups.
- Opaque `jwe_builder_t`/`jwe_checker_t` with `auto_t` cleanup typedefs, and `new`/`free`/`error`/`error_msg`/`error_clear` plus the two-algorithm `setkey`.

**Internals (`jwt-private.h`)**
- A parallel `struct jwe_common` (not embedding `struct jwt_common`) holding the selected alg/enc, key, and the five JWE components (CEK/encrypted-key/IV/ciphertext/tag).
- `struct jwt_crypto_ops` extended with the JWE op pointers (`rng`, AES-GCM, AES-CBC-HMAC, AES Key Wrap, RSA-OAEP, ECDH-ES `epk`) and a `jwe_implemented` gate. Declarations only — each op is implemented in its own stage; backends implement JWE ops themselves, only JWK *parsing* falls back to OpenSSL.

**Build**
- `jwe-common.c` compiled twice (`-DJWE_BUILDER`/`-DJWE_CHECKER`) like `jwt-common.c`; new sources wired into `JWT_SOURCES`.

## Tests
`tests/jwe_foundation.c` — enum round-trips (all values + invalid inputs), object lifecycle (incl. NULL-safety), and `setkey` accept/reject, looped over every compiled crypto provider.

- ✅ Full suite green (13/13)
- ✅ **100% line coverage** on the new code (`jwe-common.c` 98/98, `jwe-setget.c` 64/64) — no new uncovered lines
- ✅ Builds and tests clean under both Jansson and json-c

closes #241