### PR TITLE
jwe: enforce JWK key-usage gating for JWE operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set(JWT_SOURCES libjwt/jwt-memory.c
 	libjwt/jwt-builder.c
 	libjwt/jwt-checker.c
 	libjwt/jwe-setget.c
+	libjwt/jwe.c
 	libjwt/jwe-builder.c
 	libjwt/jwe-checker.c
 	libjwt/jwks-curl.c)
@@ -348,7 +349,7 @@ if (CHECK_FOUND)
 	list (APPEND UNIT_TESTS jwt_builder jwt_checker jwt_flipflop)
 
 	# JWE
-	list (APPEND UNIT_TESTS jwe_foundation)
+	list (APPEND UNIT_TESTS jwe_foundation jwe_keys)
 
 	# Claims
 	list (APPEND UNIT_TESTS jwt_claims)

--- a/libjwt/jwe-common.c
+++ b/libjwt/jwe-common.c
@@ -95,6 +95,8 @@ void FUNC(error_clear)(jwe_common_t *__cmd)
 int FUNC(setkey)(jwe_common_t *__cmd, jwe_key_alg_t alg, jwe_enc_t enc,
 		 const jwk_item_t *key)
 {
+	const char *reason;
+
 	if (__cmd == NULL)
 		return 1;
 
@@ -113,8 +115,17 @@ int FUNC(setkey)(jwe_common_t *__cmd, jwe_key_alg_t alg, jwe_enc_t enc,
 		return 1;
 	}
 
-	/* TODO (#222): enforce key "use"/"key_ops"/"alg" gating and that the
-	 * key type matches the key management alg. */
+	/* @rfc{7516,11.4} Enforce key-usage gating. The builder is the producer
+	 * (encrypt/wrap); the checker is the consumer (decrypt/unwrap). */
+#ifdef JWE_BUILDER
+	reason = jwe_key_usage_check(key, alg, 1);
+#else
+	reason = jwe_key_usage_check(key, alg, 0);
+#endif
+	if (reason != NULL) {
+		jwt_write_error(__cmd, "%s", reason);
+		return 1;
+	}
 
 	__cmd->c.key_alg = alg;
 	__cmd->c.enc = enc;

--- a/libjwt/jwe.c
+++ b/libjwt/jwe.c
@@ -1,0 +1,70 @@
+/* Copyright (C) 2015-2025 maClara, LLC <info@maclara-llc.com>
+   This file is part of the JWT C Library
+
+   SPDX-License-Identifier:  MPL-2.0
+   This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <jwt.h>
+
+#include "jwt-private.h"
+
+/* @rfc{7516,11.4} @rfc{7517,4.2,4.3} Gate a JWK against a JWE key management
+ * algorithm. */
+const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
+				int for_encrypt)
+{
+	jwk_key_type_t need = jwe_alg_required_kty(alg);
+
+	/* Callers (setkey) already reject a NULL key; this is defensive. */
+	if (key == NULL)
+		return "JWE requires a key"; // LCOV_EXCL_LINE
+
+	if (need == JWK_KEY_TYPE_NONE)
+		return "Unknown JWE key management algorithm"; // LCOV_EXCL_LINE
+
+	/* The key's actual type must match what the alg requires. This is the
+	 * authoritative gate and does not depend on optional JWK hints. */
+	if (jwks_item_kty(key) != need)
+		return "Key type does not match JWE algorithm";
+
+	/* @rfc{7517,4.2} If "use" is set, it must be "enc" for JWE; a key
+	 * marked "sig" must never be used for encryption. */
+	if (jwks_item_use(key) == JWK_PUB_KEY_USE_SIG)
+		return "Key marked for signing cannot be used for JWE";
+
+	/* @rfc{7517,4.3} If "key_ops" is present, it must permit the operation
+	 * we are about to perform. dir/A*KW use (un)wrapKey; RSA-OAEP uses
+	 * (en|de)crypt. If no key_ops are declared, this check is skipped. */
+	if (jwks_item_key_ops(key) != JWK_KEY_OP_NONE) {
+		jwk_key_op_t ops = jwks_item_key_ops(key);
+		jwk_key_op_t want;
+
+		switch (alg) {
+		case JWE_ALG_DIR:
+		case JWE_ALG_A128KW:
+		case JWE_ALG_A192KW:
+		case JWE_ALG_A256KW:
+			want = for_encrypt ? JWK_KEY_OP_WRAP : JWK_KEY_OP_UNWRAP;
+			break;
+		case JWE_ALG_RSA_OAEP:
+		case JWE_ALG_RSA_OAEP_256:
+			want = for_encrypt ? JWK_KEY_OP_ENCRYPT
+					   : JWK_KEY_OP_DECRYPT;
+			break;
+		// LCOV_EXCL_START
+		default:
+			return "Unknown JWE key management algorithm";
+		// LCOV_EXCL_STOP
+		}
+
+		if (!(ops & want))
+			return "Key does not permit the required JWE operation";
+	}
+
+	return NULL;
+}

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -407,4 +407,79 @@ static inline jwk_key_type_t jwt_alg_required_kty(jwt_alg_t alg)
 	}
 }
 
