### PR TITLE
jwe: recipient list refactor (prep for JSON serialization, #262)

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -120,6 +120,23 @@ typedef enum {
 	JWE_ENC_INVAL,		/**< An invalid algorithm from the caller or the token */
 } jwe_enc_t;
 
+/** @ingroup jwt_alg_grp
+ * @brief JWE serialization formats
+ *
+ * RFC 7516 defines two serializations. The Compact Serialization is the
+ * five-part ``header.encrypted_key.iv.ciphertext.tag`` string and supports a
+ * single recipient. The JSON Serialization is a JSON object; its Flattened
+ * form is the single-recipient special case, and its General form carries a
+ * ``recipients`` array for one or more recipients.
+ *
+ * @rfc{7516,7}
+ */
+typedef enum {
+	JWE_FORMAT_COMPACT = 0,	/**< @rfc{7516,7.1} Compact Serialization (default) */
+	JWE_FORMAT_JSON_FLAT,	/**< @rfc{7516,7.2.2} Flattened JSON Serialization */
+	JWE_FORMAT_JSON_GENERAL,/**< @rfc{7516,7.2.1} General JSON Serialization */
+} jwe_serialization_t;
+
 /** @ingroup jwt_crypto_grp
  * @brief  Different providers for crypto operations
  *

--- a/libjwt/jwe-common.c
+++ b/libjwt/jwe-common.c
@@ -24,21 +24,30 @@
 
 void FUNC(free)(jwe_common_t *__cmd)
 {
+	struct jwe_recipient *r, *tmp;
+
 	if (__cmd == NULL)
 		return;
 
 	jwt_json_release(__cmd->c.payload);
 	jwt_json_release(__cmd->c.headers);
+	jwt_json_release(__cmd->c.unprotected);
+
+	/* @rfc{7516,7.2.1} Free every recipient (and its owned key material). */
+	list_for_each_entry_safe(r, tmp, &__cmd->c.recipients, node) {
+		list_del(&r->node);
+		jwe_recipient_free(r);
+	}
 
 	/* Scrub sensitive key material. The CEK is secret; the other
 	 * components are not, but free them all here. */
 	jwt_scrub_and_free(__cmd->c.cek, __cmd->c.cek_len);
-	jwt_freemem(__cmd->c.enckey);
 	jwt_freemem(__cmd->c.iv);
 	jwt_freemem(__cmd->c.ct);
 	jwt_freemem(__cmd->c.tag);
-	jwt_freemem(__cmd->c.apu);
-	jwt_freemem(__cmd->c.apv);
+	jwt_scrub_and_free(__cmd->c.aad, __cmd->c.aad_len);
+	jwt_freemem(__cmd->c.aad_b64);
+	jwt_scrub_and_free(__cmd->c.recovered_aad, __cmd->c.recovered_aad_len);
 
 	memset(__cmd, 0, sizeof(*__cmd));
 
@@ -53,6 +62,9 @@ jwe_common_t *FUNC(new)(void)
 		return NULL; // LCOV_EXCL_LINE
 
 	memset(__cmd, 0, sizeof(*__cmd));
+
+	INIT_LIST_HEAD(&__cmd->c.recipients);
+	__cmd->c.format = JWE_FORMAT_COMPACT;
 
 	__cmd->c.payload = jwt_json_create();
 	__cmd->c.headers = jwt_json_create();
@@ -97,6 +109,7 @@ void FUNC(error_clear)(jwe_common_t *__cmd)
 int FUNC(setkey)(jwe_common_t *__cmd, jwe_key_alg_t alg, jwe_enc_t enc,
 		 const jwk_item_t *key)
 {
+	struct jwe_recipient *r;
 	const char *reason;
 
 	if (__cmd == NULL)
@@ -129,9 +142,17 @@ int FUNC(setkey)(jwe_common_t *__cmd, jwe_key_alg_t alg, jwe_enc_t enc,
 		return 1;
 	}
 
-	__cmd->c.key_alg = alg;
+	/* @rfc{7516,7.2.1} setkey configures the first (and, for Compact, only)
+	 * recipient. Calling it again replaces that recipient's alg/key. */
+	r = jwe_recipient_first_or_add(&__cmd->c);
+	if (r == NULL) {
+		jwt_write_error(__cmd, "Error allocating memory"); // LCOV_EXCL_LINE
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	r->key_alg = alg;
+	r->key = key;
 	__cmd->c.enc = enc;
-	__cmd->c.key = key;
 
 	return 0;
 }
@@ -144,10 +165,19 @@ int FUNC(set_partyinfo)(jwe_common_t *__cmd,
 			const unsigned char *apu, size_t apu_len,
 			const unsigned char *apv, size_t apv_len)
 {
+	struct jwe_recipient *r;
 	char *apu_b64 = NULL, *apv_b64 = NULL;
 
 	if (__cmd == NULL)
 		return 1;
+
+	/* @rfc{7518,4.6.2} Party info targets the first recipient (the one set
+	 * by setkey). Create it if setkey has not run yet. */
+	r = jwe_recipient_first_or_add(&__cmd->c);
+	if (r == NULL) {
+		jwt_write_error(__cmd, "Error allocating memory"); // LCOV_EXCL_LINE
+		return 1; // LCOV_EXCL_LINE
+	}
 
 	if (apu && apu_len &&
 	    jwt_base64uri_encode(&apu_b64, (const char *)apu, (int)apu_len) <= 0)
@@ -156,10 +186,10 @@ int FUNC(set_partyinfo)(jwe_common_t *__cmd,
 	    jwt_base64uri_encode(&apv_b64, (const char *)apv, (int)apv_len) <= 0)
 		goto oom; // LCOV_EXCL_LINE
 
-	jwt_freemem(__cmd->c.apu);
-	jwt_freemem(__cmd->c.apv);
-	__cmd->c.apu = apu_b64;
-	__cmd->c.apv = apv_b64;
+	jwt_freemem(r->apu);
+	jwt_freemem(r->apv);
+	r->apu = apu_b64;
+	r->apv = apv_b64;
 
 	return 0;
 
@@ -179,6 +209,7 @@ oom:
 char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 		     size_t plaintext_len)
 {
+	struct jwe_recipient *recip;
 	jwt_json_auto_t *hdr = NULL;
 	char_auto *hdr_json = NULL, *hdr_b64 = NULL, *ek_b64 = NULL;
 	char_auto *iv_b64 = NULL, *ct_b64 = NULL, *tag_b64 = NULL;
@@ -192,7 +223,11 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 	if (__cmd == NULL)
 		return NULL;
 
-	if (__cmd->c.key == NULL || __cmd->c.key_alg == JWE_ALG_NONE) {
+	/* @rfc{7516,7.2.1} The Compact Serialization has exactly one recipient,
+	 * configured via setkey. */
+	recip = jwe_recipient_first(&__cmd->c);
+	if (recip == NULL || recip->key == NULL ||
+	    recip->key_alg == JWE_ALG_NONE) {
 		jwt_write_error(__cmd, "No key/algorithm set");
 		return NULL;
 	}
@@ -207,7 +242,7 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 	if (hdr == NULL)
 		goto oom; // LCOV_EXCL_LINE
 	if (jwt_json_obj_set(hdr, "alg",
-			     jwt_json_create_str(jwe_alg_str(__cmd->c.key_alg))) ||
+			     jwt_json_create_str(jwe_alg_str(recip->key_alg))) ||
 	    jwt_json_obj_set(hdr, "enc",
 			     jwt_json_create_str(jwe_enc_str(__cmd->c.enc)))) {
 		jwt_write_error(__cmd, "Error building JWE header"); // LCOV_EXCL_LINE
@@ -217,34 +252,34 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 	/* @rfc{7518,4.6.2} For ECDH-ES, emit any apu/apv into the header before
 	 * the key agreement runs, so they are bound into the Concat KDF (and,
 	 * being part of the protected header, into the AAD). */
-	if (jwe_alg_is_ecdh(__cmd->c.key_alg)) {
-		if (__cmd->c.apu &&
+	if (jwe_alg_is_ecdh(recip->key_alg)) {
+		if (recip->apu &&
 		    jwt_json_obj_set(hdr, "apu",
-				     jwt_json_create_str(__cmd->c.apu)))
+				     jwt_json_create_str(recip->apu)))
 			goto oom; // LCOV_EXCL_LINE
-		if (__cmd->c.apv &&
+		if (recip->apv &&
 		    jwt_json_obj_set(hdr, "apv",
-				     jwt_json_create_str(__cmd->c.apv)))
+				     jwt_json_create_str(recip->apv)))
 			goto oom; // LCOV_EXCL_LINE
 	}
 
 	/* @rfc{7518,4.6} ECDH-ES (Direct): derive the CEK and add the "epk"
 	 * to the header BEFORE it is serialized, since the header bytes are
 	 * the AAD. The Encrypted Key stays empty (like dir). */
-	if (jwe_alg_is_ecdh(__cmd->c.key_alg)) {
+	if (jwe_alg_is_ecdh(recip->key_alg)) {
 		/* @rfc{7518,4.6} Derive the agreed key and emit "epk" while the
 		 * header object can still be modified. For Direct mode the
 		 * agreed key is the CEK; for +A*KW it is the KEK. */
 		unsigned char *agreed = NULL;
 		size_t agreed_len = 0;
 
-		if (jwe_ecdh_derive(__cmd->c.key_alg, __cmd->c.enc,
-				    __cmd->c.key, 1, hdr, &agreed, &agreed_len)) {
+		if (jwe_ecdh_derive(recip->key_alg, __cmd->c.enc,
+				    recip->key, 1, hdr, &agreed, &agreed_len)) {
 			jwt_write_error(__cmd, "ECDH-ES key agreement failed");
 			return NULL;
 		}
 
-		if (jwe_alg_is_ecdh_direct(__cmd->c.key_alg)) {
+		if (jwe_alg_is_ecdh_direct(recip->key_alg)) {
 			cek = agreed;
 			cek_len = agreed_len;
 		} else {
@@ -278,15 +313,15 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 
 	/* @rfc{7516,5.1} Produce the CEK and the JWE Encrypted Key per the key
 	 * management algorithm. */
-	if (jwe_alg_is_ecdh(__cmd->c.key_alg)) {
+	if (jwe_alg_is_ecdh(recip->key_alg)) {
 		/* ECDH-ES: the CEK (Direct) or CEK+Encrypted Key (+A*KW) was
 		 * already produced above, before the header was serialized. */
-	} else if (__cmd->c.key_alg == JWE_ALG_DIR) {
+	} else if (recip->key_alg == JWE_ALG_DIR) {
 		/* dir: the CEK is the shared symmetric key; Encrypted Key is
 		 * empty. */
 		size_t need = jwe_enc_cek_len(__cmd->c.enc);
 
-		ret = jwks_item_key_oct(__cmd->c.key, &k, &cek_len);
+		ret = jwks_item_key_oct(recip->key, &k, &cek_len);
 		if (ret || k == NULL || cek_len != need) {
 			jwt_write_error(__cmd,
 				"dir key length does not match enc");
@@ -305,7 +340,7 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 			return NULL;
 			// LCOV_EXCL_STOP
 		}
-		if (jwe_encrypt_cek(__cmd->c.key_alg, __cmd->c.key, cek, cek_len,
+		if (jwe_encrypt_cek(recip->key_alg, recip->key, cek, cek_len,
 				    &enckey, &enckey_len)) {
 			jwt_write_error(__cmd, "Could not encrypt the CEK");
 			goto fail;
@@ -400,6 +435,7 @@ static char *split_dot(char *p)
 unsigned char *FUNC(decrypt)(jwe_common_t *__cmd, const char *token,
 			     size_t *plaintext_len)
 {
+	struct jwe_recipient *recip;
 	char_auto *dup = NULL;
 	char *p_hdr, *p_ek, *p_iv, *p_ct, *p_tag, *rest;
 	jwt_json_auto_t *hdr = NULL;
@@ -422,7 +458,11 @@ unsigned char *FUNC(decrypt)(jwe_common_t *__cmd, const char *token,
 		return NULL;
 	}
 
-	if (__cmd->c.key == NULL || __cmd->c.key_alg == JWE_ALG_NONE) {
+	/* @rfc{7516,7.1} The checker is configured with one (alg, enc, key) via
+	 * setkey, which populates the first recipient. */
+	recip = jwe_recipient_first(&__cmd->c);
+	if (recip == NULL || recip->key == NULL ||
+	    recip->key_alg == JWE_ALG_NONE) {
 		jwt_write_error(__cmd, "No key/algorithm set");
 		return NULL;
 	}
@@ -478,7 +518,7 @@ unsigned char *FUNC(decrypt)(jwe_common_t *__cmd, const char *token,
 
 	alg = jwe_str_alg(jwt_json_str_val(jalg));
 	enc = jwe_str_enc(jwt_json_str_val(jenc));
-	if (alg != __cmd->c.key_alg || enc != __cmd->c.enc) {
+	if (alg != recip->key_alg || enc != __cmd->c.enc) {
 		jwt_write_error(__cmd, "JWE alg/enc does not match expected");
 		return NULL;
 	}
@@ -503,7 +543,7 @@ unsigned char *FUNC(decrypt)(jwe_common_t *__cmd, const char *token,
 
 		/* A failed agreement (bad/missing epk, curve mismatch) is a
 		 * structural error, not a key-recovery oracle. */
-		if (jwe_ecdh_derive(alg, enc, __cmd->c.key, 0, hdr,
+		if (jwe_ecdh_derive(alg, enc, recip->key, 0, hdr,
 				    &agreed, &agreed_len)) {
 			jwt_write_error(__cmd, "ECDH-ES key agreement failed");
 			goto fail;
@@ -549,7 +589,7 @@ unsigned char *FUNC(decrypt)(jwe_common_t *__cmd, const char *token,
 				"dir must have an empty Encrypted Key");
 			return NULL;
 		}
-		if (jwks_item_key_oct(__cmd->c.key, &k, &cek_len) ||
+		if (jwks_item_key_oct(recip->key, &k, &cek_len) ||
 		    k == NULL || cek_len != need) {
 			jwt_write_error(__cmd,
 				"dir key length does not match enc");
@@ -573,7 +613,7 @@ unsigned char *FUNC(decrypt)(jwe_common_t *__cmd, const char *token,
 		enckey = jwt_base64uri_decode(p_ek, &ek_len);
 		if (enckey == NULL || ek_len <= 0)
 			bad = 1;
-		else if (jwe_decrypt_cek(alg, __cmd->c.key, enckey, ek_len,
+		else if (jwe_decrypt_cek(alg, recip->key, enckey, ek_len,
 					 &cek, &cek_len))
 			bad = 1;
 		else if (cek_len != need)

--- a/libjwt/jwe.c
+++ b/libjwt/jwe.c
@@ -335,3 +335,64 @@ const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
 
 	return NULL;
 }
+
+/* @rfc{7516,7.2.1} Return the first recipient, or NULL if the list is empty.
+ * The Compact and Flattened serializations only ever have this one; the
+ * General serialization iterates the list directly. */
+struct jwe_recipient *jwe_recipient_first(struct jwe_common *cmd)
+{
+	if (cmd == NULL || cmd->recipients.next == &cmd->recipients)
+		return NULL;
+
+	return list_first_entry(&cmd->recipients, struct jwe_recipient, node);
+}
+
+/* Allocate and tail-append an empty recipient. Returns NULL on OOM. */
+struct jwe_recipient *jwe_recipient_append(struct jwe_common *cmd)
+{
+	struct jwe_recipient *r;
+
+	if (cmd == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	r = jwt_malloc(sizeof(*r));
+	if (r == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	memset(r, 0, sizeof(*r));
+	list_add_tail(&r->node, &cmd->recipients);
+	cmd->n_recipients++;
+
+	return r;
+}
+
+/* Return the first recipient, creating an empty one if the list is empty. Used
+ * by the legacy single-key setkey path so repeated setkey() calls update one
+ * recipient rather than appending. */
+struct jwe_recipient *jwe_recipient_first_or_add(struct jwe_common *cmd)
+{
+	struct jwe_recipient *r;
+
+	if (cmd == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	r = jwe_recipient_first(cmd);
+	if (r != NULL)
+		return r;
+
+	return jwe_recipient_append(cmd);
+}
+
+/* Free a single recipient and the members it owns. Does not unlink it; the
+ * caller (FUNC(free)) drains the whole list. */
+void jwe_recipient_free(struct jwe_recipient *r)
+{
+	if (r == NULL)
+		return; // LCOV_EXCL_LINE
+
+	jwt_scrub_and_free(r->enckey, r->enckey_len);
+	jwt_freemem(r->apu);
+	jwt_freemem(r->apv);
+	jwt_json_release(r->header);
+	jwt_freemem(r);
+}

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -98,35 +98,72 @@ struct jwt_checker {
 
 /******************************/
 
-/* JWE is kept deliberately separate from JWS/JWT. A JWE is structurally and
- * cryptographically different (5 parts, "alg"+"enc", a CEK), so it gets its
- * own common struct rather than overloading struct jwt_common. */
-struct jwe_common {
+/* @rfc{7516,7.2.1} A single JWE recipient: its own key management alg, key,
+ * optional ECDH-ES partyinfo, optional per-recipient (unprotected) header, and
+ * the JWE Encrypted Key produced for it. Linked via ll.h (like jwk_set), so a
+ * Compact / Flattened JWE is just a one-element list and the General JSON
+ * Serialization is a list of N. Owned by the enclosing struct jwe_common. */
+struct jwe_recipient {
+	ll_t node;
 	jwe_key_alg_t key_alg;	/* @rfc{7516,4.1.1} "alg" key management	*/
-	jwe_enc_t enc;		/* @rfc{7516,4.1.2} "enc" content encryption	*/
 	const jwk_item_t *key;	/* Recipient key used for key management		*/
-	jwt_json_t *payload;	/* Claims/plaintext to encrypt (builder)	*/
-	jwt_json_t *headers;	/* Protected header				*/
-	jwt_callback_t cb;
-	void *cb_ctx;
 
 	/* @rfc{7518,4.6.2} Optional ECDH-ES PartyUInfo/PartyVInfo, stored as
 	 * the base64url strings emitted in the "apu"/"apv" headers. */
 	char *apu;
 	char *apv;
 
-	/* The five JWE Compact Serialization components, populated during
-	 * encrypt (builder) or decrypt (checker). Owned by this struct. */
-	unsigned char *cek;	/* Content Encryption Key			*/
-	size_t cek_len;
+	/* @rfc{7516,7.2.1} Optional per-recipient unprotected header. For the
+	 * JSON serializations this also carries ECDH-ES "epk"/"apu"/"apv". */
+	jwt_json_t *header;
+
 	unsigned char *enckey;	/* JWE Encrypted Key (wrapped CEK)		*/
 	size_t enckey_len;
+};
+
+/* JWE is kept deliberately separate from JWS/JWT. A JWE is structurally and
+ * cryptographically different (5 parts, "alg"+"enc", a CEK), so it gets its
+ * own common struct rather than overloading struct jwt_common. */
+struct jwe_common {
+	jwe_enc_t enc;		/* @rfc{7516,4.1.2} "enc" content encryption	*/
+	jwt_json_t *payload;	/* Claims/plaintext to encrypt (builder)	*/
+	jwt_json_t *headers;	/* @rfc{7516,7.2.1} Protected header		*/
+	jwt_json_t *unprotected;/* @rfc{7516,7.2.1} Shared unprotected header	*/
+	jwt_callback_t cb;
+	void *cb_ctx;
+
+	/* @rfc{7516,7.2.1} Recipients. setkey()/set_partyinfo() manage the
+	 * first element; add_recipient() appends further ones. A Compact or
+	 * Flattened JWE has exactly one. */
+	ll_t recipients;
+	int n_recipients;
+
+	/* @rfc{7516,4.1.4} Serialization to emit (builder). */
+	jwe_serialization_t format;
+
+	/* @rfc{7516,5.1} step 14 The application-supplied JWE AAD (the "aad"
+	 * member of the JSON serializations). @aad_b64 is its base64url form,
+	 * which is also what is concatenated into the AEAD AAD. */
+	unsigned char *aad;	/* Raw AAD provided by the builder caller	*/
+	size_t aad_len;
+	char *aad_b64;
+
+	/* The shared JWE components (one CEK / IV / ciphertext / tag per token,
+	 * regardless of recipient count). Populated during encrypt (builder) or
+	 * decrypt (checker). Owned by this struct. */
+	unsigned char *cek;	/* Content Encryption Key			*/
+	size_t cek_len;
 	unsigned char *iv;	/* JWE Initialization Vector			*/
 	size_t iv_len;
 	unsigned char *ct;	/* JWE Ciphertext				*/
 	size_t ct_len;
 	unsigned char *tag;	/* JWE Authentication Tag			*/
 	size_t tag_len;
+
+	/* @rfc{7516,7.2.1} The application AAD recovered by the checker from a
+	 * JSON serialization's "aad" member, handed back via get_aad(). */
+	unsigned char *recovered_aad;
+	size_t recovered_aad_len;
 };
 
 struct jwe_builder {
@@ -574,5 +611,20 @@ int jwe_decrypt_content(jwe_enc_t enc, const unsigned char *cek,
 JWT_NO_EXPORT
 const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
 				int for_encrypt);
+
+/* Recipient list helpers (jwe.c). A recipient is heap-allocated and linked
+ * into jwe_common.recipients. jwe_recipient_first() returns the first recipient
+ * or NULL; jwe_recipient_first_or_add() returns it, creating an empty one if
+ * the list is empty (used by the legacy single-key setkey path).
+ * jwe_recipient_append() always adds a new recipient. jwe_recipient_free()
+ * frees one recipient and its owned members. */
+JWT_NO_EXPORT
+struct jwe_recipient *jwe_recipient_first(struct jwe_common *cmd);
+JWT_NO_EXPORT
+struct jwe_recipient *jwe_recipient_first_or_add(struct jwe_common *cmd);
+JWT_NO_EXPORT
+struct jwe_recipient *jwe_recipient_append(struct jwe_common *cmd);
+JWT_NO_EXPORT
+void jwe_recipient_free(struct jwe_recipient *r);
 
 #endif /* JWT_PRIVATE_H */


### PR DESCRIPTION
First stage of JWE JSON Serialization + multiple recipients (#262). This PR is **purely internal**: the public builder/checker API, the Compact Serialization output, and all existing behavior are unchanged. It restructures the internal JWE state so a token can carry one or more recipients, the precondition for the RFC 7516 JSON Serialization.

## What changes
- **`struct jwe_recipient`** holds the per-recipient state (key management alg, key, ECDH-ES `apu`/`apv`, per-recipient header, and the JWE Encrypted Key), linked via `ll.h` like `jwk_set`. **`struct jwe_common`** keeps only the per-token state (`enc`, one CEK/IV/ciphertext/tag) plus a list of recipients.
- **`setkey()`/`set_partyinfo()`** now manage the first recipient: repeated `setkey()` replaces `recipient[0]` rather than appending, so legacy single-recipient callers transparently get a one-element list. The Compact `generate()`/`decrypt()` paths read `recipient[0]` and produce byte-identical output.
- Adds the public **`jwe_serialization_t`** enum (`COMPACT`/`JSON_FLAT`/`JSON_GENERAL`) and the `jwe_common` fields the JSON serializations will use (shared unprotected header, `aad`/`aad_b64`, `recovered_aad`, `format`). These are inert until the JSON output/parse stages land.
- `jwe_recipient_first`/`append`/`first_or_add`/`free` helpers in `jwe.c`.

## Verification
- All 18 tests pass under OpenSSL + GnuTLS + MbedTLS.
- `jwe.c`, `jwe-common.c`, `jwe-setget.c` at 100% line coverage.
- Verified leak-free under AddressSanitizer (the recipient alloc/free path has no leaks).
- Compact CLI round-trip confirmed: `{"alg":"A256KW","enc":"A256GCM"}` protected header, 5-part output, decrypts back.

Plan for the full feature posted on #262. Subsequent stages: single-recipient JSON output + AAD, multi-recipient General + disjointness, then tools/docs.

Refs #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)