### PR TITLE
docs: ECDH-ES (Direct) is now supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ JWE key management ``alg``    | OpenSSL            | GnuTLS             | MbedTL
 ``dir`` (Direct Encryption)   | :white_check_mark: | :white_check_mark: | :x:
 ``A128KW`` ``A192KW`` ``A256KW`` | :white_check_mark: | :white_check_mark: | :x:
 ``RSA-OAEP`` ``RSA-OAEP-256`` | :white_check_mark: | :white_check_mark: | :x:
+``ECDH-ES`` (Direct, EC P-256/384/521) | :white_check_mark: | :white_check_mark: | :x:
 
 JWE content encryption ``enc`` | OpenSSL            | GnuTLS             | MbedTLS
 :----------------------------- | :----------------- | :----------------- | :--------
@@ -73,8 +74,10 @@ JWE content encryption ``enc`` | OpenSSL            | GnuTLS             | MbedT
 
 > [!NOTE]
 > ``RSA1_5`` and ``zip`` (compression) are intentionally not supported.
-> ``ECDH-ES`` is planned for a later release. RSA key operations always use
-> OpenSSL (which is required for JWK parsing).
+> ``ECDH-ES`` is supported in Direct Key Agreement mode; the ``+A*KW``
+> variants and the X25519/X448 curves are planned for a later release. RSA
+> and ECDH-ES key operations always use OpenSSL (which is required for JWK
+> parsing).
 
 ### Optional
 

--- a/doxygen/mainpage.dox
+++ b/doxygen/mainpage.dox
@@ -59,6 +59,7 @@ JWE key management ``alg``    | OpenSSL                   | GnuTLS              
 ``dir``                       | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
 ``A128KW`` ``A192KW`` ``A256KW`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
 ``RSA-OAEP`` ``RSA-OAEP-256`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
+``ECDH-ES`` (Direct, P-256/384/521) | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
 
 JWE content encryption ``enc`` | OpenSSL                   | GnuTLS                    | MbedTLS
 :----------------------------- | :------------------------ | :------------------------ | :--------------
@@ -66,7 +67,8 @@ JWE content encryption ``enc`` | OpenSSL                   | GnuTLS             
 ``A128CBC-HS256`` ``A192CBC-HS384`` ``A256CBC-HS512`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
 
 @note ``RSA1_5`` and ``zip`` are intentionally not supported. ``ECDH-ES`` is
-planned for a later release.
+supported in Direct Key Agreement mode; the ``+A*KW`` variants and the
+X25519/X448 curves are planned for a later release.
 
 @subsection optional Optional
 


### PR DESCRIPTION
Update the JWE algorithm matrix in the README and Doxygen mainpage: ECDH-ES Direct Key Agreement on EC P-256/384/521 is implemented. The `+A*KW` variants and X25519/X448 curves remain planned for a later release.

Refs #158