### PR TITLE
jwe: emit ECDH-ES apu/apv PartyInfo from the builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ JWE key management ``alg``    | OpenSSL            | GnuTLS             | MbedTL
 ``dir`` (Direct Encryption)   | :white_check_mark: | :white_check_mark: | :x:
 ``A128KW`` ``A192KW`` ``A256KW`` | :white_check_mark: | :white_check_mark: | :x:
 ``RSA-OAEP`` ``RSA-OAEP-256`` | :white_check_mark: | :white_check_mark: | :x:
-``ECDH-ES`` (Direct, EC P-256/384/521) | :white_check_mark: | :white_check_mark: | :x:
+``ECDH-ES`` (+ ``+A128KW``/``+A192KW``/``+A256KW``) | :white_check_mark: | :white_check_mark: | :x:
 
 JWE content encryption ``enc`` | OpenSSL            | GnuTLS             | MbedTLS
 :----------------------------- | :----------------- | :----------------- | :--------
@@ -73,11 +73,11 @@ JWE content encryption ``enc`` | OpenSSL            | GnuTLS             | MbedT
 ``A128CBC-HS256`` ``A192CBC-HS384`` ``A256CBC-HS512`` | :white_check_mark: | :white_check_mark: | :x:
 
 > [!NOTE]
-> ``RSA1_5`` and ``zip`` (compression) are intentionally not supported.
-> ``ECDH-ES`` is supported in Direct Key Agreement mode; the ``+A*KW``
-> variants and the X25519/X448 curves are planned for a later release. RSA
-> and ECDH-ES key operations always use OpenSSL (which is required for JWK
-> parsing).
+> ``ECDH-ES`` supports both Direct Key Agreement and the ``+A*KW`` key
+> wrapping modes, on the EC curves P-256/384/521 and the OKP curves
+> X25519/X448, with optional ``apu``/``apv`` PartyInfo. ``RSA1_5`` and
+> ``zip`` (compression) are intentionally not supported. RSA and ECDH-ES key
+> operations always use OpenSSL (which is required for JWK parsing).
 
 ### Optional
 

--- a/doxygen/mainpage.dox
+++ b/doxygen/mainpage.dox
@@ -59,16 +59,17 @@ JWE key management ``alg``    | OpenSSL                   | GnuTLS              
 ``dir``                       | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
 ``A128KW`` ``A192KW`` ``A256KW`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
 ``RSA-OAEP`` ``RSA-OAEP-256`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