+/* @rfc{7518,5.1} The CEK length (in bytes) required by a content encryption
+ * ("enc") algorithm. The AES-CBC-HMAC algorithms use a double-length key
+ * (MAC_KEY || ENC_KEY), hence 32/48/64 bytes. Returns 0 for invalid enc. */
+static inline size_t jwe_enc_cek_len(jwe_enc_t enc)
+{
+	switch (enc) {
+	case JWE_ENC_A128GCM:
+		return 16;
+	case JWE_ENC_A192GCM:
+		return 24;
+	case JWE_ENC_A256GCM:
+		return 32;
+	case JWE_ENC_A128CBC_HS256:
+		return 32;
+	case JWE_ENC_A192CBC_HS384:
+		return 48;
+	case JWE_ENC_A256CBC_HS512:
+		return 64;
+	default:
+		return 0;
+	}
+}
+
+/* @rfc{7518,4.1} The IV length (in bytes) for a content encryption algorithm:
+ * 96-bit nonce for GCM, 128-bit IV for CBC. Returns 0 for invalid enc. */
+static inline size_t jwe_enc_iv_len(jwe_enc_t enc)
+{
+	switch (enc) {
+	case JWE_ENC_A128GCM:
+	case JWE_ENC_A192GCM:
+	case JWE_ENC_A256GCM:
+		return 12;
+	case JWE_ENC_A128CBC_HS256:
+	case JWE_ENC_A192CBC_HS384:
+	case JWE_ENC_A256CBC_HS512:
+		return 16;
+	default:
+		return 0;
+	}
+}
+
+/* The jwk_key_type_t that a JWE key management ("alg") algorithm requires of
+ * the recipient key. Mirrors jwt_alg_required_kty() for JWE and is the
+ * authoritative kty<->alg gate that prevents using, e.g., an RSA key for an
+ * AES Key Wrap operation. JWE_KEY_TYPE_NONE for invalid/unknown. */
+static inline jwk_key_type_t jwe_alg_required_kty(jwe_key_alg_t alg)
+{
+	switch (alg) {
+	case JWE_ALG_DIR:
+	case JWE_ALG_A128KW:
+	case JWE_ALG_A192KW:
+	case JWE_ALG_A256KW:
+		return JWK_KEY_TYPE_OCT;
+
+	case JWE_ALG_RSA_OAEP:
+	case JWE_ALG_RSA_OAEP_256:
+		return JWK_KEY_TYPE_RSA;
+
+	// LCOV_EXCL_START
+	default:
+		return JWK_KEY_TYPE_NONE;
+	// LCOV_EXCL_STOP
+	}
+}
+
+/* Validate that a JWK may be used for a JWE operation with the given key
+ * management alg. Checks key type vs alg, the "use" attribute (must not be
+ * "sig"), and "key_ops" (if present, must permit the needed operation).
+ * @for_encrypt selects the producer (encrypt/wrap) vs consumer (decrypt/
+ * unwrap) direction. Returns NULL if the key is acceptable, or a static
+ * human-readable reason string if not. */
+JWT_NO_EXPORT
+const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
+				int for_encrypt);
+
 #endif /* JWT_PRIVATE_H */

