### PR TITLE
jwe: JSON Serialization output + parsing + AAD member (#262)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,7 +359,7 @@ if (CHECK_FOUND)
 
 	# JWE
 	list (APPEND UNIT_TESTS jwe_foundation jwe_keys jwe_gcm jwe_cbc
-		jwe_aeskw jwe_rsa jwe_ecdh)
+		jwe_aeskw jwe_rsa jwe_ecdh jwe_json jwe_aad)
 
 	# Claims
 	list (APPEND UNIT_TESTS jwt_claims)

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -1502,16 +1502,98 @@ int jwe_builder_set_partyinfo(jwe_builder_t *builder,
 			      const unsigned char *apv, size_t apv_len);
 
 /**
- * @brief Encrypt a plaintext into a Compact Serialization JWE
+ * @brief Select the serialization @ref jwe_builder_generate produces
  *
- * Produces a five-part JWE using the key and algorithms configured with
- * @ref jwe_builder_setkey.
+ * The default is @ref JWE_FORMAT_COMPACT (the five-part string). Selecting
+ * @ref JWE_FORMAT_JSON_FLAT or @ref JWE_FORMAT_JSON_GENERAL produces the
+ * Flattened or General JSON Serialization respectively. The JSON
+ * serializations are required to carry a shared unprotected header
+ * (@ref jwe_builder_add_unprotected_json), a per-recipient header, or a JWE
+ * AAD member (@ref jwe_builder_set_aad); the Compact Serialization supports
+ * none of these.
+ *
+ * @param builder Pointer to a JWE builder object
+ * @param format The serialization to emit
+ * @return 0 on success, non-zero otherwise with error set in the builder
+ *
+ * @rfc{7516,7}
+ */
+JWT_EXPORT
+int jwe_builder_set_format(jwe_builder_t *builder, jwe_serialization_t format);
+
+/**
+ * @brief Add a parameter to the JWE Protected Header
+ *
+ * Adds an application-defined member to the integrity-protected JWE header
+ * (the ``protected`` member of the JSON serializations, and part of the AAD).
+ * The library sets ``"enc"`` (and, for the Compact Serialization, ``"alg"``
+ * and the ECDH-ES parameters) itself; those reserved names are rejected here.
+ *
+ * @p value_json is parsed as JSON, so a string value must include its quotes
+ * (the four-byte fragment quote-p-r-o-d-quote for the string @c prod); objects,
+ * arrays, numbers and booleans are accepted as written. The same parameter name
+ * must not also appear in the shared unprotected or any per-recipient header
+ * (@rfc{7516,7.2.1}).
+ *
+ * @param builder Pointer to a JWE builder object
+ * @param key The header parameter name
+ * @param value_json The parameter value as a JSON fragment
+ * @return 0 on success, non-zero otherwise with error set in the builder
+ */
+JWT_EXPORT
+int jwe_builder_add_protected_json(jwe_builder_t *builder, const char *key,
+				   const char *value_json);
+
+/**
+ * @brief Add a parameter to the shared JWE Unprotected Header
+ *
+ * Adds an application-defined member to the shared (not integrity-protected)
+ * JWE header, emitted as the ``unprotected`` member of the JSON
+ * serializations. Only the JSON serializations can carry it. @p value_json is
+ * parsed as JSON (see @ref jwe_builder_add_protected_json). The same parameter
+ * name must not also appear in the protected or any per-recipient header.
+ *
+ * @param builder Pointer to a JWE builder object
+ * @param key The header parameter name
+ * @param value_json The parameter value as a JSON fragment
+ * @return 0 on success, non-zero otherwise with error set in the builder
+ *
+ * @rfc{7516,7.2.1}
+ */
+JWT_EXPORT
+int jwe_builder_add_unprotected_json(jwe_builder_t *builder, const char *key,
+				     const char *value_json);
+
+/**
+ * @brief Set the JWE Additional Authenticated Data
+ *
+ * Sets the optional application AAD emitted as the ``aad`` member of the JSON
+ * serializations. It is authenticated (bound into the AEAD tag) but not
+ * encrypted. Per @rfc{7516,5.1} the AEAD AAD becomes
+ * ``ASCII(BASE64URL(protected)) || '.' || BASE64URL(aad)``. Only the JSON
+ * serializations can carry it. Pass NULL (with length 0) to clear it.
+ *
+ * @param builder Pointer to a JWE builder object
+ * @param aad The AAD octets, or NULL
+ * @param aad_len Length of @p aad in bytes
+ * @return 0 on success, non-zero otherwise with error set in the builder
+ */
+JWT_EXPORT
+int jwe_builder_set_aad(jwe_builder_t *builder, const unsigned char *aad,
+			size_t aad_len);
+
+/**
+ * @brief Encrypt a plaintext into a JWE
+ *
+ * Produces a JWE using the key and algorithms configured with
+ * @ref jwe_builder_setkey. The serialization is the Compact Serialization (a
+ * five-part string) unless changed with @ref jwe_builder_set_format.
  *
  * @param builder Pointer to a JWE builder object
  * @param plaintext The bytes to encrypt
  * @param plaintext_len Length of @p plaintext in bytes
- * @return A newly allocated, nil-terminated compact JWE string the caller
- *  must free, or NULL on error (with the error set in the builder)
+ * @return A newly allocated, nil-terminated JWE string the caller must free,
+ *  or NULL on error (with the error set in the builder)
  */
 JWT_EXPORT
 char *jwe_builder_generate(jwe_builder_t *builder,
@@ -1621,6 +1703,44 @@ int jwe_checker_setkey(jwe_checker_t *checker, jwe_key_alg_t alg,
 JWT_EXPORT
 unsigned char *jwe_checker_decrypt(jwe_checker_t *checker, const char *token,
 				   size_t *plaintext_len);
+
+/**
+ * @brief Decrypt and authenticate a JWE in any serialization
+ *
+ * Like @ref jwe_checker_decrypt, but auto-detects the serialization: a token
+ * beginning with ``{`` is parsed as a JSON Serialization (Flattened or
+ * General), otherwise as the Compact Serialization. For a General JWE the
+ * checker selects the recipient matching its configured key and algorithm.
+ *
+ * @param checker Pointer to a JWE checker object
+ * @param token A nil-terminated JWE string (compact or JSON)
+ * @param plaintext_len If non-NULL, set to the length of the returned
+ *  plaintext on success
+ * @return A newly allocated, nil-terminated buffer of decrypted plaintext the
+ *  caller must free, or NULL on error (with the error set in the checker)
+ *
+ * @rfc{7516,7}
+ */
+JWT_EXPORT
+unsigned char *jwe_checker_decrypt_all(jwe_checker_t *checker,
+				       const char *token, size_t *plaintext_len);
+
+/**
+ * @brief Get the JWE AAD recovered from a JSON-serialized token
+ *
+ * After a successful @ref jwe_checker_decrypt_all on a JSON Serialization that
+ * carried an ``aad`` member, returns the authenticated application AAD octets.
+ * Returns NULL if the last token had no AAD member (or was compact). The
+ * returned buffer is owned by the checker and valid until the next decrypt or
+ * until the checker is freed.
+ *
+ * @param checker Pointer to a JWE checker object
+ * @param aad_len If non-NULL, set to the length of the returned AAD in bytes
+ * @return Pointer to the AAD octets, or NULL if none
+ */
+JWT_EXPORT
+const unsigned char *jwe_checker_get_aad(const jwe_checker_t *checker,
+					 size_t *aad_len);
 
 /**
  * @}

--- a/libjwt/jansson/jwt-jansson.c
+++ b/libjwt/jansson/jwt-jansson.c
@@ -198,6 +198,11 @@ int jwt_json_arr_append(jwt_json_t *array, jwt_json_t *value)
  * Type checking
  * ================================================================ */
 
+int jwt_json_is_object(const jwt_json_t *json)
+{
+	return json_is_object(to_json(json));
+}
+
 int jwt_json_is_array(const jwt_json_t *json)
 {
 	return json_is_array(to_json(json));

--- a/libjwt/json-c/jwt-json-c.c
+++ b/libjwt/json-c/jwt-json-c.c
@@ -238,6 +238,11 @@ int jwt_json_arr_append(jwt_json_t *array, jwt_json_t *value)
  * Type checking
  * ================================================================ */
 
+int jwt_json_is_object(const jwt_json_t *json)
+{
+	return json && json_object_is_type(to_jc(json), json_type_object);
+}
+
 int jwt_json_is_array(const jwt_json_t *json)
 {
 	return json && json_object_is_type(to_jc(json), json_type_array);

--- a/libjwt/jwe-common.c
+++ b/libjwt/jwe-common.c
@@ -201,21 +201,277 @@ oom:
 	return 1;
 	// LCOV_EXCL_STOP
 }
+
+/* @rfc{7516,4.1} Header parameter names the library manages itself and that an
+ * application must not set via add_protected_json / add_unprotected_json:
+ * "enc" lives in the protected header; "alg"/"epk"/"apu"/"apv" are placed in
+ * the per-recipient header by setkey/set_partyinfo and the ECDH-ES agreement. */
+static int jwe_header_name_reserved(const char *key)
+{
+	return !strcmp(key, "alg") || !strcmp(key, "enc") ||
+	       !strcmp(key, "epk") || !strcmp(key, "apu") ||
+	       !strcmp(key, "apv");
+}
+
+/* Parse @value_json (a JSON fragment) and set it on @obj under @key. Rejects a
+ * reserved name, a NULL arg, a parse failure, and a duplicate key already in
+ * @obj. JWT_JSON_DECODE_ANY lets a value be any JSON type, including a bare
+ * scalar. Returns 0 on success, non-zero (with the builder error set) on
+ * failure. */
+static int FUNC(add_header_json)(jwe_common_t *__cmd, jwt_json_t *obj,
+				 const char *key, const char *value_json)
+{
+	jwt_json_t *val;
+
+	/* The public wrappers (add_protected_json / add_unprotected_json) guard
+	 * a NULL builder before reaching this static helper. */
+	if (__cmd == NULL)
+		return 1; // LCOV_EXCL_LINE
+
+	if (key == NULL || value_json == NULL) {
+		jwt_write_error(__cmd, "Header key and value are required");
+		return 1;
+	}
+
+	if (jwe_header_name_reserved(key)) {
+		jwt_write_error(__cmd,
+			"Header parameter \"%s\" is reserved by the library",
+			key);
+		return 1;
+	}
+
+	if (jwt_json_obj_get(obj, key) != NULL) {
+		jwt_write_error(__cmd,
+			"Header parameter \"%s\" is already set", key);
+		return 1;
+	}
+
+	val = jwt_json_parse(value_json, JWT_JSON_DECODE_ANY, NULL);
+	if (val == NULL) {
+		jwt_write_error(__cmd, "Could not parse header value as JSON");
+		return 1;
+	}
+
+	/* obj_set steals the reference to val on success and on failure. */
+	if (jwt_json_obj_set(obj, key, val)) {
+		jwt_write_error(__cmd, "Could not set header parameter"); // LCOV_EXCL_LINE
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	return 0;
+}
+
+/* @rfc{7516,7.2.1} Add an application parameter to the protected header. */
+int FUNC(add_protected_json)(jwe_common_t *__cmd, const char *key,
+			     const char *value_json)
+{
+	if (__cmd == NULL)
+		return 1;
+
+	return FUNC(add_header_json)(__cmd, __cmd->c.headers, key, value_json);
+}
+
+/* @rfc{7516,7.2.1} Add an application parameter to the shared unprotected
+ * header, creating that header object on first use. */
+int FUNC(add_unprotected_json)(jwe_common_t *__cmd, const char *key,
+			       const char *value_json)
+{
+	if (__cmd == NULL)
+		return 1;
+
+	if (__cmd->c.unprotected == NULL) {
+		__cmd->c.unprotected = jwt_json_create();
+		if (__cmd->c.unprotected == NULL) {
+			jwt_write_error(__cmd, "Error allocating memory"); // LCOV_EXCL_LINE
+			return 1; // LCOV_EXCL_LINE
+		}
+	}
+
+	return FUNC(add_header_json)(__cmd, __cmd->c.unprotected, key,
+				    value_json);
+}
+
+/* @rfc{7516,4.1.4} Select the serialization to emit. */
+int FUNC(set_format)(jwe_common_t *__cmd, jwe_serialization_t format)
+{
+	if (__cmd == NULL)
+		return 1;
+
+	if (format != JWE_FORMAT_COMPACT && format != JWE_FORMAT_JSON_FLAT &&
+	    format != JWE_FORMAT_JSON_GENERAL) {
+		jwt_write_error(__cmd, "Invalid JWE serialization format");
+		return 1;
+	}
+
+	__cmd->c.format = format;
+
+	return 0;
+}
+
+/* @rfc{7516,5.1} step 14 Store the application AAD (the "aad" member). Keep both
+ * the raw octets (for symmetry / future accessors) and the base64url form that
+ * is emitted and concatenated into the AEAD AAD. NULL clears it. */
+int FUNC(set_aad)(jwe_common_t *__cmd, const unsigned char *aad, size_t aad_len)
+{
+	unsigned char *raw = NULL;
+	char *b64 = NULL;
+
+	if (__cmd == NULL)
+		return 1;
+
+	if (aad != NULL && aad_len) {
+		raw = jwt_malloc(aad_len);
+		if (raw == NULL)
+			goto oom; // LCOV_EXCL_LINE
+		memcpy(raw, aad, aad_len);
+
+		if (jwt_base64uri_encode(&b64, (const char *)aad,
+					 (int)aad_len) <= 0)
+			goto oom; // LCOV_EXCL_LINE
+	}
+
+	jwt_scrub_and_free(__cmd->c.aad, __cmd->c.aad_len);
+	jwt_freemem(__cmd->c.aad_b64);
+	__cmd->c.aad = raw;
+	__cmd->c.aad_len = raw ? aad_len : 0;
+	__cmd->c.aad_b64 = b64;
+
+	return 0;
+
+	// LCOV_EXCL_START
+oom:
+	jwt_scrub_and_free(raw, aad_len);
+	jwt_freemem(b64);
+	jwt_write_error(__cmd, "Error storing JWE AAD");
+	return 1;
+	// LCOV_EXCL_STOP
+}
 #endif
 
 #ifdef JWE_BUILDER
-/* @rfc{7516,5.1} Encrypt @plaintext into a Compact Serialization JWE. This
- * stage implements the dir + AES-GCM path. */
+/* @rfc{7516,7.1} Assemble the five-part Compact Serialization from the encoded
+ * segments. The Encrypted Key is empty for dir / ECDH-ES Direct. */
+static char *jwe_assemble_compact(const char *hdr_b64, const char *ek_b64,
+				  const char *iv_b64, const char *ct_b64,
+				  const char *tag_b64)
+{
+	const char *ek = ek_b64 ? ek_b64 : "";
+	char *out;
+
+	out = jwt_malloc(strlen(hdr_b64) + strlen(ek) + strlen(iv_b64) +
+			 strlen(ct_b64) + strlen(tag_b64) + 5);
+	if (out == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	sprintf(out, "%s.%s.%s.%s.%s", hdr_b64, ek, iv_b64, ct_b64, tag_b64);
+
+	return out;
+}
+
+/* @rfc{7516,7.2} Assemble a JSON Serialization. @recip_hdr is the single
+ * recipient's per-recipient header (may be NULL/empty) and @ek_b64 its
+ * Encrypted Key (NULL for dir / ECDH-ES Direct). For JWE_FORMAT_JSON_FLAT the
+ * header and encrypted_key are hoisted to the top level; for
+ * JWE_FORMAT_JSON_GENERAL they go inside a one-element "recipients" array.
+ * Returns a newly allocated string or NULL on error. */
+static char *FUNC(assemble_json)(jwe_common_t *__cmd, const char *hdr_b64,
+				 jwt_json_t *recip_hdr, const char *ek_b64,
+				 const char *iv_b64, const char *ct_b64,
+				 const char *tag_b64)
+{
+	jwt_json_auto_t *obj = NULL;
+	jwt_json_t *rcp_arr = NULL, *rcp = NULL;
+	int recip_hdr_used = 0;
+	char *out = NULL;
+
+	obj = jwt_json_create();
+	if (obj == NULL)
+		goto oom; // LCOV_EXCL_LINE
+
+	/* Members shared by both JSON forms. */
+	if (jwt_json_obj_set(obj, "protected", jwt_json_create_str(hdr_b64)))
+		goto oom; // LCOV_EXCL_LINE
+	if (__cmd->c.unprotected != NULL) {
+		jwt_json_t *cl = jwt_json_clone(__cmd->c.unprotected);
+		if (cl == NULL || jwt_json_obj_set(obj, "unprotected", cl))
+			goto oom; // LCOV_EXCL_LINE
+	}
+	if (__cmd->c.aad_b64 != NULL &&
+	    jwt_json_obj_set(obj, "aad", jwt_json_create_str(__cmd->c.aad_b64)))
+		goto oom; // LCOV_EXCL_LINE
+	if (jwt_json_obj_set(obj, "iv", jwt_json_create_str(iv_b64)) ||
+	    jwt_json_obj_set(obj, "ciphertext", jwt_json_create_str(ct_b64)) ||
+	    jwt_json_obj_set(obj, "tag", jwt_json_create_str(tag_b64)))
+		goto oom; // LCOV_EXCL_LINE
+
+	/* A non-empty per-recipient header is emitted; an empty one is omitted. */
+	if (recip_hdr != NULL && jwt_json_obj_get(recip_hdr, "alg") != NULL)
+		recip_hdr_used = 1;
+
+	if (__cmd->c.format == JWE_FORMAT_JSON_FLAT) {
+		/* @rfc{7516,7.2.2} Flattened: header / encrypted_key at top level. */
+		if (recip_hdr_used) {
+			jwt_json_t *cl = jwt_json_clone(recip_hdr);
+			if (cl == NULL || jwt_json_obj_set(obj, "header", cl))
+				goto oom; // LCOV_EXCL_LINE
+		}
+		if (ek_b64 != NULL &&
+		    jwt_json_obj_set(obj, "encrypted_key",
+				     jwt_json_create_str(ek_b64)))
+			goto oom; // LCOV_EXCL_LINE
+	} else {
+		/* @rfc{7516,7.2.1} General: a one-element "recipients" array. */
+		rcp_arr = jwt_json_create_arr();
+		if (rcp_arr == NULL || jwt_json_obj_set(obj, "recipients", rcp_arr))
+			goto oom; // LCOV_EXCL_LINE
+
+		rcp = jwt_json_create();
+		if (rcp == NULL || jwt_json_arr_append(rcp_arr, rcp))
+			goto oom; // LCOV_EXCL_LINE
+
+		if (recip_hdr_used) {
+			jwt_json_t *cl = jwt_json_clone(recip_hdr);
+			if (cl == NULL || jwt_json_obj_set(rcp, "header", cl))
+				goto oom; // LCOV_EXCL_LINE
+		}
+		if (ek_b64 != NULL &&
+		    jwt_json_obj_set(rcp, "encrypted_key",
+				     jwt_json_create_str(ek_b64)))
+			goto oom; // LCOV_EXCL_LINE
+	}
+
+	/* The protected header was already serialized with sorted keys; the
+	 * outer object is just compacted (RFC 7520 JSON vectors are unsorted, so
+	 * output is not byte-compared to them). */
+	out = jwt_json_serialize(obj, JWT_JSON_COMPACT);
+	if (out == NULL)
+		goto oom; // LCOV_EXCL_LINE
+
+	return out;
+
+	// LCOV_EXCL_START
+oom:
+	jwt_write_error(__cmd, "Error building JWE JSON");
+	return NULL;
+	// LCOV_EXCL_STOP
+}
+
+/* @rfc{7516,5.1} Encrypt @plaintext into a JWE. The Compact Serialization is
+ * produced unless a JSON format was selected with set_format. */
 char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 		     size_t plaintext_len)
 {
 	struct jwe_recipient *recip;
 	jwt_json_auto_t *hdr = NULL;
+	jwt_json_t *kmhdr;
 	char_auto *hdr_json = NULL, *hdr_b64 = NULL, *ek_b64 = NULL;
 	char_auto *iv_b64 = NULL, *ct_b64 = NULL, *tag_b64 = NULL;
 	unsigned char *cek = NULL, *iv = NULL, *ct = NULL, *tag = NULL;
 	unsigned char *enckey = NULL;
+	const unsigned char *aad = NULL;
 	size_t cek_len = 0, iv_len, ct_len = 0, tag_len = 0, enckey_len = 0;
+	size_t aad_len = 0;
+	int aad_owned = 0, is_json;
 	const unsigned char *k;
 	char *out = NULL;
 	int hdr_len, ret;
@@ -223,8 +479,8 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 	if (__cmd == NULL)
 		return NULL;
 
-	/* @rfc{7516,7.2.1} The Compact Serialization has exactly one recipient,
-	 * configured via setkey. */
+	/* @rfc{7516,7.2.1} The Compact and Flattened serializations have exactly
+	 * one recipient, configured via setkey. */
 	recip = jwe_recipient_first(&__cmd->c);
 	if (recip == NULL || recip->key == NULL ||
 	    recip->key_alg == JWE_ALG_NONE) {
@@ -237,35 +493,67 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 		return NULL;
 	}
 
-	/* @rfc{7516,5.1} step 12-13: build and encode the protected header. */
+	is_json = (__cmd->c.format != JWE_FORMAT_COMPACT);
+
+	/* @rfc{7516,7.1} The Compact Serialization cannot carry a shared
+	 * unprotected header or a JWE AAD member; only the JSON serializations
+	 * can. (Multi-recipient is enforced in a later stage.) */
+	if (!is_json &&
+	    (__cmd->c.unprotected != NULL || __cmd->c.aad_b64 != NULL)) {
+		jwt_write_error(__cmd,
+			"Compact Serialization cannot carry unprotected header or aad");
+		return NULL;
+	}
+
+	/* @rfc{7516,5.1} step 12-13: build the protected header. It always
+	 * carries "enc". For the Compact Serialization the key-management
+	 * parameters ("alg", and the ECDH-ES "epk"/"apu"/"apv") also live in the
+	 * protected header, so they are bound into the single AAD. For the JSON
+	 * serializations they belong in the per-recipient header instead, since
+	 * each recipient agrees its own "epk". @kmhdr is whichever object
+	 * receives those key-management parameters. */
 	hdr = jwt_json_create();
 	if (hdr == NULL)
 		goto oom; // LCOV_EXCL_LINE
-	if (jwt_json_obj_set(hdr, "alg",
-			     jwt_json_create_str(jwe_alg_str(recip->key_alg))) ||
-	    jwt_json_obj_set(hdr, "enc",
+	if (jwt_json_obj_set(hdr, "enc",
 			     jwt_json_create_str(jwe_enc_str(__cmd->c.enc)))) {
 		jwt_write_error(__cmd, "Error building JWE header"); // LCOV_EXCL_LINE
 		return NULL; // LCOV_EXCL_LINE
 	}
 
-	/* @rfc{7518,4.6.2} For ECDH-ES, emit any apu/apv into the header before
-	 * the key agreement runs, so they are bound into the Concat KDF (and,
-	 * being part of the protected header, into the AAD). */
+	if (is_json) {
+		if (recip->header == NULL) {
+			recip->header = jwt_json_create();
+			if (recip->header == NULL)
+				goto oom; // LCOV_EXCL_LINE
+		}
+		kmhdr = recip->header;
+	} else {
+		kmhdr = hdr;
+	}
+
+	if (jwt_json_obj_set(kmhdr, "alg",
+			     jwt_json_create_str(jwe_alg_str(recip->key_alg))))
+		goto oom; // LCOV_EXCL_LINE
+
+	/* @rfc{7518,4.6.2} For ECDH-ES, emit any apu/apv into the key-management
+	 * header before the agreement runs, so they are bound into the Concat
+	 * KDF. */
 	if (jwe_alg_is_ecdh(recip->key_alg)) {
 		if (recip->apu &&
-		    jwt_json_obj_set(hdr, "apu",
+		    jwt_json_obj_set(kmhdr, "apu",
 				     jwt_json_create_str(recip->apu)))
 			goto oom; // LCOV_EXCL_LINE
 		if (recip->apv &&
-		    jwt_json_obj_set(hdr, "apv",
+		    jwt_json_obj_set(kmhdr, "apv",
 				     jwt_json_create_str(recip->apv)))
 			goto oom; // LCOV_EXCL_LINE
 	}
 
 	/* @rfc{7518,4.6} ECDH-ES (Direct): derive the CEK and add the "epk"
-	 * to the header BEFORE it is serialized, since the header bytes are
-	 * the AAD. The Encrypted Key stays empty (like dir). */
+	 * to the key-management header BEFORE the protected header is serialized,
+	 * since the protected header bytes are (part of) the AAD. The Encrypted
+	 * Key stays empty (like dir). */
 	if (jwe_alg_is_ecdh(recip->key_alg)) {
 		/* @rfc{7518,4.6} Derive the agreed key and emit "epk" while the
 		 * header object can still be modified. For Direct mode the
@@ -274,7 +562,7 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 		size_t agreed_len = 0;
 
 		if (jwe_ecdh_derive(recip->key_alg, __cmd->c.enc,
-				    recip->key, 1, hdr, &agreed, &agreed_len)) {
+				    recip->key, 1, kmhdr, &agreed, &agreed_len)) {
 			jwt_write_error(__cmd, "ECDH-ES key agreement failed");
 			return NULL;
 		}
@@ -364,11 +652,14 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 		// LCOV_EXCL_STOP
 	}
 
-	/* @rfc{7516,5.1} step 14-15: AAD is ASCII(Encoded Protected Header);
-	 * encrypt the content. */
+	/* @rfc{7516,5.1} step 14-15: build the AAD and encrypt the content. For
+	 * the Compact Serialization there is no "aad" member, so jwe_build_aad
+	 * aliases hdr_b64 (byte-identical). For the JSON serializations a present
+	 * "aad" member appends '.' || BASE64URL(aad). */
+	if (jwe_build_aad(hdr_b64, __cmd->c.aad_b64, &aad, &aad_len, &aad_owned))
+		goto oom; // LCOV_EXCL_LINE
 	ret = jwe_encrypt_content(__cmd->c.enc, cek, cek_len, iv, iv_len,
-				  (const unsigned char *)hdr_b64,
-				  strlen(hdr_b64), plaintext, plaintext_len,
+				  aad, aad_len, plaintext, plaintext_len,
 				  &ct, &ct_len, &tag, &tag_len);
 	if (ret) {
 		// LCOV_EXCL_START
@@ -383,18 +674,18 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 	    jwt_base64uri_encode(&tag_b64, (char *)tag, (int)tag_len) <= 0)
 		goto oom; // LCOV_EXCL_LINE
 
-	/* @rfc{7516,7.1} Assemble: header.encrypted_key.iv.ct.tag. The
-	 * Encrypted Key segment is empty for dir and the wrapped key for A*KW.
-	 * Length is the five parts plus 4 dots and a nil. */
-	{
-		const char *ek = ek_b64 ? ek_b64 : "";
-
-		out = jwt_malloc(strlen(hdr_b64) + strlen(ek) + strlen(iv_b64) +
-				 strlen(ct_b64) + strlen(tag_b64) + 5);
+	/* @rfc{7516,7} Assemble in the configured serialization. assemble_json
+	 * sets its own error; the compact path only fails on OOM. */
+	if (is_json) {
+		out = FUNC(assemble_json)(__cmd, hdr_b64, recip->header, ek_b64,
+					  iv_b64, ct_b64, tag_b64);
+		if (out == NULL)
+			goto fail; // LCOV_EXCL_LINE
+	} else {
+		out = jwe_assemble_compact(hdr_b64, ek_b64, iv_b64, ct_b64,
+					   tag_b64);
 		if (out == NULL)
 			goto oom; // LCOV_EXCL_LINE
-		sprintf(out, "%s.%s.%s.%s.%s", hdr_b64, ek, iv_b64, ct_b64,
-			tag_b64);
 	}
 
 	goto done;
@@ -406,6 +697,10 @@ oom:
 fail:
 	out = NULL;
 done:
+	if (aad_owned) {
+		void *aad_free = (void *)(uintptr_t)aad;
+		jwt_freemem(aad_free);
+	}
 	jwt_scrub_and_free(cek, cek_len);
 	jwt_freemem(enckey);
 	jwt_freemem(iv);
@@ -430,47 +725,216 @@ static char *split_dot(char *p)
 	return NULL;
 }
 
-/* @rfc{7516,5.2} Decrypt and authenticate a Compact Serialization JWE. This
- * stage implements the dir + AES-GCM path. */
-unsigned char *FUNC(decrypt)(jwe_common_t *__cmd, const char *token,
-			     size_t *plaintext_len)
+/* @rfc{7516,5.2} Recover the CEK and decrypt the content for one recipient.
+ * Shared by the Compact and JSON serialization paths. Inputs are the decoded
+ * b64 segments (as nil-terminated strings) plus @eff_hdr, the effective header
+ * the ECDH-ES "epk" is read from (the protected header for Compact, the
+ * per-recipient header for JSON). @ek_b64 may be "" or NULL when there is no
+ * Encrypted Key (dir / ECDH-ES Direct). @aad_b64 is the JSON "aad" member's
+ * base64url (NULL for Compact). Returns a newly allocated nil-terminated
+ * plaintext buffer or NULL on error, with the error set in @__cmd.
+ *
+ * @rfc{7516,11.5} All CEK-recovery failures funnel to a random CEK so the AEAD
+ * tag fails uniformly; the only post-CEK error is the generic auth failure. */
+static unsigned char *FUNC(recover_and_decrypt)(jwe_common_t *__cmd,
+		struct jwe_recipient *recip, jwt_json_t *eff_hdr,
+		jwe_key_alg_t alg, jwe_enc_t enc, const char *protected_b64,
+		const char *aad_b64, const char *ek_b64, const char *iv_b64,
+		const char *ct_b64, const char *tag_b64, size_t *plaintext_len)
 {
-	struct jwe_recipient *recip;
+	unsigned char *cek = NULL, *iv = NULL, *ct = NULL, *tag = NULL;
+	unsigned char *pt = NULL, *out = NULL, *enckey = NULL;
+	const unsigned char *aad = NULL;
+	size_t cek_len = 0, pt_len = 0, aad_len = 0;
+	int iv_len = 0, ct_len = 0, tag_len = 0, ek_len = 0, aad_owned = 0;
+	int have_ek = (ek_b64 != NULL && *ek_b64 != '\0');
+	const unsigned char *k;
+
+	/* @rfc{7516,5.2} CEK per the key management algorithm. */
+	if (jwe_alg_is_ecdh(alg)) {
+		/* @rfc{7518,4.6} Derive the agreed key from the recipient
+		 * private key and the effective header's "epk". */
+		unsigned char *agreed = NULL;
+		size_t agreed_len = 0, need = jwe_enc_cek_len(enc);
+
+		if (jwe_alg_is_ecdh_direct(alg) && have_ek) {
+			jwt_write_error(__cmd,
+				"ECDH-ES (Direct) must have an empty Encrypted Key");
+			return NULL;
+		}
+		if (!jwe_alg_is_ecdh_direct(alg) && !have_ek) {
+			jwt_write_error(__cmd,
+				"ECDH-ES+A*KW requires an Encrypted Key");
+			return NULL;
+		}
+
+		/* A failed agreement (bad/missing epk, curve mismatch) is a
+		 * structural error, not a key-recovery oracle. */
+		if (jwe_ecdh_derive(alg, enc, recip->key, 0, eff_hdr,
+				    &agreed, &agreed_len)) {
+			jwt_write_error(__cmd, "ECDH-ES key agreement failed");
+			goto fail;
+		}
+
+		if (jwe_alg_is_ecdh_direct(alg)) {
+			cek = agreed;
+			cek_len = agreed_len;
+			if (cek_len != need) {
+				jwt_write_error(__cmd, "Derived CEK length wrong"); // LCOV_EXCL_LINE
+				goto fail; // LCOV_EXCL_LINE
+			}
+		} else {
+			/* +A*KW: unwrap the CEK with the agreed KEK. @rfc{7516,11.5}
+			 * On any unwrap failure, substitute a random CEK and let
+			 * the AEAD tag fail uniformly. */
+			int bad = 0;
+
+			enckey = jwt_base64uri_decode(ek_b64, &ek_len);
+			if (enckey == NULL || ek_len <= 0)
+				bad = 1;
+			else if (jwe_aeskw_unwrap_raw(agreed, agreed_len, enckey,
+						      ek_len, &cek, &cek_len))
+				bad = 1;
+			else if (cek_len != need)
+				bad = 1; // LCOV_EXCL_LINE
+
+			jwt_scrub_and_free(agreed, agreed_len);
+
+			if (bad) {
+				jwt_scrub_and_free(cek, cek_len);
+				cek = NULL;
+				cek_len = 0;
+				if (jwe_generate_cek(enc, &cek, &cek_len))
+					goto oom; // LCOV_EXCL_LINE
+			}
+		}
+	} else if (alg == JWE_ALG_DIR) {
+		size_t need = jwe_enc_cek_len(enc);
+
+		if (have_ek) {
+			jwt_write_error(__cmd,
+				"dir must have an empty Encrypted Key");
+			return NULL;
+		}
+		if (jwks_item_key_oct(recip->key, &k, &cek_len) ||
+		    k == NULL || cek_len != need) {
+			jwt_write_error(__cmd,
+				"dir key length does not match enc");
+			return NULL;
+		}
+		cek = jwt_malloc(cek_len);
+		if (cek == NULL)
+			goto oom; // LCOV_EXCL_LINE
+		memcpy(cek, k, cek_len);
+	} else {
+		/* A*KW / RSA-OAEP: the Encrypted Key carries the CEK. */
+		size_t need = jwe_enc_cek_len(enc);
+		int bad = 0;
+
+		if (!have_ek) {
+			jwt_write_error(__cmd,
+				"Key management requires an Encrypted Key");
+			return NULL;
+		}
+
+		enckey = jwt_base64uri_decode(ek_b64, &ek_len);
+		if (enckey == NULL || ek_len <= 0)
+			bad = 1;
+		else if (jwe_decrypt_cek(alg, recip->key, enckey, ek_len,
+					 &cek, &cek_len))
+			bad = 1;
+		else if (cek_len != need)
+			bad = 1; // LCOV_EXCL_LINE
+
+		/* @rfc{7516,11.5} Do not reveal why CEK recovery failed: a
+		 * padding/format/length error would otherwise be an oracle
+		 * (e.g. Bleichenbacher against RSA). On any failure, substitute
+		 * a random CEK of the correct length and proceed; the AEAD tag
+		 * check below then fails uniformly, indistinguishable from a
+		 * merely-wrong key. */
+		if (bad) {
+			jwt_scrub_and_free(cek, cek_len);
+			cek = NULL;
+			cek_len = 0;
+			if (jwe_generate_cek(enc, &cek, &cek_len))
+				goto oom; // LCOV_EXCL_LINE
+		}
+	}
+
+	/* Decode IV, ciphertext, tag. */
+	iv = jwt_base64uri_decode(iv_b64, &iv_len);
+	ct = jwt_base64uri_decode(ct_b64, &ct_len);
+	tag = jwt_base64uri_decode(tag_b64, &tag_len);
+	if (iv == NULL || ct == NULL || tag == NULL || iv_len <= 0 ||
+	    ct_len < 0 || tag_len <= 0) {
+		jwt_write_error(__cmd, "Error decoding JWE components");
+		goto fail;
+	}
+
+	/* @rfc{7516,5.2} Build the AAD (ASCII(protected) for Compact, plus '.'
+	 * BASE64URL(aad) when an "aad" member is present) and decrypt+verify. */
+	if (jwe_build_aad(protected_b64, aad_b64, &aad, &aad_len, &aad_owned))
+		goto oom; // LCOV_EXCL_LINE
+	if (jwe_decrypt_content(enc, cek, cek_len, iv, iv_len, aad, aad_len,
+				ct, ct_len, tag, tag_len, &pt, &pt_len)) {
+		jwt_write_error(__cmd, "JWE authentication/decryption failed");
+		goto fail;
+	}
+
+	/* Hand back a nil-terminated buffer for caller convenience. */
+	out = jwt_malloc(pt_len + 1);
+	if (out == NULL)
+		goto oom; // LCOV_EXCL_LINE
+	if (pt_len)
+		memcpy(out, pt, pt_len);
+	out[pt_len] = '\0';
+	if (plaintext_len)
+		*plaintext_len = pt_len;
+
+	goto done;
+
+	// LCOV_EXCL_START
+oom:
+	jwt_write_error(__cmd, "Error allocating memory");
+	// LCOV_EXCL_STOP
+fail:
+	out = NULL;
+done:
+	if (aad_owned) {
+		void *aad_free = (void *)(uintptr_t)aad;
+		jwt_freemem(aad_free);
+	}
+	jwt_scrub_and_free(cek, cek_len);
+	jwt_freemem(enckey);
+	jwt_freemem(iv);
+	jwt_freemem(ct);
+	jwt_freemem(tag);
+	jwt_scrub_and_free(pt, pt_len);
+
+	return out;
+}
+
+/* @rfc{7516,5.2} Decrypt and authenticate a Compact Serialization JWE. */
+static unsigned char *FUNC(decrypt_compact)(jwe_common_t *__cmd,
+		struct jwe_recipient *recip, const char *token,
+		size_t *plaintext_len)
+{
 	char_auto *dup = NULL;
 	char *p_hdr, *p_ek, *p_iv, *p_ct, *p_tag, *rest;
 	jwt_json_auto_t *hdr = NULL;
 	char_auto *hdr_json = NULL;
-	unsigned char *cek = NULL, *iv = NULL, *ct = NULL, *tag = NULL;
-	unsigned char *pt = NULL, *out = NULL, *enckey = NULL;
-	int iv_len = 0, ct_len = 0, tag_len = 0, hdr_dlen = 0, ek_len = 0;
-	size_t cek_len = 0, pt_len = 0;
-	const unsigned char *k;
+	int hdr_dlen = 0;
 	jwt_json_t *jalg, *jenc;
 	jwe_key_alg_t alg;
 	jwe_enc_t enc;
 	size_t dup_len;
 
-	if (__cmd == NULL)
-		return NULL;
-
-	if (token == NULL || !strlen(token)) {
-		jwt_write_error(__cmd, "Must pass a token");
-		return NULL;
-	}
-
-	/* @rfc{7516,7.1} The checker is configured with one (alg, enc, key) via
-	 * setkey, which populates the first recipient. */
-	recip = jwe_recipient_first(&__cmd->c);
-	if (recip == NULL || recip->key == NULL ||
-	    recip->key_alg == JWE_ALG_NONE) {
-		jwt_write_error(__cmd, "No key/algorithm set");
-		return NULL;
-	}
-
 	dup_len = strlen(token) + 1;
 	dup = jwt_malloc(dup_len);
-	if (dup == NULL)
-		goto oom; // LCOV_EXCL_LINE
+	if (dup == NULL) {
+		jwt_write_error(__cmd, "Error allocating memory"); // LCOV_EXCL_LINE
+		return NULL; // LCOV_EXCL_LINE
+	}
 	memcpy(dup, token, dup_len);
 
 	/* @rfc{7516,5.2} Split exactly 5 parts (4 dots). */
@@ -502,7 +966,8 @@ unsigned char *FUNC(decrypt)(jwe_common_t *__cmd, const char *token,
 	}
 
 	/* A JWE protected header carries "enc"; its absence means this is not
-	 * a JWE (e.g. a JWS was passed). */
+	 * a JWE (e.g. a JWS was passed). The Compact Serialization also carries
+	 * "alg" in the protected header. */
 	jenc = jwt_json_obj_get(hdr, "enc");
 	jalg = jwt_json_obj_get(hdr, "alg");
 	if (jenc == NULL || !jwt_json_is_string(jenc) ||
@@ -523,162 +988,268 @@ unsigned char *FUNC(decrypt)(jwe_common_t *__cmd, const char *token,
 		return NULL;
 	}
 
-	/* @rfc{7516,5.2} CEK per the key management algorithm. */
-	if (jwe_alg_is_ecdh(alg)) {
-		/* @rfc{7518,4.6} Derive the agreed key from the recipient
-		 * private key and the header's "epk". */
-		unsigned char *agreed = NULL;
-		size_t agreed_len = 0, need = jwe_enc_cek_len(enc);
+	/* For Compact the AAD is just ASCII(protected) (no "aad" member) and the
+	 * "epk" (if any) lives in the protected header. */
+	return FUNC(recover_and_decrypt)(__cmd, recip, hdr, alg, enc, p_hdr,
+					 NULL, p_ek, p_iv, p_ct, p_tag,
+					 plaintext_len);
+}
 
-		if (jwe_alg_is_ecdh_direct(alg) && *p_ek != '\0') {
+/* @rfc{7516,5.2} Decrypt and authenticate a Compact Serialization JWE. */
+unsigned char *FUNC(decrypt)(jwe_common_t *__cmd, const char *token,
+			     size_t *plaintext_len)
+{
+	struct jwe_recipient *recip;
+
+	if (__cmd == NULL)
+		return NULL;
+
+	if (token == NULL || !strlen(token)) {
+		jwt_write_error(__cmd, "Must pass a token");
+		return NULL;
+	}
+
+	/* @rfc{7516,7.1} The checker is configured with one (alg, enc, key) via
+	 * setkey, which populates the first recipient. */
+	recip = jwe_recipient_first(&__cmd->c);
+	if (recip == NULL || recip->key == NULL ||
+	    recip->key_alg == JWE_ALG_NONE) {
+		jwt_write_error(__cmd, "No key/algorithm set");
+		return NULL;
+	}
+
+	return FUNC(decrypt_compact)(__cmd, recip, token, plaintext_len);
+}
+
+/* Get a required string member of @obj. Returns its value or NULL (setting an
+ * error) if absent or not a string. Type-checked so json-c does not abort. */
+static const char *FUNC(json_str_member)(jwe_common_t *__cmd, jwt_json_t *obj,
+					 const char *name, int required)
+{
+	jwt_json_t *m = jwt_json_obj_get(obj, name);
+
+	if (m == NULL) {
+		if (required)
+			jwt_write_error(__cmd, "JWE JSON missing \"%s\"", name);
+		return NULL;
+	}
+	if (!jwt_json_is_string(m)) {
+		jwt_write_error(__cmd, "JWE JSON \"%s\" is not a string", name);
+		return NULL;
+	}
+
+	return jwt_json_str_val(m);
+}
+
+/* @rfc{7516,7.2} Decrypt a JSON Serialization (Flattened or single-recipient
+ * General). The protected header is authenticated; the per-recipient header
+ * supplies "alg" (and the ECDH-ES "epk"). Multi-recipient selection and full
+ * header-disjointness enforcement are added in a later stage. */
+static unsigned char *FUNC(decrypt_json)(jwe_common_t *__cmd,
+		struct jwe_recipient *recip, const char *token,
+		size_t *plaintext_len)
+{
+	jwt_json_auto_t *obj = NULL, *prot = NULL, *eff = NULL;
+	char_auto *prot_json = NULL;
+	jwt_json_t *recips, *rcp, *rhdr, *unprot, *jenc;
+	const char *prot_b64, *iv_b64, *ct_b64, *tag_b64, *aad_b64, *ek_b64;
+	const char *alg_str, *enc_str;
+	int prot_dlen = 0;
+	jwe_key_alg_t alg;
+	jwe_enc_t enc;
+
+	obj = jwt_json_parse(token, 0, NULL);
+	if (obj == NULL) {
+		jwt_write_error(__cmd, "Error parsing JWE JSON");
+		return NULL;
+	}
+
+	/* @rfc{7516,7.2} "protected" is required for the algorithms we support
+	 * (it carries "enc"). Decode and parse it; keep the verbatim b64 for the
+	 * AAD. */
+	prot_b64 = FUNC(json_str_member)(__cmd, obj, "protected", 1);
+	if (prot_b64 == NULL)
+		return NULL;
+	prot_json = jwt_base64uri_decode(prot_b64, &prot_dlen);
+	if (prot_json == NULL || prot_dlen <= 0) {
+		jwt_write_error(__cmd, "Error decoding JWE protected header");
+		return NULL;
+	}
+	prot_json[prot_dlen] = '\0';
+	prot = jwt_json_parse(prot_json, 0, NULL);
+	if (prot == NULL) {
+		jwt_write_error(__cmd, "Error parsing JWE protected header");
+		return NULL;
+	}
+
+	jenc = jwt_json_obj_get(prot, "enc");
+	if (jenc == NULL || !jwt_json_is_string(jenc)) {
+		jwt_write_error(__cmd, "Not a JWE: missing enc header");
+		return NULL;
+	}
+	if (jwt_json_obj_get(prot, "zip") != NULL) {
+		jwt_write_error(__cmd, "JWE \"zip\" is not supported");
+		return NULL;
+	}
+
+	/* @rfc{7516,7.2.1} Locate the recipient. General form has a "recipients"
+	 * array; Flattened hoists "header"/"encrypted_key" to the top level. The
+	 * two forms are mutually exclusive. This stage decrypts a single
+	 * recipient (the first); multi-recipient selection lands later. */
+	recips = jwt_json_obj_get(obj, "recipients");
+	if (recips != NULL) {
+		if (jwt_json_obj_get(obj, "header") != NULL ||
+		    jwt_json_obj_get(obj, "encrypted_key") != NULL) {
 			jwt_write_error(__cmd,
-				"ECDH-ES (Direct) must have an empty Encrypted Key");
+				"JWE JSON has both General and Flattened members");
 			return NULL;
 		}
-		if (!jwe_alg_is_ecdh_direct(alg) && *p_ek == '\0') {
+		if (!jwt_json_is_array(recips) || jwt_json_arr_size(recips) == 0) {
 			jwt_write_error(__cmd,
-				"ECDH-ES+A*KW requires an Encrypted Key");
+				"JWE JSON \"recipients\" must be a non-empty array");
 			return NULL;
 		}
-
-		/* A failed agreement (bad/missing epk, curve mismatch) is a
-		 * structural error, not a key-recovery oracle. */
-		if (jwe_ecdh_derive(alg, enc, recip->key, 0, hdr,
-				    &agreed, &agreed_len)) {
-			jwt_write_error(__cmd, "ECDH-ES key agreement failed");
-			goto fail;
+		rcp = jwt_json_arr_get(recips, 0);
+		if (rcp == NULL) {
+			jwt_write_error(__cmd, "JWE JSON recipient is invalid"); // LCOV_EXCL_LINE
+			return NULL; // LCOV_EXCL_LINE
 		}
-
-		if (jwe_alg_is_ecdh_direct(alg)) {
-			cek = agreed;
-			cek_len = agreed_len;
-			if (cek_len != need) {
-				jwt_write_error(__cmd, "Derived CEK length wrong"); // LCOV_EXCL_LINE
-				goto fail; // LCOV_EXCL_LINE
-			}
-		} else {
-			/* +A*KW: unwrap the CEK with the agreed KEK. @rfc{7516,11.5}
-			 * On any unwrap failure, substitute a random CEK and let
-			 * the AEAD tag fail uniformly. */
-			int bad = 0;
-
-			enckey = jwt_base64uri_decode(p_ek, &ek_len);
-			if (enckey == NULL || ek_len <= 0)
-				bad = 1;
-			else if (jwe_aeskw_unwrap_raw(agreed, agreed_len, enckey,
-						      ek_len, &cek, &cek_len))
-				bad = 1;
-			else if (cek_len != need)
-				bad = 1; // LCOV_EXCL_LINE
-
-			jwt_scrub_and_free(agreed, agreed_len);
-
-			if (bad) {
-				jwt_scrub_and_free(cek, cek_len);
-				cek = NULL;
-				cek_len = 0;
-				if (jwe_generate_cek(enc, &cek, &cek_len))
-					goto oom; // LCOV_EXCL_LINE
-			}
-		}
-	} else if (alg == JWE_ALG_DIR) {
-		size_t need = jwe_enc_cek_len(enc);
-
-		if (*p_ek != '\0') {
-			jwt_write_error(__cmd,
-				"dir must have an empty Encrypted Key");
+		rhdr = jwt_json_obj_get(rcp, "header");
+		ek_b64 = FUNC(json_str_member)(__cmd, rcp, "encrypted_key", 0);
+		if (ek_b64 == NULL && jwt_json_obj_get(rcp, "encrypted_key"))
 			return NULL;
-		}
-		if (jwks_item_key_oct(recip->key, &k, &cek_len) ||
-		    k == NULL || cek_len != need) {
-			jwt_write_error(__cmd,
-				"dir key length does not match enc");
-			return NULL;
-		}
-		cek = jwt_malloc(cek_len);
-		if (cek == NULL)
-			goto oom; // LCOV_EXCL_LINE
-		memcpy(cek, k, cek_len);
 	} else {
-		/* A*KW / RSA-OAEP: the Encrypted Key carries the CEK. */
-		size_t need = jwe_enc_cek_len(enc);
-		int bad = 0;
+		rcp = NULL;
+		rhdr = jwt_json_obj_get(obj, "header");
+		ek_b64 = FUNC(json_str_member)(__cmd, obj, "encrypted_key", 0);
+		if (ek_b64 == NULL && jwt_json_obj_get(obj, "encrypted_key"))
+			return NULL;
+	}
 
-		if (*p_ek == '\0') {
+	/* @rfc{7516,7.2.1} The effective JOSE header is the union of the
+	 * protected, shared-unprotected and per-recipient headers. (Strict
+	 * disjointness enforcement is added in the multi-recipient stage; here a
+	 * later source simply overrides an earlier one.) "alg" and "epk" are read
+	 * from this union. */
+	eff = jwt_json_clone(prot);
+	if (eff == NULL)
+		goto oom; // LCOV_EXCL_LINE
+	unprot = jwt_json_obj_get(obj, "unprotected");
+	if (unprot != NULL) {
+		if (!jwt_json_is_object(unprot)) {
 			jwt_write_error(__cmd,
-				"Key management requires an Encrypted Key");
+				"JWE JSON \"unprotected\" is not an object");
 			return NULL;
 		}
-
-		enckey = jwt_base64uri_decode(p_ek, &ek_len);
-		if (enckey == NULL || ek_len <= 0)
-			bad = 1;
-		else if (jwe_decrypt_cek(alg, recip->key, enckey, ek_len,
-					 &cek, &cek_len))
-			bad = 1;
-		else if (cek_len != need)
-			bad = 1; // LCOV_EXCL_LINE
-
-		/* @rfc{7516,11.5} Do not reveal why CEK recovery failed: a
-		 * padding/format/length error would otherwise be an oracle
-		 * (e.g. Bleichenbacher against RSA). On any failure, substitute
-		 * a random CEK of the correct length and proceed; the AEAD tag
-		 * check below then fails uniformly, indistinguishable from a
-		 * merely-wrong key. */
-		if (bad) {
-			jwt_scrub_and_free(cek, cek_len);
-			cek = NULL;
-			cek_len = 0;
-			if (jwe_generate_cek(enc, &cek, &cek_len))
-				goto oom; // LCOV_EXCL_LINE
+		if (jwt_json_obj_merge(eff, unprot))
+			goto oom; // LCOV_EXCL_LINE
+	}
+	if (rhdr != NULL) {
+		if (!jwt_json_is_object(rhdr)) {
+			jwt_write_error(__cmd,
+				"JWE JSON recipient \"header\" is not an object");
+			return NULL;
 		}
+		if (jwt_json_obj_merge(eff, rhdr))
+			goto oom; // LCOV_EXCL_LINE
 	}
 
-	/* Decode IV, ciphertext, tag. */
-	iv = jwt_base64uri_decode(p_iv, &iv_len);
-	ct = jwt_base64uri_decode(p_ct, &ct_len);
-	tag = jwt_base64uri_decode(p_tag, &tag_len);
-	if (iv == NULL || ct == NULL || tag == NULL || iv_len <= 0 ||
-	    ct_len < 0 || tag_len <= 0) {
-		jwt_write_error(__cmd, "Error decoding JWE components");
-		goto fail;
+	alg_str = FUNC(json_str_member)(__cmd, eff, "alg", 1);
+	enc_str = jwt_json_str_val(jenc);
+	if (alg_str == NULL)
+		return NULL;
+	alg = jwe_str_alg(alg_str);
+	enc = jwe_str_enc(enc_str);
+	if (alg != recip->key_alg || enc != __cmd->c.enc) {
+		jwt_write_error(__cmd, "JWE alg/enc does not match expected");
+		return NULL;
 	}
 
-	/* @rfc{7516,5.2} AAD is ASCII(Encoded Protected Header) = the received
-	 * header bytes verbatim. Decrypt + verify the tag. */
-	if (jwe_decrypt_content(enc, cek, cek_len, iv, iv_len,
-				(const unsigned char *)p_hdr, strlen(p_hdr),
-				ct, ct_len, tag, tag_len, &pt, &pt_len)) {
-		jwt_write_error(__cmd, "JWE authentication/decryption failed");
-		goto fail;
+	/* Required content members. */
+	iv_b64 = FUNC(json_str_member)(__cmd, obj, "iv", 1);
+	ct_b64 = FUNC(json_str_member)(__cmd, obj, "ciphertext", 1);
+	tag_b64 = FUNC(json_str_member)(__cmd, obj, "tag", 1);
+	if (iv_b64 == NULL || ct_b64 == NULL || tag_b64 == NULL)
+		return NULL;
+
+	/* Optional "aad" member: authenticated, and surfaced via get_aad. */
+	aad_b64 = FUNC(json_str_member)(__cmd, obj, "aad", 0);
+	if (aad_b64 == NULL && jwt_json_obj_get(obj, "aad"))
+		return NULL;
+	/* recovered_aad was already reset by decrypt_all; only repopulate it. */
+	if (aad_b64 != NULL) {
+		int raw_len = 0;
+		unsigned char *raw = jwt_base64uri_decode(aad_b64, &raw_len);
+
+		if (raw == NULL || raw_len < 0) {
+			jwt_freemem(raw);
+			jwt_write_error(__cmd, "Error decoding JWE aad");
+			return NULL;
+		}
+		__cmd->c.recovered_aad = raw;
+		__cmd->c.recovered_aad_len = (size_t)raw_len;
 	}
 
-	/* Hand back a nil-terminated buffer for caller convenience. */
-	out = jwt_malloc(pt_len + 1);
-	if (out == NULL)
-		goto oom; // LCOV_EXCL_LINE
-	if (pt_len)
-		memcpy(out, pt, pt_len);
-	out[pt_len] = '\0';
-	if (plaintext_len)
-		*plaintext_len = pt_len;
-
-	goto done;
+	/* The ECDH-ES "epk" is read from the effective header. */
+	return FUNC(recover_and_decrypt)(__cmd, recip, eff, alg, enc, prot_b64,
+					 aad_b64, ek_b64, iv_b64, ct_b64,
+					 tag_b64, plaintext_len);
 
 	// LCOV_EXCL_START
 oom:
 	jwt_write_error(__cmd, "Error allocating memory");
+	return NULL;
 	// LCOV_EXCL_STOP
-fail:
-	out = NULL;
-done:
-	jwt_scrub_and_free(cek, cek_len);
-	jwt_freemem(enckey);
-	jwt_freemem(iv);
-	jwt_freemem(ct);
-	jwt_freemem(tag);
-	jwt_scrub_and_free(pt, pt_len);
+}
 
-	return out;
+/* @rfc{7516,7} Decrypt a JWE in any serialization, auto-detecting compact vs
+ * JSON: a token whose first non-space character is '{' is JSON. */
+unsigned char *FUNC(decrypt_all)(jwe_common_t *__cmd, const char *token,
+				 size_t *plaintext_len)
+{
+	struct jwe_recipient *recip;
+	const char *p;
+
+	if (__cmd == NULL)
+		return NULL;
+
+	if (token == NULL || !strlen(token)) {
+		jwt_write_error(__cmd, "Must pass a token");
+		return NULL;
+	}
+
+	recip = jwe_recipient_first(&__cmd->c);
+	if (recip == NULL || recip->key == NULL ||
+	    recip->key_alg == JWE_ALG_NONE) {
+		jwt_write_error(__cmd, "No key/algorithm set");
+		return NULL;
+	}
+
+	/* @rfc{7516,7.2.1} Reset any AAD recovered from a prior token before this
+	 * decrypt, so get_aad() reflects only the current token regardless of
+	 * serialization or an early failure. Only the JSON path repopulates it. */
+	jwt_scrub_and_free(__cmd->c.recovered_aad, __cmd->c.recovered_aad_len);
+	__cmd->c.recovered_aad = NULL;
+	__cmd->c.recovered_aad_len = 0;
+
+	for (p = token; *p == ' ' || *p == '\t' || *p == '\n' || *p == '\r'; p++)
+		;
+
+	if (*p == '{')
+		return FUNC(decrypt_json)(__cmd, recip, token, plaintext_len);
+
+	return FUNC(decrypt_compact)(__cmd, recip, token, plaintext_len);
+}
+
+/* @rfc{7516,7.2.1} Return the AAD recovered from the last JSON token. */
+const unsigned char *FUNC(get_aad)(const jwe_common_t *__cmd, size_t *aad_len)
+{
+	if (__cmd == NULL)
+		return NULL;
+
+	if (aad_len)
+		*aad_len = __cmd->c.recovered_aad_len;
+
+	return __cmd->c.recovered_aad;
 }
 #endif

--- a/libjwt/jwe.c
+++ b/libjwt/jwe.c
@@ -336,6 +336,42 @@ const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
 	return NULL;
 }
 
+/* @rfc{7516,5.1} step 14 See jwt-private.h for the contract. The base AAD is
+ * ASCII(Encoded Protected Header); a present JWE "aad" member adds '.' plus its
+ * base64url. The no-aad case aliases @protected_b64 with zero allocation, so
+ * the Compact Serialization keeps producing byte-identical AAD. */
+int jwe_build_aad(const char *protected_b64, const char *aad_b64,
+		  const unsigned char **aad, size_t *aad_len, int *owned)
+{
+	size_t plen, alen;
+	char *buf;
+
+	*owned = 0;
+
+	if (aad_b64 == NULL) {
+		*aad = (const unsigned char *)protected_b64;
+		*aad_len = strlen(protected_b64);
+		return 0;
+	}
+
+	plen = strlen(protected_b64);
+	alen = strlen(aad_b64);
+	buf = jwt_malloc(plen + 1 + alen + 1);
+	if (buf == NULL)
+		return 1; // LCOV_EXCL_LINE
+
+	memcpy(buf, protected_b64, plen);
+	buf[plen] = '.';
+	memcpy(buf + plen + 1, aad_b64, alen);
+	buf[plen + 1 + alen] = '\0';
+
+	*aad = (const unsigned char *)buf;
+	*aad_len = plen + 1 + alen;
+	*owned = 1;
+
+	return 0;
+}
+
 /* @rfc{7516,7.2.1} Return the first recipient, or NULL if the list is empty.
  * The Compact and Flattened serializations only ever have this one; the
  * General serialization iterates the list directly. */

--- a/libjwt/jwt-json-ops.h
+++ b/libjwt/jwt-json-ops.h
@@ -120,6 +120,8 @@ int jwt_json_arr_append(jwt_json_t *array, jwt_json_t *value);
  * Type checking
  * ================================================================ */
 JWT_NO_EXPORT
+int jwt_json_is_object(const jwt_json_t *json);
+JWT_NO_EXPORT
 int jwt_json_is_array(const jwt_json_t *json);
 JWT_NO_EXPORT
 int jwt_json_is_string(const jwt_json_t *json);

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -612,6 +612,18 @@ JWT_NO_EXPORT
 const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
 				int for_encrypt);
 
+/* @rfc{7516,5.1} step 14 Build the Additional Authenticated Data for the AEAD.
+ * Compact and the JSON serializations agree on the base: ASCII(@protected_b64).
+ * When a JWE "aad" member is present (its base64url form passed as @aad_b64),
+ * the AAD becomes ASCII(@protected_b64 || '.' || @aad_b64). On return *@aad
+ * points at the AAD bytes and *@aad_len is its length. If *@owned is set, the
+ * caller must free *@aad; otherwise *@aad aliases @protected_b64 (the no-aad
+ * case, byte-identical to the Compact Serialization) and must not be freed.
+ * Returns 0 on success, non-zero on allocation failure. */
+JWT_NO_EXPORT
+int jwe_build_aad(const char *protected_b64, const char *aad_b64,
+		  const unsigned char **aad, size_t *aad_len, int *owned);
+
 /* Recipient list helpers (jwe.c). A recipient is heap-allocated and linked
  * into jwe_common.recipients. jwe_recipient_first() returns the first recipient
  * or NULL; jwe_recipient_first_or_add() returns it, creating an empty one if

--- a/tests/jwe_aad.c
+++ b/tests/jwe_aad.c
@@ -1,0 +1,314 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+static const char PT[] = "Live long and prosper.";
+static const unsigned char AAD[] = "additional authenticated data";
+
+/* @rfc{7516,5.1} step 14 A JSON-serialized JWE with an "aad" member round-trips,
+ * and the checker hands the AAD octets back via get_aad. */
+START_TEST(aad_roundtrip)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	const unsigned char *got;
+	size_t pt_len = 0, got_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder,
+						JWE_FORMAT_JSON_FLAT), 0);
+	ck_assert_int_eq(jwe_builder_set_aad(builder, AAD, strlen((char *)AAD)),
+			 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+	ck_assert_ptr_nonnull(strstr(tok, "\"aad\":"));
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	got = jwe_checker_get_aad(checker, &got_len);
+	ck_assert_ptr_nonnull(got);
+	ck_assert_int_eq(got_len, strlen((char *)AAD));
+	ck_assert_mem_eq(got, AAD, got_len);
+
+	free(pt);
+	free_key();
+}
+END_TEST
+
+/* set_aad(NULL) clears a previously set AAD; the resulting token has no aad
+ * member and recovers no AAD. */
+START_TEST(aad_clear)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder,
+						JWE_FORMAT_JSON_FLAT), 0);
+	ck_assert_int_eq(jwe_builder_set_aad(builder, AAD, strlen((char *)AAD)),
+			 0);
+	/* Clear it again. */
+	ck_assert_int_eq(jwe_builder_set_aad(builder, NULL, 0), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+	ck_assert_ptr_null(strstr(tok, "\"aad\":"));
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_ptr_null(jwe_checker_get_aad(checker, NULL));
+
+	free(pt);
+	free_key();
+}
+END_TEST
+
+/* @rfc{7516,5.1} step 14 The AAD is bound into the AEAD tag: tampering with the
+ * "aad" member must make decryption fail. */
+START_TEST(aad_tamper)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+	char *p;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder,
+						JWE_FORMAT_JSON_FLAT), 0);
+	ck_assert_int_eq(jwe_builder_set_aad(builder, AAD, strlen((char *)AAD)),
+			 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	/* Flip a character inside the base64url aad value. */
+	p = strstr(tok, "\"aad\":\"");
+	ck_assert_ptr_nonnull(p);
+	p += strlen("\"aad\":\"");
+	*p = (*p == 'A') ? 'B' : 'A';
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_null(pt);
+	ck_assert_int_eq(jwe_checker_error(checker), 1);
+
+	free_key();
+}
+END_TEST
+
+/* Without an aad member, the JSON path's AAD equals the Compact path's AAD: a
+ * token built as JSON_FLAT (no aad) and one built as COMPACT share the same
+ * protected header and both decrypt. This pins that jwe_build_aad's no-aad
+ * branch is byte-identical across the two paths. */
+START_TEST(no_aad_matches_compact)
+{
+	jwe_builder_auto_t *bc = NULL, *bj = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *ct = NULL, *jt = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	/* dir keeps the protected header identical across both (just "enc" plus,
+	 * for compact, "alg"); use A256KW so "alg" placement differs but the
+	 * decrypt still succeeds either way. */
+	bc = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(bc, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ct = jwe_builder_generate(bc, (const unsigned char *)PT, strlen(PT));
+	ck_assert_ptr_nonnull(ct);
+
+	bj = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(bj, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(bj, JWE_FORMAT_JSON_FLAT), 0);
+	jt = jwe_builder_generate(bj, (const unsigned char *)PT, strlen(PT));
+	ck_assert_ptr_nonnull(jt);
+
+	/* Both decrypt with the same checker via auto-detect. */
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+
+	pt = jwe_checker_decrypt_all(checker, ct, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_mem_eq(pt, PT, pt_len);
+	free(pt);
+
+	pt = jwe_checker_decrypt_all(checker, jt, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_mem_eq(pt, PT, pt_len);
+	free(pt);
+
+	free_key();
+}
+END_TEST
+
+/* A CBC-HMAC content alg also binds the JSON AAD (the AAD length field AL and
+ * the HMAC cover protected || '.' || aad). */
+START_TEST(aad_cbc)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	const unsigned char *got;
+	size_t pt_len = 0, got_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256CBC_HS512, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder,
+						JWE_FORMAT_JSON_GENERAL), 0);
+	ck_assert_int_eq(jwe_builder_set_aad(builder, AAD, strlen((char *)AAD)),
+			 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256CBC_HS512, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	got = jwe_checker_get_aad(checker, &got_len);
+	ck_assert_ptr_nonnull(got);
+	ck_assert_mem_eq(got, AAD, got_len);
+
+	free(pt);
+	free_key();
+}
+END_TEST
+
+/* get_aad must reflect only the most recent token: decrypting a JSON token with
+ * AAD and then a token without AAD (compact, or JSON-without-aad) must leave no
+ * stale AAD behind. Reusing one checker exercises the reset in decrypt_all. */
+START_TEST(aad_not_stale)
+{
+	jwe_builder_auto_t *bj = NULL, *bc = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *jt = NULL, *ct = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	/* A JSON token carrying AAD. */
+	bj = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(bj, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(bj, JWE_FORMAT_JSON_FLAT), 0);
+	ck_assert_int_eq(jwe_builder_set_aad(bj, AAD, strlen((char *)AAD)), 0);
+	jt = jwe_builder_generate(bj, (const unsigned char *)PT, strlen(PT));
+	ck_assert_ptr_nonnull(jt);
+
+	/* A compact token (no AAD). */
+	bc = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(bc, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ct = jwe_builder_generate(bc, (const unsigned char *)PT, strlen(PT));
+	ck_assert_ptr_nonnull(ct);
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+
+	/* First the JSON token: AAD is recovered. */
+	pt = jwe_checker_decrypt_all(checker, jt, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_ptr_nonnull(jwe_checker_get_aad(checker, NULL));
+	free(pt);
+
+	/* Then the compact token: the prior AAD must NOT linger. */
+	pt = jwe_checker_decrypt_all(checker, ct, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_ptr_null(jwe_checker_get_aad(checker, NULL));
+	free(pt);
+
+	/* A subsequent early-failing decrypt must also leave no stale AAD: decrypt
+	 * the JSON token again, then feed garbage. */
+	pt = jwe_checker_decrypt_all(checker, jt, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_ptr_nonnull(jwe_checker_get_aad(checker, NULL));
+	free(pt);
+	jwe_checker_error_clear(checker);
+	pt = jwe_checker_decrypt_all(checker, "{bad", &pt_len);
+	ck_assert_ptr_null(pt);
+	ck_assert_ptr_null(jwe_checker_get_aad(checker, NULL));
+
+	free_key();
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+
+	tc_core = tcase_create("JWE AAD");
+
+	tcase_add_loop_test(tc_core, aad_roundtrip, 0, i);
+	tcase_add_loop_test(tc_core, aad_clear, 0, i);
+	tcase_add_loop_test(tc_core, aad_tamper, 0, i);
+	tcase_add_loop_test(tc_core, no_aad_matches_compact, 0, i);
+	tcase_add_loop_test(tc_core, aad_cbc, 0, i);
+	tcase_add_loop_test(tc_core, aad_not_stale, 0, i);
+
+	tcase_set_timeout(tc_core, 30);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT JWE AAD");
+}

--- a/tests/jwe_json.c
+++ b/tests/jwe_json.c
@@ -1,0 +1,520 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+static const char PT[] = "{\"sub\":\"1234567890\",\"name\":\"Jane Doe\"}";
+
+/* Build a JSON-serialized JWE and decrypt it back, asserting the plaintext
+ * round-trips and the structural expectations of the chosen form. */
+static void roundtrip(const char *keyfile, jwe_key_alg_t alg, jwe_enc_t enc,
+		      jwe_serialization_t fmt)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	read_json(keyfile);
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, alg, enc, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder, fmt), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	/* The JSON serialization is a JSON object, not a dotted string. */
+	ck_assert_int_eq(tok[0], '{');
+	ck_assert_ptr_nonnull(strstr(tok, "\"protected\":"));
+	ck_assert_ptr_nonnull(strstr(tok, "\"ciphertext\":"));
+	if (fmt == JWE_FORMAT_JSON_GENERAL)
+		ck_assert_ptr_nonnull(strstr(tok, "\"recipients\":"));
+	else
+		ck_assert_ptr_null(strstr(tok, "\"recipients\":"));
+
+	/* The decrypter auto-detects the JSON serialization. */
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, alg, enc, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_int_eq(pt_len, strlen(PT));
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	free(pt);
+	free_key();
+}
+
+START_TEST(flat_dir_gcm)
+{
+	SET_OPS();
+	roundtrip("oct_dir_256.json", JWE_ALG_DIR, JWE_ENC_A256GCM,
+		  JWE_FORMAT_JSON_FLAT);
+}
+END_TEST
+
+START_TEST(flat_aeskw_gcm)
+{
+	SET_OPS();
+	roundtrip("oct_key_256_enc.json", JWE_ALG_A256KW, JWE_ENC_A256GCM,
+		  JWE_FORMAT_JSON_FLAT);
+}
+END_TEST
+
+START_TEST(flat_aeskw_cbc)
+{
+	SET_OPS();
+	roundtrip("oct_key_256_enc.json", JWE_ALG_A256KW, JWE_ENC_A256CBC_HS512,
+		  JWE_FORMAT_JSON_FLAT);
+}
+END_TEST
+
+START_TEST(flat_rsa_gcm)
+{
+	SET_OPS();
+	roundtrip("rsa_key_2048_enc.json", JWE_ALG_RSA_OAEP_256, JWE_ENC_A256GCM,
+		  JWE_FORMAT_JSON_FLAT);
+}
+END_TEST
+
+START_TEST(flat_ecdh_dir)
+{
+	SET_OPS();
+	roundtrip("ec_key_prime256v1_enc.json", JWE_ALG_ECDH_ES,
+		  JWE_ENC_A256GCM, JWE_FORMAT_JSON_FLAT);
+}
+END_TEST
+
+START_TEST(flat_ecdh_kw)
+{
+	SET_OPS();
+	roundtrip("ec_key_secp521r1_enc.json", JWE_ALG_ECDH_ES_A256KW,
+		  JWE_ENC_A256GCM, JWE_FORMAT_JSON_FLAT);
+}
+END_TEST
+
+START_TEST(general_dir_gcm)
+{
+	SET_OPS();
+	roundtrip("oct_dir_256.json", JWE_ALG_DIR, JWE_ENC_A256GCM,
+		  JWE_FORMAT_JSON_GENERAL);
+}
+END_TEST
+
+START_TEST(general_aeskw_gcm)
+{
+	SET_OPS();
+	roundtrip("oct_key_256_enc.json", JWE_ALG_A256KW, JWE_ENC_A256GCM,
+		  JWE_FORMAT_JSON_GENERAL);
+}
+END_TEST
+
+START_TEST(general_rsa_cbc)
+{
+	SET_OPS();
+	roundtrip("rsa_key_2048_enc.json", JWE_ALG_RSA_OAEP_256,
+		  JWE_ENC_A192CBC_HS384, JWE_FORMAT_JSON_GENERAL);
+}
+END_TEST
+
+START_TEST(general_ecdh_kw)
+{
+	SET_OPS();
+	roundtrip("okp_x25519_enc.json", JWE_ALG_ECDH_ES_A128KW,
+		  JWE_ENC_A256GCM, JWE_FORMAT_JSON_GENERAL);
+}
+END_TEST
+
+/* @rfc{7516,7.2.1} For a JSON serialization, "alg" lives in the per-recipient
+ * header, not the protected header; the protected header still carries "enc". */
+START_TEST(alg_in_recipient_header)
+{
+	jwe_builder_auto_t *builder = NULL;
+	char_auto *tok = NULL;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder,
+						JWE_FORMAT_JSON_FLAT), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	/* protected decodes to {"enc":"A256GCM"} (no "alg"); the recipient header
+	 * carries "alg":"A256KW". */
+	ck_assert_ptr_nonnull(strstr(tok, "\"header\":{\"alg\":\"A256KW\"}"));
+	ck_assert_ptr_nonnull(strstr(tok, "\"encrypted_key\":"));
+
+	free_key();
+}
+END_TEST
+
+/* Application-set protected and shared-unprotected header parameters survive a
+ * round-trip and land in the right place. */
+START_TEST(app_headers)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder,
+						JWE_FORMAT_JSON_FLAT), 0);
+	ck_assert_int_eq(jwe_builder_add_protected_json(builder, "cty",
+							"\"example\""), 0);
+	ck_assert_int_eq(jwe_builder_add_unprotected_json(builder, "kid",
+							  "\"2011-04-29\""), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	ck_assert_ptr_nonnull(strstr(tok, "\"unprotected\":{\"kid\":\"2011-04-29\"}"));
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	free(pt);
+	free_key();
+}
+END_TEST
+
+/* Reserved header names cannot be set by the application. */
+START_TEST(reserved_header_rejected)
+{
+	jwe_builder_auto_t *builder = NULL;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+
+	ck_assert_int_ne(jwe_builder_add_protected_json(builder, "enc",
+							"\"A128GCM\""), 0);
+	jwe_builder_error_clear(builder);
+	ck_assert_int_ne(jwe_builder_add_protected_json(builder, "alg",
+							"\"dir\""), 0);
+	jwe_builder_error_clear(builder);
+	ck_assert_int_ne(jwe_builder_add_unprotected_json(builder, "epk",
+							  "{}"), 0);
+	jwe_builder_error_clear(builder);
+
+	/* A malformed JSON value is rejected. */
+	ck_assert_int_ne(jwe_builder_add_protected_json(builder, "x",
+							"{not json"), 0);
+	jwe_builder_error_clear(builder);
+
+	/* Setting the same protected parameter twice is rejected. */
+	ck_assert_int_eq(jwe_builder_add_protected_json(builder, "cty",
+							"\"a\""), 0);
+	ck_assert_int_ne(jwe_builder_add_protected_json(builder, "cty",
+							"\"b\""), 0);
+
+	free_key();
+}
+END_TEST
+
+/* The Compact Serialization cannot carry a shared unprotected header or aad. */
+START_TEST(compact_rejects_json_only)
+{
+	jwe_builder_auto_t *builder = NULL;
+	char *tok;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	/* Format defaults to compact. */
+	ck_assert_int_eq(jwe_builder_add_unprotected_json(builder, "kid",
+							  "\"x\""), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_null(tok);
+	ck_assert_int_eq(jwe_builder_error(builder), 1);
+
+	free_key();
+}
+END_TEST
+
+START_TEST(bad_format_rejected)
+{
+	jwe_builder_auto_t *builder = NULL;
+
+	SET_OPS();
+
+	builder = jwe_builder_new();
+	ck_assert_int_ne(jwe_builder_set_format(builder,
+						(jwe_serialization_t)99), 0);
+	ck_assert_int_eq(jwe_builder_error(builder), 1);
+}
+END_TEST
+
+/* A JSON object missing a required member, or with a wrong-typed member, is
+ * rejected cleanly (and does NOT abort under json-c). */
+START_TEST(json_structural_negatives)
+{
+	jwe_checker_auto_t *checker = NULL;
+	unsigned char *pt;
+	size_t pt_len = 0;
+	size_t i;
+	static const char *bad[] = {
+		/* Malformed top-level JSON (still routed to the JSON path by the
+		 * leading '{'). */
+		"{not valid json",
+		/* Not a JWE object at all. */
+		"{}",
+		/* protected b64 decodes to invalid JSON. */
+		"{\"protected\":\"e2JhZA\",\"iv\":\"a\",\"ciphertext\":\"b\","
+			"\"tag\":\"c\"}",
+		/* protected present but not a string. */
+		"{\"protected\":123,\"iv\":\"a\",\"ciphertext\":\"b\",\"tag\":\"c\"}",
+		/* Missing ciphertext. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\",\"iv\":\"a\",\"tag\":\"c\"}",
+		/* recipients not an array. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\",\"recipients\":5,"
+			"\"iv\":\"a\",\"ciphertext\":\"b\",\"tag\":\"c\"}",
+		/* Empty recipients array. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\",\"recipients\":[],"
+			"\"iv\":\"a\",\"ciphertext\":\"b\",\"tag\":\"c\"}",
+		/* Both General and Flattened members present. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\",\"recipients\":"
+			"[{\"encrypted_key\":\"x\"}],\"encrypted_key\":\"y\","
+			"\"iv\":\"a\",\"ciphertext\":\"b\",\"tag\":\"c\"}",
+		/* unprotected not an object. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\",\"unprotected\":7,"
+			"\"header\":{\"alg\":\"A256KW\"},\"encrypted_key\":\"x\","
+			"\"iv\":\"a\",\"ciphertext\":\"b\",\"tag\":\"c\"}",
+		/* recipient header not an object. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\",\"header\":9,"
+			"\"encrypted_key\":\"x\",\"iv\":\"a\",\"ciphertext\":\"b\","
+			"\"tag\":\"c\"}",
+		/* No alg anywhere. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\",\"encrypted_key\":\"x\","
+			"\"iv\":\"a\",\"ciphertext\":\"b\",\"tag\":\"c\"}",
+		/* protected not valid base64url / JSON. */
+		"{\"protected\":\"@@@\",\"iv\":\"a\",\"ciphertext\":\"b\","
+			"\"tag\":\"c\"}",
+		/* protected decodes but is not a JSON object. */
+		"{\"protected\":\"WzFd\",\"iv\":\"a\",\"ciphertext\":\"b\","
+			"\"tag\":\"c\"}",
+		/* protected has no "enc". */
+		"{\"protected\":\"eyJ4IjoxfQ\",\"header\":{\"alg\":\"A256KW\"},"
+			"\"encrypted_key\":\"x\",\"iv\":\"a\",\"ciphertext\":\"b\","
+			"\"tag\":\"c\"}",
+		/* Top-level (flattened) encrypted_key present but not a string. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\","
+			"\"header\":{\"alg\":\"A256KW\"},\"encrypted_key\":5,"
+			"\"iv\":\"a\",\"ciphertext\":\"b\",\"tag\":\"c\"}",
+		/* General: a recipient encrypted_key that is not a string. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\",\"recipients\":"
+			"[{\"header\":{\"alg\":\"A256KW\"},\"encrypted_key\":5}],"
+			"\"iv\":\"a\",\"ciphertext\":\"b\",\"tag\":\"c\"}",
+		/* iv is not a string. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\","
+			"\"header\":{\"alg\":\"A256KW\"},\"encrypted_key\":\"x\","
+			"\"iv\":5,\"ciphertext\":\"b\",\"tag\":\"c\"}",
+		/* aad present but not a string. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\","
+			"\"header\":{\"alg\":\"A256KW\"},\"encrypted_key\":\"x\","
+			"\"aad\":5,\"iv\":\"a\",\"ciphertext\":\"b\",\"tag\":\"c\"}",
+		/* aad present but not valid base64url. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\","
+			"\"header\":{\"alg\":\"A256KW\"},\"encrypted_key\":\"x\","
+			"\"aad\":\"@@@\",\"iv\":\"a\",\"ciphertext\":\"b\","
+			"\"tag\":\"c\"}",
+		/* zip is not supported. */
+		"{\"protected\":\"eyJlbmMiOiJBMjU2R0NNIiwiemlwIjoiREVGIn0\","
+			"\"header\":{\"alg\":\"A256KW\"},\"encrypted_key\":\"x\","
+			"\"iv\":\"a\",\"ciphertext\":\"b\",\"tag\":\"c\"}",
+	};
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+
+	for (i = 0; i < ARRAY_SIZE(bad); i++) {
+		pt = jwe_checker_decrypt_all(checker, bad[i], &pt_len);
+		ck_assert_ptr_null(pt);
+		ck_assert_int_eq(jwe_checker_error(checker), 1);
+		jwe_checker_error_clear(checker);
+	}
+
+	free_key();
+}
+END_TEST
+
+/* An alg/enc that does not match the checker configuration is rejected. */
+START_TEST(json_alg_mismatch)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder,
+						JWE_FORMAT_JSON_GENERAL), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	/* Checker expects a different enc. */
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A128GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_null(pt);
+	ck_assert_int_eq(jwe_checker_error(checker), 1);
+
+	free_key();
+}
+END_TEST
+
+/* decrypt_all still handles the Compact Serialization (auto-detect). */
+START_TEST(decrypt_all_compact)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+	ck_assert_int_ne(tok[0], '{');
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	/* A compact token carries no AAD member. */
+	ck_assert_ptr_null(jwe_checker_get_aad(checker, NULL));
+
+	free(pt);
+	free_key();
+}
+END_TEST
+
+/* NULL-safety and empty-token handling on the new entry points. */
+START_TEST(api_nullsafe)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	size_t len = 99;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	/* Builder setters reject a NULL builder. */
+	ck_assert_int_ne(jwe_builder_set_format(NULL, JWE_FORMAT_JSON_FLAT), 0);
+	ck_assert_int_ne(jwe_builder_set_aad(NULL, NULL, 0), 0);
+	ck_assert_int_ne(jwe_builder_add_protected_json(NULL, "a", "1"), 0);
+	ck_assert_int_ne(jwe_builder_add_unprotected_json(NULL, "a", "1"), 0);
+
+	/* add_*_json reject a NULL key or value. */
+	builder = jwe_builder_new();
+	ck_assert_int_ne(jwe_builder_add_protected_json(builder, "a", NULL), 0);
+	jwe_builder_error_clear(builder);
+	ck_assert_int_ne(jwe_builder_add_unprotected_json(builder, NULL, "1"), 0);
+	jwe_builder_error_clear(builder);
+
+	ck_assert_ptr_null(jwe_checker_decrypt_all(NULL, "x", NULL));
+	ck_assert_ptr_null(jwe_checker_get_aad(NULL, &len));
+
+	checker = jwe_checker_new();
+	/* No key set yet. */
+	ck_assert_ptr_null(jwe_checker_decrypt_all(checker, "{}", NULL));
+	jwe_checker_error_clear(checker);
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	/* Empty token. */
+	ck_assert_ptr_null(jwe_checker_decrypt_all(checker, "", NULL));
+	/* No AAD recovered yet. */
+	ck_assert_ptr_null(jwe_checker_get_aad(checker, &len));
+	ck_assert_int_eq(len, 0);
+
+	free_key();
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+
+	tc_core = tcase_create("JWE JSON Serialization");
+
+	tcase_add_loop_test(tc_core, flat_dir_gcm, 0, i);
+	tcase_add_loop_test(tc_core, flat_aeskw_gcm, 0, i);
+	tcase_add_loop_test(tc_core, flat_aeskw_cbc, 0, i);
+	tcase_add_loop_test(tc_core, flat_rsa_gcm, 0, i);
+	tcase_add_loop_test(tc_core, flat_ecdh_dir, 0, i);
+	tcase_add_loop_test(tc_core, flat_ecdh_kw, 0, i);
+	tcase_add_loop_test(tc_core, general_dir_gcm, 0, i);
+	tcase_add_loop_test(tc_core, general_aeskw_gcm, 0, i);
+	tcase_add_loop_test(tc_core, general_rsa_cbc, 0, i);
+	tcase_add_loop_test(tc_core, general_ecdh_kw, 0, i);
+	tcase_add_loop_test(tc_core, alg_in_recipient_header, 0, i);
+	tcase_add_loop_test(tc_core, app_headers, 0, i);
+	tcase_add_loop_test(tc_core, reserved_header_rejected, 0, i);
+	tcase_add_loop_test(tc_core, compact_rejects_json_only, 0, i);
+	tcase_add_loop_test(tc_core, bad_format_rejected, 0, i);
+	tcase_add_loop_test(tc_core, json_structural_negatives, 0, i);
+	tcase_add_loop_test(tc_core, json_alg_mismatch, 0, i);
+	tcase_add_loop_test(tc_core, decrypt_all_compact, 0, i);
+	tcase_add_loop_test(tc_core, api_nullsafe, 0, i);
+
+	tcase_set_timeout(tc_core, 30);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT JWE JSON Serialization");
+}


### PR DESCRIPTION
Second stage of JWE JSON Serialization + multiple recipients (#262), stacked on the recipient-list refactor (#270). Adds the RFC 7516 **JSON Serialization for a single recipient** (Flattened + one-recipient General) and the **application AAD member**. The Compact Serialization is unchanged and stays the default. (Multi-recipient General + header disjointness is the next stage.)

## Builder
- `jwe_builder_set_format(COMPACT | JSON_FLAT | JSON_GENERAL)`.
- `jwe_builder_add_protected_json` / `add_unprotected_json` — application header parameters (JSON-valued); library-reserved names (`alg`/`enc`/`epk`/`apu`/`apv`) and duplicates are rejected.
- `jwe_builder_set_aad` — the `aad` member.
- For the JSON serializations the key-management parameters (`alg` and the ECDH-ES `epk`/`apu`/`apv`) move to the **per-recipient header** (each recipient agrees its own `epk`); the protected header keeps `enc`. The Compact path keeps them in the protected header, so its output stays **byte-identical**.

## Checker
- `jwe_checker_decrypt_all` auto-detects compact vs JSON (leading `{`) and parses the Flattened or single-recipient General form. Every member is type-checked before use, so json-c does not abort on malformed input.
- `jwe_checker_get_aad` returns the authenticated AAD recovered from a JSON token; reset per decrypt so it never reflects a prior token.

## AAD difference (RFC 7516 §5.1 step 14)
Centralized in `jwe_build_aad`: no-aad aliases the protected header (byte-identical to compact); a present `aad` member appends `'.' || BASE64URL(aad)`. The CEK-recovery + content-decrypt core is shared by both paths, preserving the **§11.5 uniform random-CEK failure** for every key-management algorithm.

## Verification
- New `tests/jwe_json.c` (round-trips for dir/A\*KW/RSA-OAEP/ECDH-ES × GCM/CBC in both JSON forms; alg-in-recipient-header; app headers; reserved-name + format-constraint rejection; ~20 JSON structural negatives exercising json-c abort-safety; compact auto-detect) and `tests/jwe_aad.c` (round-trip, clear, tamper, no-aad==compact, CBC, not-stale regression).
- 20/20 tests under OpenSSL+GnuTLS+MbedTLS; `jwe.c`/`jwe-common.c`/`jwe-setget.c` at 100% line coverage; ASan-clean.
- A high-effort code review caught one bug (stale `recovered_aad` across a JSON-then-compact decrypt) — fixed and regression-tested.

Refs #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)