-``ECDH-ES`` (Direct, P-256/384/521) | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
+``ECDH-ES`` (+ ``+A128KW``/``+A192KW``/``+A256KW``) | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
 
 JWE content encryption ``enc`` | OpenSSL                   | GnuTLS                    | MbedTLS
 :----------------------------- | :------------------------ | :------------------------ | :--------------
 ``A128GCM`` ``A192GCM`` ``A256GCM`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
 ``A128CBC-HS256`` ``A192CBC-HS384`` ``A256CBC-HS512`` | \emoji :white_check_mark: | \emoji :white_check_mark: | \emoji :x:
 
-@note ``RSA1_5`` and ``zip`` are intentionally not supported. ``ECDH-ES`` is
-supported in Direct Key Agreement mode; the ``+A*KW`` variants and the
-X25519/X448 curves are planned for a later release.
+@note ``ECDH-ES`` supports both Direct Key Agreement and ``+A*KW`` key
+wrapping, on the EC curves P-256/384/521 and the OKP curves X25519/X448, with
+optional ``apu``/``apv`` PartyInfo. ``RSA1_5`` and ``zip`` are intentionally
+not supported.
 
 @subsection optional Optional
 

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -1464,6 +1464,27 @@ int jwe_builder_setkey(jwe_builder_t *builder, jwe_key_alg_t alg,
 		       jwe_enc_t enc, const jwk_item_t *key);
 
 /**
+ * @brief Set the ECDH-ES PartyUInfo / PartyVInfo
+ *
+ * For ECDH-ES key agreement (@ref JWE_ALG_ECDH_ES and the ``+A*KW``
+ * variants), these optional octet strings are bound into the Concat KDF and
+ * emitted as the ``"apu"`` and ``"apv"`` header parameters. They have no
+ * effect for non-ECDH-ES algorithms. Pass NULL (with length 0) to leave one
+ * unset. Calling this again replaces any previous values.
+ *
+ * @param builder Pointer to a JWE builder object
+ * @param apu PartyUInfo octets, or NULL
+ * @param apu_len Length of @p apu in bytes
+ * @param apv PartyVInfo octets, or NULL
+ * @param apv_len Length of @p apv in bytes
+ * @return 0 on success, non-zero otherwise with error set in the builder
+ */
+JWT_EXPORT
+int jwe_builder_set_partyinfo(jwe_builder_t *builder,
+			      const unsigned char *apu, size_t apu_len,
+			      const unsigned char *apv, size_t apv_len);
+
+/**
  * @brief Encrypt a plaintext into a Compact Serialization JWE
  *
  * Produces a five-part JWE using the key and algorithms configured with

--- a/libjwt/jwe-common.c
+++ b/libjwt/jwe-common.c
@@ -37,6 +37,8 @@ void FUNC(free)(jwe_common_t *__cmd)
 	jwt_freemem(__cmd->c.iv);
 	jwt_freemem(__cmd->c.ct);
 	jwt_freemem(__cmd->c.tag);
+	jwt_freemem(__cmd->c.apu);
+	jwt_freemem(__cmd->c.apv);
 
 	memset(__cmd, 0, sizeof(*__cmd));
 
@@ -135,6 +137,43 @@ int FUNC(setkey)(jwe_common_t *__cmd, jwe_key_alg_t alg, jwe_enc_t enc,
 }
 
 #ifdef JWE_BUILDER
+/* @rfc{7518,4.6.2} Store apu/apv as base64url for emission in the header and
+ * binding into the Concat KDF. NULL/0 leaves a field unset; calling again
+ * replaces previous values. */
+int FUNC(set_partyinfo)(jwe_common_t *__cmd,
+			const unsigned char *apu, size_t apu_len,
+			const unsigned char *apv, size_t apv_len)
+{
+	char *apu_b64 = NULL, *apv_b64 = NULL;
+
+	if (__cmd == NULL)
+		return 1;
+
+	if (apu && apu_len &&
+	    jwt_base64uri_encode(&apu_b64, (const char *)apu, (int)apu_len) <= 0)
+		goto oom; // LCOV_EXCL_LINE
+	if (apv && apv_len &&
+	    jwt_base64uri_encode(&apv_b64, (const char *)apv, (int)apv_len) <= 0)
+		goto oom; // LCOV_EXCL_LINE
+
+	jwt_freemem(__cmd->c.apu);
+	jwt_freemem(__cmd->c.apv);
+	__cmd->c.apu = apu_b64;
+	__cmd->c.apv = apv_b64;
+
+	return 0;
+
+	// LCOV_EXCL_START
+oom:
+	jwt_freemem(apu_b64);
+	jwt_freemem(apv_b64);
+	jwt_write_error(__cmd, "Error encoding apu/apv");
+	return 1;
+	// LCOV_EXCL_STOP
+}
+#endif
+
+#ifdef JWE_BUILDER
 /* @rfc{7516,5.1} Encrypt @plaintext into a Compact Serialization JWE. This
  * stage implements the dir + AES-GCM path. */
 char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
@@ -173,6 +212,20 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 			     jwt_json_create_str(jwe_enc_str(__cmd->c.enc)))) {
 		jwt_write_error(__cmd, "Error building JWE header"); // LCOV_EXCL_LINE
 		return NULL; // LCOV_EXCL_LINE
+	}
+
+	/* @rfc{7518,4.6.2} For ECDH-ES, emit any apu/apv into the header before
+	 * the key agreement runs, so they are bound into the Concat KDF (and,
+	 * being part of the protected header, into the AAD). */
+	if (jwe_alg_is_ecdh(__cmd->c.key_alg)) {
+		if (__cmd->c.apu &&
+		    jwt_json_obj_set(hdr, "apu",
+				     jwt_json_create_str(__cmd->c.apu)))
+			goto oom; // LCOV_EXCL_LINE
+		if (__cmd->c.apv &&
+		    jwt_json_obj_set(hdr, "apv",
+				     jwt_json_create_str(__cmd->c.apv)))
+			goto oom; // LCOV_EXCL_LINE
 	}
 
 	/* @rfc{7518,4.6} ECDH-ES (Direct): derive the CEK and add the "epk"

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -110,6 +110,11 @@ struct jwe_common {
 	jwt_callback_t cb;
 	void *cb_ctx;
 
+	/* @rfc{7518,4.6.2} Optional ECDH-ES PartyUInfo/PartyVInfo, stored as
+	 * the base64url strings emitted in the "apu"/"apv" headers. */
+	char *apu;
+	char *apv;
+
 	/* The five JWE Compact Serialization components, populated during
 	 * encrypt (builder) or decrypt (checker). Owned by this struct. */
 	unsigned char *cek;	/* Content Encryption Key			*/

--- a/libjwt/openssl/jwe.c
+++ b/libjwt/openssl/jwe.c
@@ -1066,14 +1066,13 @@ int openssl_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc,
 	}
 
 	/* apu/apv (optional PartyU/PartyV info) — fed to the Concat KDF as-is.
-	 * The builder does not emit them yet, so the decode bodies are only
-	 * reachable once apu/apv emission is added. */
+	 * (the builder emits them via jwe_builder_set_partyinfo). */
 	japu = jwt_json_obj_get(hdr, "apu");
-	if (japu && jwt_json_is_string(japu)) // LCOV_EXCL_LINE
-		apu = jwt_base64uri_decode(jwt_json_str_val(japu), &apu_len); // LCOV_EXCL_LINE
+	if (japu && jwt_json_is_string(japu))
+		apu = jwt_base64uri_decode(jwt_json_str_val(japu), &apu_len);
 	japv = jwt_json_obj_get(hdr, "apv");
-	if (japv && jwt_json_is_string(japv)) // LCOV_EXCL_LINE
-		apv = jwt_base64uri_decode(jwt_json_str_val(japv), &apv_len); // LCOV_EXCL_LINE
+	if (japv && jwt_json_is_string(japv))
+		apv = jwt_base64uri_decode(jwt_json_str_val(japv), &apv_len);
 
 	if (concat_kdf(z, z_len, algid, apu, apu_len < 0 ? 0 : (size_t)apu_len,
 		       apv, apv_len < 0 ? 0 : (size_t)apv_len, keydatalen, out))

--- a/tests/jwe_ecdh.c
+++ b/tests/jwe_ecdh.c
@@ -520,6 +520,108 @@ START_TEST(okp_curve_mismatch)
 }
 END_TEST
 
+START_TEST(partyinfo)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+	const unsigned char apu[] = "Alice";
+	const unsigned char apv[] = "Bob";
+
+	SET_OPS();
+	read_json("ec_key_prime256v1_enc.json");
+
+	/* @rfc{7518,4.6.2} With apu/apv set, they are emitted in the header and
+	 * bound into the Concat KDF. The same header carries them on decrypt,
+	 * so the round-trip succeeds and "apu"/"apv" appear in the token. */
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_ECDH_ES,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_partyinfo(builder, apu, 5, apv, 3), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_ECDH_ES,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_int_eq(pt_len, strlen(PT));
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	free(pt);
+	free_key();
+}
+END_TEST
+
+START_TEST(partyinfo_binds_kdf)
+{
+	jwe_builder_auto_t *b_with = NULL, *b_without = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok_with = NULL, *tok_without = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0, hlen_with = 0, hlen_without = 0;
+	const unsigned char apu[] = "Alice";
+
+	SET_OPS();
+	read_json("ec_key_prime256v1_enc.json");
+
+	/* A token built WITH apu and one WITHOUT must have different protected
+	 * headers (apu is present only in the first), proving it is emitted. */
+	b_with = jwe_builder_new();
+	jwe_builder_setkey(b_with, JWE_ALG_ECDH_ES, JWE_ENC_A256GCM, g_item);
+	jwe_builder_set_partyinfo(b_with, apu, 5, NULL, 0);
+	tok_with = jwe_builder_generate(b_with, (const unsigned char *)PT,
+					strlen(PT));
+	ck_assert_ptr_nonnull(tok_with);
+
+	b_without = jwe_builder_new();
+	jwe_builder_setkey(b_without, JWE_ALG_ECDH_ES, JWE_ENC_A256GCM, g_item);
+	tok_without = jwe_builder_generate(b_without, (const unsigned char *)PT,
+					   strlen(PT));
+	ck_assert_ptr_nonnull(tok_without);
+
+	/* Protected-header segments differ in length (apu adds a member). */
+	hlen_with = strchr(tok_with, '.') - tok_with;
+	hlen_without = strchr(tok_without, '.') - tok_without;
+	ck_assert_int_ne(hlen_with, hlen_without);
+
+	/* And the apu token round-trips (the same header carries apu, so the
+	 * KDF agrees on both ends). */
+	checker = jwe_checker_new();
+	jwe_checker_setkey(checker, JWE_ALG_ECDH_ES, JWE_ENC_A256GCM, g_item);
+	pt = jwe_checker_decrypt(checker, tok_with, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_mem_eq(pt, PT, strlen(PT));
+
+	free(pt);
+	free_key();
+}
+END_TEST
+
+START_TEST(partyinfo_replace)
+{
+	jwe_builder_auto_t *builder = NULL;
+	const unsigned char apu[] = "Alice";
+
+	SET_OPS();
+	read_json("ec_key_prime256v1_enc.json");
+
+	builder = jwe_builder_new();
+	/* Setting partyinfo (incl. replacing and NULL-clearing) and the
+	 * NULL-object guard. */
+	ck_assert_int_eq(jwe_builder_set_partyinfo(builder, apu, 5, NULL, 0), 0);
+	ck_assert_int_eq(jwe_builder_set_partyinfo(builder, NULL, 0, apu, 5), 0);
+	ck_assert_int_eq(jwe_builder_set_partyinfo(builder, NULL, 0, NULL, 0), 0);
+	ck_assert_int_ne(jwe_builder_set_partyinfo(NULL, apu, 5, NULL, 0), 0);
+
+	free_key();
+}
+END_TEST
+
 /* Both backends route ECDH-ES to the OpenSSL EVP_PKEY, so a token from one
  * provider must decrypt under all. */
 START_TEST(interop)
@@ -593,6 +695,9 @@ static Suite *libjwt_suite(const char *title)
 	tcase_add_loop_test(tc_core, x448_direct, 0, i);
 	tcase_add_loop_test(tc_core, ed25519_rejected, 0, i);
 	tcase_add_loop_test(tc_core, okp_curve_mismatch, 0, i);
+	tcase_add_loop_test(tc_core, partyinfo, 0, i);
+	tcase_add_loop_test(tc_core, partyinfo_binds_kdf, 0, i);
+	tcase_add_loop_test(tc_core, partyinfo_replace, 0, i);
 	tcase_add_test(tc_core, interop);
 
 	tcase_set_timeout(tc_core, 30);


### PR DESCRIPTION
Final part of #256 — adds `jwe_builder_set_partyinfo()` so an application can supply the optional ECDH-ES **PartyUInfo / PartyVInfo** octet strings. They are base64url-encoded into the `"apu"`/`"apv"` protected-header parameters and, being part of the header, bound into the **Concat KDF** and the AAD. No effect for non-ECDH-ES algorithms; the call replaces any previous values.

The decrypt-side apu/apv handling already existed (previously `LCOV_EXCL`'d); this wires up the producing side and removes those exclusions.

**This completes ECDH-ES:** Direct and `+A*KW` modes, EC P-256/384/521 and OKP X25519/X448 curves, and `apu`/`apv`. Docs updated to match.

## Tests
A round-trip with apu/apv set; a check that apu changes the protected header; and the set/replace/NULL-clear/NULL-object paths.

- ✅ Full suite green (19/19)
- ✅ **100% line coverage**; verified under Jansson and json-c

closes #256