--- a/tests/jwe_keys.c
+++ b/tests/jwe_keys.c
@@ -1,0 +1,228 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* @rfc{7516,11.4} Key-usage gating is exercised through the public
+ * jwe_builder_setkey / jwe_checker_setkey, which call the internal
+ * jwe_key_usage_check. The builder is the producer (wrap/encrypt), the
+ * checker the consumer (unwrap/decrypt). */
+
+START_TEST(oct_no_restrictions)
+{
+	jwe_builder_auto_t *builder = NULL;
+	int ret;
+
+	SET_OPS();
+
+	/* oct_key_256.json has no "use"/"key_ops" -> usable for A*KW/dir. */
+	read_json("oct_key_256.json");
+
+	builder = jwe_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	ret = jwe_builder_setkey(builder, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwe_builder_setkey(builder, JWE_ALG_DIR, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 0);
+
+	free_key();
+}
+END_TEST
+
+START_TEST(oct_use_enc)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	/* use:enc, key_ops:[wrapKey,unwrapKey] */
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ret = jwe_builder_setkey(builder, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 0);
+
+	checker = jwe_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ret = jwe_checker_setkey(checker, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 0);
+
+	free_key();
+}
+END_TEST
+
+START_TEST(oct_use_sig_rejected)
+{
+	jwe_builder_auto_t *builder = NULL;
+	int ret;
+
+	SET_OPS();
+
+	/* use:sig must never be usable for JWE. */
+	read_json("oct_key_256_sig.json");
+
+	builder = jwe_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	ret = jwe_builder_setkey(builder, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	ck_assert_int_eq(jwe_builder_error(builder), 1);
+	ck_assert_str_eq(jwe_builder_error_msg(builder),
+			 "Key marked for signing cannot be used for JWE");
+
+	free_key();
+}
+END_TEST
+
+START_TEST(oct_key_ops_direction)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	int ret;
+
+	SET_OPS();
+
+	/* key_ops:[wrapKey] only: builder (wrap) OK, checker (unwrap) rejected. */
+	read_json("oct_key_256_wrap_only.json");
+
+	builder = jwe_builder_new();
+	ck_assert_ptr_nonnull(builder);
+	ret = jwe_builder_setkey(builder, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 0);
+
+	checker = jwe_checker_new();
+	ck_assert_ptr_nonnull(checker);
+	ret = jwe_checker_setkey(checker, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	ck_assert_str_eq(jwe_checker_error_msg(checker),
+			 "Key does not permit the required JWE operation");
+
+	free_key();
+}
+END_TEST
+
+START_TEST(wrong_kty_rejected)
+{
+	jwe_builder_auto_t *builder = NULL;
+	int ret;
+
+	SET_OPS();
+
+	/* An RSA key cannot be used for AES Key Wrap (needs oct). */
+	read_json("rsa_key_2048.json");
+
+	builder = jwe_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	ret = jwe_builder_setkey(builder, JWE_ALG_A256KW, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	ck_assert_str_eq(jwe_builder_error_msg(builder),
+			 "Key type does not match JWE algorithm");
+
+	free_key();
+}
+END_TEST
+
+START_TEST(rsa_oaep_kty)
+{
+	jwe_builder_auto_t *builder = NULL;
+	int ret;
+
+	SET_OPS();
+
+	/* use:enc RSA key is valid for RSA-OAEP. */
+	read_json("rsa_key_2048_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	ret = jwe_builder_setkey(builder, JWE_ALG_RSA_OAEP, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 0);
+
+	ret = jwe_builder_setkey(builder, JWE_ALG_RSA_OAEP_256, JWE_ENC_A128GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 0);
+
+	free_key();
+}
+END_TEST
+
+START_TEST(rsa_sig_rejected)
+{
+	jwe_builder_auto_t *builder = NULL;
+	int ret;
+
+	SET_OPS();
+
+	/* The stock RSA test key is use:sig and must be rejected for JWE. */
+	read_json("rsa_key_2048.json");
+
+	builder = jwe_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	ret = jwe_builder_setkey(builder, JWE_ALG_RSA_OAEP, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	ck_assert_str_eq(jwe_builder_error_msg(builder),
+			 "Key marked for signing cannot be used for JWE");
+
+	free_key();
+
+	/* An oct key cannot be used for RSA-OAEP regardless of usage. */
+	read_json("oct_key_256.json");
+	jwe_builder_error_clear(builder);
+	ret = jwe_builder_setkey(builder, JWE_ALG_RSA_OAEP, JWE_ENC_A256GCM,
+				 g_item);
+	ck_assert_int_eq(ret, 1);
+	ck_assert_str_eq(jwe_builder_error_msg(builder),
+			 "Key type does not match JWE algorithm");
+
+	free_key();
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+
+	tc_core = tcase_create("JWE Key Usage");
+
+	tcase_add_loop_test(tc_core, oct_no_restrictions, 0, i);
+	tcase_add_loop_test(tc_core, oct_use_enc, 0, i);
+	tcase_add_loop_test(tc_core, oct_use_sig_rejected, 0, i);
+	tcase_add_loop_test(tc_core, oct_key_ops_direction, 0, i);
+	tcase_add_loop_test(tc_core, wrong_kty_rejected, 0, i);
+	tcase_add_loop_test(tc_core, rsa_oaep_kty, 0, i);
+	tcase_add_loop_test(tc_core, rsa_sig_rejected, 0, i);
+
+	tcase_set_timeout(tc_core, 30);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT JWE Key Usage");
+}

--- a/tests/keys/oct_key_256_enc.json
+++ b/tests/keys/oct_key_256_enc.json
@@ -1,0 +1,13 @@
+{
+  "keys": [
+    {
+      "kty": "oct",
+      "use": "enc",
+      "key_ops": [
+        "wrapKey",
+        "unwrapKey"
+      ],
+      "k": "0gmNspkRljssLSrldySnYUS-zhtCo5sqeqo_yl7n2XA"
+    }
+  ]
+}

--- a/tests/keys/oct_key_256_sig.json
+++ b/tests/keys/oct_key_256_sig.json
@@ -1,0 +1,9 @@
+{
+  "keys": [
+    {
+      "kty": "oct",
+      "use": "sig",
+      "k": "0gmNspkRljssLSrldySnYUS-zhtCo5sqeqo_yl7n2XA"
+    }
+  ]
+}

--- a/tests/keys/oct_key_256_wrap_only.json
+++ b/tests/keys/oct_key_256_wrap_only.json
@@ -1,0 +1,12 @@
+{
+  "keys": [
+    {
+      "kty": "oct",
+      "use": "enc",
+      "key_ops": [
+        "wrapKey"
+      ],
+      "k": "0gmNspkRljssLSrldySnYUS-zhtCo5sqeqo_yl7n2XA"
+    }
+  ]
+}

--- a/tests/keys/rsa_key_2048_enc.json
+++ b/tests/keys/rsa_key_2048_enc.json
@@ -1,0 +1,17 @@
+    {
+      "use": "enc",
+      "key_ops": [
+        "encrypt",
+        "decrypt"
+      ],
+      "kid": "28c243a4-a9ac-473f-ab61-d3a68f408279",
+      "kty": "RSA",
+      "n": "wtpMAM4l1H995oqlqdMhuqNuffp4-4aUCwuFE9B5s9MJr63gyf8jW0oDr7Mb1Xb8y9iGkWfhouZqNJbMFry-iBs-z2TtJF06vbHQZzajDsdux3XVfXv9v6dDIImyU24MsGNkpNt0GISaaiqv51NMZQX0miOXXWdkQvWTZFXhmsFCmJLE67oQFSar4hzfAaCulaMD-b3Mcsjlh0yvSq7g6swiIasEU3qNLKaJAZEzfywroVYr3BwM1IiVbQeKgIkyPS_85M4Y6Ss_T-OWi1OeK49NdYBvFP-hNVEoeZzJz5K_nd6C35IX0t2bN5CVXchUFmaUMYk2iPdhXdsC720tBw",
+      "e": "AQAB",
+      "d": "D8dTnkETSSjlzhRuI9loAtAXM3Zj86JLPLW7GgaoxEoTn7lJ2bGicFMHB2ROnbOb9vnas82gtOtJsGaBslmoaCckp_C5T1eJWTEb-i-vdpPpwZcmKZovyyRFSE4-NYlU17fEv6DRvuaGBpDcW7QgHJIl45F8QWEM-msee2KE-V4Gz_9vAQ-sOlvsb4mJP1tJIBx9Lb5loVREwCRy2Ha9tnWdDNar8EYkOn8si4snPT-E3ZCy8mlcZyUkZeiS_HdtydxZfoiwrSRYamd1diQpPhWCeRteQ802a7ds0Y2YzgfFUaYjNuRQm7zA__hwbXS7ELPyNMU15N00bajlG0tUOQ",
+      "p": "5y8tNZdtDp3lugNnCAyA8mIcuTu7rpbGhLSUXlJXIxAzJIp_G--u6tlWR2__92R_oqZ0WAclFMmFIXTrNg2ERhngHm5x_MKU0-BQmMVLCFKQ3we0cH3QTjYGinsEyc_xT7MMtWHtG-R9nOr1YpthWd9x0HKGd8LxRashlZzM6Ts",
+      "q": "18S_ecqMVBimvLzM3BNwp9NbM4dHRatLKnBaTPh1i1a_OAiLbhvR-i9CmkrRBCDoibMTlaXF3xRYbCbzhoTAOA0E8B-Frl5l6dT6FTA5VeuT2Kr4c8C-PkIb2Ttm7KxLpyE1zplOwiOpIpZwDdy7j-B26mYKF_ZajyN9VWMy7qU",
+      "dp": "YRhyT3DSz_HHG1H0gu_ldGd6kt2gnNocdH33VooUqNhT8oPskMog1-gCEazbf4cJCEIK2THfBBUDQiL96szQgjS56W4Pl84NfdNXZmJuegdbayCsSxa8VyzfoGe8ghpAym1z5_ZCBJX5n98awphp0bpD7f07tq78cHtIdrLNaSM",
+      "dq": "yC0XOyWn1Old32IFaPN8I6cZSI_rln4ZaRD9JcWoP5JGKvT6bjfPMZ2g28Ynbf4d3opN1BsMnS6h7gyhB56nOhkSCLgl7KRVRn-5V-j6eHTrICtV_wXFObtZXMsYbOBX-4D7C2X9xG0TICyTXrj3Jb8oc8Qg_yQl1gAl6g7zFKU",
+      "qi": "ERMrkFR7KGYZG1eFNRdVmJMq-Ibxyw8ks_CbiI-n3yUyk1U8962ol2Q0T4qjBmb26L5rrhNQhneM4e8mo9FXLlQapYkPvkdrqW0Bp72A_UNAvcGTmN7z5OCJGMUutx2hmEAlrYmpLKS8pM_p9zpKtEOtzsP5GMDYVlEp1jYSjzQ"
+    }


### PR DESCRIPTION
Second JWE stage (RFC 7516). Adds the key-usage enforcement layer plus the algorithm/length mapping helpers later stages depend on. Part of #158.

## What's here
- **`jwe_key_usage_check()`** (`libjwt/jwe.c`) — gates a JWK against a JWE key management `alg`:
  1. **kty must match the alg** (oct for `dir`/`A*KW`, RSA for `RSA-OAEP`) — authoritative, independent of optional JWK hints (RFC 7516 §11.4).
  2. a **`use":"sig"` key is never accepted** for JWE (RFC 7517 §4.2).
  3. if **`key_ops`** is present it must permit the operation — builder needs `wrapKey`/`encrypt`, checker needs `unwrapKey`/`decrypt` (RFC 7517 §4.3).
- `jwe_builder_setkey`/`jwe_checker_setkey` now call the gate (builder = producer, checker = consumer), rejecting unusable keys at config time.
- Mapping helpers in `jwt-private.h`: `jwe_enc_cek_len`/`jwe_enc_iv_len` (RFC 7518 §5.1) and `jwe_alg_required_kty`.
- New `use:"enc"`/`"sig"` test fixtures with assorted `key_ops`.

## Scope note
The per-backend CSPRNG (`rng` op) and `jwe_generate_cek()` move to **#242** (content encryption), where the GCM path exercises them end-to-end — implementing them here would add lines with no testable caller (the project requires no new uncovered lines).

## Tests
`tests/jwe_keys.c` — the full accept/reject matrix (unrestricted, `use:enc`, `use:sig`, `key_ops` direction, wrong-kty, RSA-OAEP vs oct) under every crypto provider.

- ✅ Full suite green (14/14)
- ✅ **100% line coverage** on the new code (`jwe.c`, `jwe-common.c`, `jwe-setget.c`)
- ✅ Clean under Jansson and json-c

closes #222