### PR TITLE
jwe: ECDH-ES on the OKP X25519 and X448 curves

### DIFF
--- a/libjwt/jwe.c
+++ b/libjwt/jwe.c
@@ -270,10 +270,27 @@ const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
 	if (need == JWK_KEY_TYPE_NONE)
 		return "Unknown JWE key management algorithm"; // LCOV_EXCL_LINE
 
-	/* The key's actual type must match what the alg requires. This is the
-	 * authoritative gate and does not depend on optional JWK hints. */
-	if (jwks_item_kty(key) != need)
+	/* @rfc{7518,4.6} ECDH-ES accepts an EC key (P-256/384/521) or an OKP
+	 * key on an X-curve (X25519/X448). An OKP Ed-curve key is for signing
+	 * only and must be rejected. */
+	if (jwe_alg_is_ecdh(alg)) {
+		jwk_key_type_t kty = jwks_item_kty(key);
+		const char *crv = jwks_item_curve(key);
+
+		if (kty == JWK_KEY_TYPE_EC) {
+			/* Any supported EC curve is fine; the derive validates
+			 * the specific curve. */
+		} else if (kty == JWK_KEY_TYPE_OKP && crv != NULL &&
+			   (!strcmp(crv, "X25519") || !strcmp(crv, "X448"))) {
+			/* OKP X-curve: usable for key agreement. */
+		} else {
+			return "Key type/curve does not match ECDH-ES";
+		}
+	} else if (jwks_item_kty(key) != need) {
+		/* The key's actual type must match what the alg requires. This
+		 * is the authoritative gate and ignores optional JWK hints. */
 		return "Key type does not match JWE algorithm";
+	}
 
 	/* @rfc{7517,4.2} If "use" is set, it must be "enc" for JWE; a key
 	 * marked "sig" must never be used for encryption. */

--- a/libjwt/openssl/jwe.c
+++ b/libjwt/openssl/jwe.c
@@ -875,6 +875,79 @@ out:
 	return pkey;
 }
 
+/* Is this an OKP X-curve (X25519/X448) usable for ECDH? */
+static int crv_is_okp_x(const char *crv)
+{
+	return !strcmp(crv, "X25519") || !strcmp(crv, "X448");
+}
+
+/* Build an "epk" JWK object {kty:"OKP",crv,x} from an OKP public EVP_PKEY.
+ * OKP public keys are a single raw octet string, base64url'd as "x". */
+static jwt_json_t *okp_epk_to_json(EVP_PKEY *pkey, const char *crv)
+{
+	jwt_json_t *epk = NULL;
+	char_auto *x_b64 = NULL;
+	unsigned char *raw = NULL;
+	size_t rawlen = 0;
+
+	if (EVP_PKEY_get_raw_public_key(pkey, NULL, &rawlen) != 1)
+		return NULL; // LCOV_EXCL_LINE
+	raw = jwt_malloc(rawlen);
+	if (raw == NULL)
+		return NULL; // LCOV_EXCL_LINE
+	if (EVP_PKEY_get_raw_public_key(pkey, raw, &rawlen) != 1)
+		goto out; // LCOV_EXCL_LINE
+
+	if (jwt_base64uri_encode(&x_b64, (char *)raw, (int)rawlen) <= 0)
+		goto out; // LCOV_EXCL_LINE
+
+	epk = jwt_json_create();
+	if (epk == NULL)
+		goto out; // LCOV_EXCL_LINE
+	jwt_json_obj_set(epk, "kty", jwt_json_create_str("OKP"));
+	jwt_json_obj_set(epk, "crv", jwt_json_create_str(crv));
+	jwt_json_obj_set(epk, "x", jwt_json_create_str(x_b64));
+
+out:
+	jwt_freemem(raw);
+
+	return epk;
+}
+
+/* Build a public OKP EVP_PKEY from an "epk" JWK object. */
+static EVP_PKEY *okp_epk_from_json(jwt_json_t *epk, const char *want_crv)
+{
+	jwt_json_t *jkty, *jcrv, *jx;
+	const char *kty, *crv;
+	unsigned char *xb = NULL;
+	int xlen = 0;
+	EVP_PKEY *pkey = NULL;
+
+	jkty = jwt_json_obj_get(epk, "kty");
+	jcrv = jwt_json_obj_get(epk, "crv");
+	jx = jwt_json_obj_get(epk, "x");
+	if (!jkty || !jcrv || !jx || !jwt_json_is_string(jkty) ||
+	    !jwt_json_is_string(jcrv) || !jwt_json_is_string(jx))
+		return NULL; // LCOV_EXCL_LINE
+
+	kty = jwt_json_str_val(jkty);
+	crv = jwt_json_str_val(jcrv);
+	if (strcmp(kty, "OKP") || strcmp(crv, want_crv))
+		return NULL;
+
+	xb = jwt_base64uri_decode(jwt_json_str_val(jx), &xlen);
+	if (xb == NULL || xlen <= 0)
+		goto out; // LCOV_EXCL_LINE
+
+	pkey = EVP_PKEY_new_raw_public_key_ex(NULL, want_crv, NULL, xb,
+					      (size_t)xlen);
+
+out:
+	jwt_freemem(xb);
+
+	return pkey;
+}
+
 /* Raw ECDH shared secret Z between a private and a peer public EVP_PKEY. */
 static int ecdh_z(EVP_PKEY *priv, EVP_PKEY *peer, unsigned char **z,
 		  size_t *z_len)
