### PR TITLE
docs: document supported JWE algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ JWS Algorithm ``alg``         | OpenSSL            | GnuTLS             | MbedTL
 
 ``*`` RSASSA-PSS support in MbedTLS depends on Mbed-TLS/TF-PSA-Crypto#154
 
+#### JWE
+
+LibJWT supports JWE (RFC 7516) Compact Serialization with a single recipient.
+A JWE uses two algorithms: a key management algorithm (``alg``) and a content
+encryption algorithm (``enc``).
+
+JWE key management ``alg``    | OpenSSL            | GnuTLS             | MbedTLS
+:---------------------------- | :----------------- | :----------------- | :--------
+``dir`` (Direct Encryption)   | :white_check_mark: | :white_check_mark: | :x:
+``A128KW`` ``A192KW`` ``A256KW`` | :white_check_mark: | :white_check_mark: | :x:
+``RSA-OAEP`` ``RSA-OAEP-256`` | :white_check_mark: | :white_check_mark: | :x:
+
+JWE content encryption ``enc`` | OpenSSL            | GnuTLS             | MbedTLS
+:----------------------------- | :----------------- | :----------------- | :--------
+``A128GCM`` ``A192GCM`` ``A256GCM`` | :white_check_mark: | :white_check_mark: | :x:
+``A128CBC-HS256`` ``A192CBC-HS384`` ``A256CBC-HS512`` | :white_check_mark: | :white_check_mark: | :x:
+
+> [!NOTE]
+> ``RSA1_5`` and ``zip`` (compression) are intentionally not supported.
+> ``ECDH-ES`` is planned for a later release. RSA key operations always use
+> OpenSSL (which is required for JWK parsing).
+
 ### Optional
 
 - [Check Library](https://github.com/libcheck/check/issues) (>= 0.9.10) for unit

--- a/doxygen/mainpage.dox
+++ b/doxygen/mainpage.dox
@@ -48,6 +48,26 @@ JWS Algorithm ``alg``         | OpenSSL                   | GnuTLS              
 
 ``*`` RSASSA-PSS support in MbedTLS depends on [TF-PSA-Ctypto#154](https://github.com/Mbed-TLS/TF-PSA-Crypto/pull/154)
 
+@subsubsection jwe_support JWE
+
+LibJWT supports JWE (RFC 7516) Compact Serialization with a single recipient,
+using a key management algorithm (``alg``) plus a content encryption
+algorithm (``enc``).
+
+JWE key management ``alg``    | OpenSSL                   | GnuTLS                    | MbedTLS
+:---------------------------- | :------------------------ | :------------------------ | :--------------
+``dir``                       | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
+``A128KW`` ``A192KW`` ``A256KW`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
+``RSA-OAEP`` ``RSA-OAEP-256`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
+
+JWE content encryption ``enc`` | OpenSSL                   | GnuTLS                    | MbedTLS
+:----------------------------- | :------------------------ | :------------------------ | :--------------
+``A128GCM`` ``A192GCM`` ``A256GCM`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
+``A128CBC-HS256`` ``A192CBC-HS384`` ``A256CBC-HS512`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
+
+@note ``RSA1_5`` and ``zip`` are intentionally not supported. ``ECDH-ES`` is
+planned for a later release.
+
 @subsection optional Optional
 
 - [Check Library](https://github.com/libcheck/check/issues) (>= 0.9.10) for unit


### PR DESCRIPTION
JWE (RFC 7516) is now implemented, so document the supported algorithms. Adds a JWE algorithm matrix to the README and Doxygen mainpage alongside the JWS one — key management (`dir`, `A*KW`, `RSA-OAEP`/`-256`) and content encryption (`A*GCM`, `A*CBC-HS*`) on OpenSSL and GnuTLS. Notes that `RSA1_5`/`zip` are intentionally unsupported, ECDH-ES is planned for later, and MbedTLS does not yet implement JWE.

Refs #158