@@ -942,20 +1015,30 @@ int openssl_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc,
 	if (out == NULL)
 		goto out; // LCOV_EXCL_LINE
 
+	int is_okp = crv_is_okp_x(crv);
+
 	if (for_encrypt) {
-		const char *ossl_crv = crv;
+		/* Ephemeral keypair on the recipient's curve. OKP curves
+		 * (X25519/X448) keygen directly by name; EC needs the group
+		 * set on the context. */
+		if (is_okp) {
+			gctx = EVP_PKEY_CTX_new_from_name(NULL, crv, NULL);
+			if (gctx == NULL || EVP_PKEY_keygen_init(gctx) <= 0)
+				goto out; // LCOV_EXCL_LINE
+		} else {
+			const char *ossl_crv = crv;
 
-		if (!strcmp(crv, "P-256")) ossl_crv = "prime256v1";
-		else if (!strcmp(crv, "P-384")) ossl_crv = "secp384r1";
-		else if (!strcmp(crv, "P-521")) ossl_crv = "secp521r1";
-		else goto out;
+			if (!strcmp(crv, "P-256")) ossl_crv = "prime256v1";
+			else if (!strcmp(crv, "P-384")) ossl_crv = "secp384r1";
+			else if (!strcmp(crv, "P-521")) ossl_crv = "secp521r1";
+			else goto out;
 
-		/* Ephemeral keypair on the recipient's curve. */
-		gctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
-		if (gctx == NULL || EVP_PKEY_keygen_init(gctx) <= 0)
-			goto out; // LCOV_EXCL_LINE
-		if (EVP_PKEY_CTX_set_group_name(gctx, ossl_crv) <= 0)
-			goto out; // LCOV_EXCL_LINE
+			gctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+			if (gctx == NULL || EVP_PKEY_keygen_init(gctx) <= 0)
+				goto out; // LCOV_EXCL_LINE
+			if (EVP_PKEY_CTX_set_group_name(gctx, ossl_crv) <= 0)
+				goto out; // LCOV_EXCL_LINE
+		}
 		if (EVP_PKEY_keygen(gctx, &eph) <= 0)
 			goto out; // LCOV_EXCL_LINE
 
@@ -964,7 +1047,8 @@ int openssl_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc,
 			goto out; // LCOV_EXCL_LINE
 
 		/* Emit the epk public half in the header. */
-		jepk = epk_to_json(eph, crv);
+		jepk = is_okp ? okp_epk_to_json(eph, crv)
+			      : epk_to_json(eph, crv);
 		if (jepk == NULL)
 			goto out; // LCOV_EXCL_LINE
 		jwt_json_obj_set(hdr, "epk", jepk);
@@ -972,7 +1056,8 @@ int openssl_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc,
 		jepk = jwt_json_obj_get(hdr, "epk");
 		if (jepk == NULL)
 			goto out;
-		peer = epk_from_json(jepk, crv);
+		peer = is_okp ? okp_epk_from_json(jepk, crv)
+			      : epk_from_json(jepk, crv);
 		if (peer == NULL)
 			goto out;
 		/* Z = ECDH(recipient_priv, eph_pub). */

--- a/libjwt/openssl/jwk-parse.c
+++ b/libjwt/openssl/jwk-parse.c
@@ -243,6 +243,10 @@ int openssl_process_eddsa(jwt_json_t *jwk, jwk_item_t *item)
 		pctx = EVP_PKEY_CTX_new_from_name(NULL, "ED25519", NULL);
 	else if (!strcmp(crv_str, "Ed448"))
 		pctx = EVP_PKEY_CTX_new_from_name(NULL, "ED448", NULL);
+	else if (!strcmp(crv_str, "X25519"))
+		pctx = EVP_PKEY_CTX_new_from_name(NULL, "X25519", NULL);
+	else if (!strcmp(crv_str, "X448"))
+		pctx = EVP_PKEY_CTX_new_from_name(NULL, "X448", NULL);
 	else {
 		jwt_write_error(item,
                         "Unknown curve [%s] (note, curves are case sensitive)",

--- a/tests/jwe_ecdh.c
+++ b/tests/jwe_ecdh.c
@@ -414,6 +414,112 @@ START_TEST(missing_epk)
 }
 END_TEST
 
+/* @rfc{7518,4.6} ECDH-ES on the OKP X-curves (X25519/X448). */
+static void okp_roundtrip(const char *keyfile, jwe_key_alg_t alg,
+			  jwe_enc_t enc)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	read_json(keyfile);
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, alg, enc, g_item), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, alg, enc, g_item), 0);
+	pt = jwe_checker_decrypt(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_int_eq(pt_len, strlen(PT));
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	free(pt);
+	free_key();
+}
+
+START_TEST(x25519_direct)
+{
+	SET_OPS();
+	okp_roundtrip("okp_x25519_enc.json", JWE_ALG_ECDH_ES, JWE_ENC_A256GCM);
+}
+END_TEST
+
+START_TEST(x25519_cbc)
+{
+	SET_OPS();
+	okp_roundtrip("okp_x25519_enc.json", JWE_ALG_ECDH_ES,
+		      JWE_ENC_A128CBC_HS256);
+}
+END_TEST
+
+START_TEST(x25519_kw)
+{
+	SET_OPS();
+	okp_roundtrip("okp_x25519_enc.json", JWE_ALG_ECDH_ES_A256KW,
+		      JWE_ENC_A256GCM);
+}
+END_TEST
+
+START_TEST(x448_direct)
+{
+	SET_OPS();
+	okp_roundtrip("okp_x448_enc.json", JWE_ALG_ECDH_ES, JWE_ENC_A256GCM);
+}
+END_TEST
+
+START_TEST(ed25519_rejected)
+{
+	jwe_builder_auto_t *builder = NULL;
+
+	SET_OPS();
+
+	/* An Ed25519 (signing) OKP key, even marked use:enc, must not be
+	 * usable for ECDH-ES key agreement. */
+	read_json("eddsa_key_ed25519_enc.json");
+	builder = jwe_builder_new();
+	ck_assert_int_ne(jwe_builder_setkey(builder, JWE_ALG_ECDH_ES,
+					    JWE_ENC_A256GCM, g_item), 0);
+	free_key();
+}
+END_TEST
+
+START_TEST(okp_curve_mismatch)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	SET_OPS();
+
+	/* Encrypt to an X25519 recipient... */
+	read_json("okp_x25519_enc.json");
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_ECDH_ES,
+					    JWE_ENC_A256GCM, g_item), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+	free_key();
+
+	/* ...decrypt with an X448 key: the epk curve will not match. */
+	read_json("okp_x448_enc.json");
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_ECDH_ES,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt(checker, tok, &pt_len);
+	ck_assert_ptr_null(pt);
+	free_key();
+}
+END_TEST
+
 /* Both backends route ECDH-ES to the OpenSSL EVP_PKEY, so a token from one
  * provider must decrypt under all. */
 START_TEST(interop)
@@ -481,6 +587,12 @@ static Suite *libjwt_suite(const char *title)
 	tcase_add_loop_test(tc_core, decrypt_nonempty_ek, 0, i);
 	tcase_add_loop_test(tc_core, unsupported_curve, 0, i);
 	tcase_add_loop_test(tc_core, missing_epk, 0, i);
+	tcase_add_loop_test(tc_core, x25519_direct, 0, i);
+	tcase_add_loop_test(tc_core, x25519_cbc, 0, i);
+	tcase_add_loop_test(tc_core, x25519_kw, 0, i);
+	tcase_add_loop_test(tc_core, x448_direct, 0, i);
+	tcase_add_loop_test(tc_core, ed25519_rejected, 0, i);
+	tcase_add_loop_test(tc_core, okp_curve_mismatch, 0, i);
 	tcase_add_test(tc_core, interop);
 
 	tcase_set_timeout(tc_core, 30);

--- a/tests/keys/eddsa_key_ed25519_enc.json
+++ b/tests/keys/eddsa_key_ed25519_enc.json
@@ -1,0 +1,11 @@
+{
+  "kid": "7dc4a07e-51b6-47dd-ae8c-2da0ef921818",
+  "kty": "OKP",
+  "crv": "Ed25519",
+  "x": "HUj-14kN6N4i5qNVkfEhwKiCf-tSrvRHstQdtV8a5QM",
+  "d": "XY5oUZqGWVZhX7J09hG-rRnAKXiw1g_aBh-Bc52KZ_Y",
+  "use": "enc",
+  "key_ops": [
+    "deriveKey"
+  ]
+}

--- a/tests/keys/okp_x25519_enc.json
+++ b/tests/keys/okp_x25519_enc.json
@@ -1,0 +1,11 @@
+{
+  "kty": "OKP",
+  "crv": "X25519",
+  "use": "enc",
+  "key_ops": [
+    "deriveKey",
+    "deriveBits"
+  ],
+  "x": "S46Jc4ib5np5zMd8F4xCJL3wLqM_mYlgGGhw0XQAsBU",
+  "d": "8HS-8uSD0zo8pLVHOs3UQh6R57knGnjMgf7iCCknPGs"
+}

--- a/tests/keys/okp_x448_enc.json
+++ b/tests/keys/okp_x448_enc.json
@@ -1,0 +1,11 @@
+{
+  "kty": "OKP",
+  "crv": "X448",
+  "use": "enc",
+  "key_ops": [
+    "deriveKey",
+    "deriveBits"
+  ],
+  "x": "-eNBPMKYtcVxRqF8Xk2bVBdBvjAKm1gaC8LQiguNmN69hfQ5t-zEmVob_8IPyBRklLzJMWgCd2A",
+  "d": "6EYeCbX9ZymPzYOQ2M4xc67yRhJ1hxBEIZTR7LtL2DMbe8PFJhOMyv1dtamsSj5rYKmEWLURi_Y"
+}


### PR DESCRIPTION
Second part of #256 — extends ECDH-ES (RFC 7518 §4.6) to the OKP key-agreement curves **X25519** and **X448**, alongside the EC curves already supported.

## What's here
- The JWK parser now recognizes the X25519/X448 OKP curves (in addition to Ed25519/Ed448).
- **Key-usage gating** accepts an EC key or an OKP key on an X-curve for ECDH-ES, and **rejects an OKP Ed-curve key** — so an Ed25519 key, even marked `use:"enc"`, cannot be used for key agreement.
- `openssl_ecdh_derive` branches on the curve: OKP ephemeral keys are generated by curve name, and the `epk` is emitted/parsed as an OKP JWK (`{kty:"OKP",crv,x}`) with the single raw public-key octet string. The shared-secret derivation and Concat KDF are unchanged.

Works in both **Direct** and **+A*KW** modes, with GCM and CBC-HMAC.

## Tests
X25519 (Direct, CBC, +A256KW) and X448 (Direct) round-trips; an Ed25519 key rejected for ECDH-ES; an X25519-vs-X448 curve mismatch.

- ✅ Full suite green (19/19)
- ✅ **100% line coverage**; verified under Jansson and json-c

An X-curve key remains unusable for EdDSA signing (the JWS sign path rejects it). Remaining for #256: builder `apu`/`apv` emission.

Refs #256