### PR TITLE
jwe: multiple recipients (General JSON) + header disjointness (#262)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,7 +359,8 @@ if (CHECK_FOUND)
 
 	# JWE
 	list (APPEND UNIT_TESTS jwe_foundation jwe_keys jwe_gcm jwe_cbc
-		jwe_aeskw jwe_rsa jwe_ecdh jwe_json jwe_aad)
+		jwe_aeskw jwe_rsa jwe_ecdh jwe_json jwe_aad jwe_multi
+		jwe_json_neg)
 
 	# Claims
 	list (APPEND UNIT_TESTS jwt_claims)

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -1414,6 +1414,17 @@ jwe_enc_t jwe_str_enc(const char *enc);
 typedef struct jwe_builder jwe_builder_t;
 
 /**
+ * @brief Opaque JWE recipient handle
+ *
+ * Returned by @ref jwe_builder_add_recipient to address one recipient of a
+ * General JSON Serialization. The handle is borrowed: it is owned by the
+ * builder and valid until the builder is freed; do not free it directly.
+ *
+ * @rfc{7516,7.2.1}
+ */
+typedef struct jwe_recipient jwe_recipient_t;
+
+/**
  * @brief Create a new JWE builder instance
  *
  * @return Pointer to a JWE builder object on success, NULL on failure
@@ -1500,6 +1511,71 @@ JWT_EXPORT
 int jwe_builder_set_partyinfo(jwe_builder_t *builder,
 			      const unsigned char *apu, size_t apu_len,
 			      const unsigned char *apv, size_t apv_len);
+
+/**
+ * @brief Add a recipient to a General JSON Serialization JWE
+ *
+ * The plaintext is encrypted once with a single CEK; each recipient wraps or
+ * encrypts that same CEK independently with its own key management algorithm
+ * and key. The first recipient may equivalently be configured with
+ * @ref jwe_builder_setkey; this call appends further ones. Adding more than one
+ * recipient forces @ref JWE_FORMAT_JSON_GENERAL.
+ *
+ * The shared content encryption algorithm (``"enc"``) must be set via
+ * @ref jwe_builder_setkey. ``dir`` and ECDH-ES Direct (@ref JWE_ALG_ECDH_ES)
+ * dictate the CEK from the key, so they cannot be combined with any other
+ * recipient.
+ *
+ * @param builder Pointer to a JWE builder object
+ * @param alg The recipient's key management algorithm (``"alg"`` header)
+ * @param key The recipient's key (a JWK)
+ * @return A borrowed recipient handle (owned by the builder, valid until it is
+ *  freed) on success, or NULL on error (with the error set in the builder)
+ *
+ * @rfc{7516,7.2.1}
+ */
+JWT_EXPORT
+jwe_recipient_t *jwe_builder_add_recipient(jwe_builder_t *builder,
+					   jwe_key_alg_t alg,
+					   const jwk_item_t *key);
+
+/**
+ * @brief Set the ECDH-ES PartyUInfo / PartyVInfo for one recipient
+ *
+ * The per-recipient equivalent of @ref jwe_builder_set_partyinfo, addressing
+ * the recipient identified by @p recipient. Has no effect for non-ECDH-ES
+ * algorithms. Pass NULL (with length 0) to leave one unset.
+ *
+ * @param recipient A recipient handle from @ref jwe_builder_add_recipient
+ * @param apu PartyUInfo octets, or NULL
+ * @param apu_len Length of @p apu in bytes
+ * @param apv PartyVInfo octets, or NULL
+ * @param apv_len Length of @p apv in bytes
+ * @return 0 on success, non-zero otherwise
+ */
+JWT_EXPORT
+int jwe_recipient_set_partyinfo(jwe_recipient_t *recipient,
+				const unsigned char *apu, size_t apu_len,
+				const unsigned char *apv, size_t apv_len);
+
+/**
+ * @brief Add a parameter to one recipient's unprotected header
+ *
+ * Adds an application-defined member to the per-recipient (unprotected) header
+ * emitted for @p recipient. @p value_json is parsed as JSON (see
+ * @ref jwe_builder_add_protected_json). The library-managed names
+ * (``alg``/``enc``/``epk``/``apu``/``apv``) and a duplicate name are rejected;
+ * the same name must not also appear in the protected or shared unprotected
+ * header (@rfc{7516,7.2.1}).
+ *
+ * @param recipient A recipient handle from @ref jwe_builder_add_recipient
+ * @param key The header parameter name
+ * @param value_json The parameter value as a JSON fragment
+ * @return 0 on success, non-zero otherwise
+ */
+JWT_EXPORT
+int jwe_recipient_add_header_json(jwe_recipient_t *recipient, const char *key,
+				  const char *value_json);
 
 /**
  * @brief Select the serialization @ref jwe_builder_generate produces

--- a/libjwt/jansson/jwt-jansson.c
+++ b/libjwt/jansson/jwt-jansson.c
@@ -175,6 +175,29 @@ int jwt_json_obj_merge_new(jwt_json_t *object, jwt_json_t *other)
 	return json_object_update_missing(to_json(object), to_json(other));
 }
 
+int jwt_json_obj_foreach(const jwt_json_t *object, jwt_json_obj_iter_cb cb,
+			 void *ctx)
+{
+	const char *key;
+	json_t *val;
+	int ret;
+
+	/* Defensive: callers type-check before iterating; a non-object is a
+	 * no-op (matching the abort-safety guards on the array accessors). */
+	if (!object || !cb || !json_is_object(to_json(object)))
+		return 0; // LCOV_EXCL_LINE
+
+	/* The callback gets a borrowed reference; we never mutate during
+	 * iteration. */
+	json_object_foreach(to_json(object), key, val) {
+		ret = cb(key, from_json(val), ctx);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
 /* ================================================================
  * Array operations
  * ================================================================ */

--- a/libjwt/json-c/jwt-json-c.c
+++ b/libjwt/json-c/jwt-json-c.c
@@ -203,6 +203,27 @@ int jwt_json_obj_merge_new(jwt_json_t *object, jwt_json_t *other)
 	return 0;
 }
 
+int jwt_json_obj_foreach(const jwt_json_t *object, jwt_json_obj_iter_cb cb,
+			 void *ctx)
+{
+	int ret;
+
+	/* json_object_object_foreach aborts on a non-object, so type-check
+	 * first (matching the abort-safety guards elsewhere in this backend).
+	 * Callers type-check before iterating, so the guard is defensive. */
+	if (!object || !cb ||
+	    !json_object_is_type(to_jc(object), json_type_object))
+		return 0; // LCOV_EXCL_LINE
+
+	json_object_object_foreach(to_jc(object), key, val) {
+		ret = cb(key, from_jc(val), ctx);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
 /* ================================================================
  * Array operations
  * ================================================================ */

--- a/libjwt/jwe-common.c
+++ b/libjwt/jwe-common.c
@@ -158,26 +158,26 @@ int FUNC(setkey)(jwe_common_t *__cmd, jwe_key_alg_t alg, jwe_enc_t enc,
 }
 
 #ifdef JWE_BUILDER
-/* @rfc{7518,4.6.2} Store apu/apv as base64url for emission in the header and
- * binding into the Concat KDF. NULL/0 leaves a field unset; calling again
- * replaces previous values. */
-int FUNC(set_partyinfo)(jwe_common_t *__cmd,
-			const unsigned char *apu, size_t apu_len,
-			const unsigned char *apv, size_t apv_len)
+/* @rfc{7516,4.1} Header parameter names the library manages itself and that an
+ * application must not set via add_protected_json / add_unprotected_json /
+ * jwe_recipient_add_header_json: "enc" lives in the protected header;
+ * "alg"/"epk"/"apu"/"apv" are placed in the per-recipient header by
+ * setkey/set_partyinfo and the ECDH-ES agreement. */
+static int jwe_header_name_reserved(const char *key)
 {
-	struct jwe_recipient *r;
+	return !strcmp(key, "alg") || !strcmp(key, "enc") ||
+	       !strcmp(key, "epk") || !strcmp(key, "apu") ||
+	       !strcmp(key, "apv");
+}
+
+/* @rfc{7518,4.6.2} Encode apu/apv as base64url into recipient @r. NULL/0 leaves
+ * a field unset; calling again replaces previous values. Returns 0 on success,
+ * non-zero on encode failure. */
+static int jwe_recip_set_partyinfo(struct jwe_recipient *r,
+				   const unsigned char *apu, size_t apu_len,
+				   const unsigned char *apv, size_t apv_len)
+{
 	char *apu_b64 = NULL, *apv_b64 = NULL;
-
-	if (__cmd == NULL)
-		return 1;
-
-	/* @rfc{7518,4.6.2} Party info targets the first recipient (the one set
-	 * by setkey). Create it if setkey has not run yet. */
-	r = jwe_recipient_first_or_add(&__cmd->c);
-	if (r == NULL) {
-		jwt_write_error(__cmd, "Error allocating memory"); // LCOV_EXCL_LINE
-		return 1; // LCOV_EXCL_LINE
-	}
 
 	if (apu && apu_len &&
 	    jwt_base64uri_encode(&apu_b64, (const char *)apu, (int)apu_len) <= 0)
@@ -197,20 +197,147 @@ int FUNC(set_partyinfo)(jwe_common_t *__cmd,
 oom:
 	jwt_freemem(apu_b64);
 	jwt_freemem(apv_b64);
-	jwt_write_error(__cmd, "Error encoding apu/apv");
 	return 1;
 	// LCOV_EXCL_STOP
 }
 
-/* @rfc{7516,4.1} Header parameter names the library manages itself and that an
- * application must not set via add_protected_json / add_unprotected_json:
- * "enc" lives in the protected header; "alg"/"epk"/"apu"/"apv" are placed in
- * the per-recipient header by setkey/set_partyinfo and the ECDH-ES agreement. */
-static int jwe_header_name_reserved(const char *key)
+/* @rfc{7518,4.6.2} Store apu/apv for the first recipient (the one set by
+ * setkey), creating it if setkey has not run yet. */
+int FUNC(set_partyinfo)(jwe_common_t *__cmd,
+			const unsigned char *apu, size_t apu_len,
+			const unsigned char *apv, size_t apv_len)
 {
-	return !strcmp(key, "alg") || !strcmp(key, "enc") ||
-	       !strcmp(key, "epk") || !strcmp(key, "apu") ||
-	       !strcmp(key, "apv");
+	struct jwe_recipient *r;
+
+	if (__cmd == NULL)
+		return 1;
+
+	r = jwe_recipient_first_or_add(&__cmd->c);
+	if (r == NULL) {
+		jwt_write_error(__cmd, "Error allocating memory"); // LCOV_EXCL_LINE
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	if (jwe_recip_set_partyinfo(r, apu, apu_len, apv, apv_len)) {
+		jwt_write_error(__cmd, "Error encoding apu/apv"); // LCOV_EXCL_LINE
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	return 0;
+}
+
+/* @rfc{7516,7.2.1} Append a recipient with its own key management alg and key.
+ * The first recipient may instead be configured via setkey; this appends
+ * further ones (forcing the General JSON Serialization). Returns a borrowed
+ * handle (owned by the builder) or NULL on error. */
+jwe_recipient_t *jwe_builder_add_recipient(jwe_builder_t *builder,
+					   jwe_key_alg_t alg,
+					   const jwk_item_t *key)
+{
+	struct jwe_recipient *r;
+	const char *reason;
+
+	if (builder == NULL)
+		return NULL;
+
+	if (alg == JWE_ALG_NONE || alg >= JWE_ALG_INVAL) {
+		jwt_write_error(builder, "Invalid JWE key management alg");
+		return NULL;
+	}
+
+	if (key == NULL) {
+		jwt_write_error(builder, "JWE requires a key");
+		return NULL;
+	}
+
+	/* @rfc{7516,11.4} Gate the key for the producer (encrypt/wrap). */
+	reason = jwe_key_usage_check(key, alg, 1);
+	if (reason != NULL) {
+		jwt_write_error(builder, "%s", reason);
+		return NULL;
+	}
+
+	/* @rfc{7516,7.2.1} dir / ECDH-ES Direct dictate the CEK from the key, so
+	 * they cannot share a token with any other recipient. Reject early both
+	 * when a direct recipient already exists and when this one is direct and
+	 * the list is non-empty. */
+	if (jwe_alg_is_direct(alg) && builder->c.n_recipients > 0) {
+		jwt_write_error(builder,
+			"dir/ECDH-ES Direct cannot be combined with other recipients");
+		return NULL;
+	}
+	{
+		struct jwe_recipient *first = jwe_recipient_first(&builder->c);
+		if (first != NULL && jwe_alg_is_direct(first->key_alg)) {
+			jwt_write_error(builder,
+				"dir/ECDH-ES Direct cannot be combined with other recipients");
+			return NULL;
+		}
+	}
+
+	r = jwe_recipient_append(&builder->c);
+	if (r == NULL) {
+		jwt_write_error(builder, "Error allocating memory"); // LCOV_EXCL_LINE
+		return NULL; // LCOV_EXCL_LINE
+	}
+
+	r->key_alg = alg;
+	r->key = key;
+
+	/* More than one recipient implies the General JSON Serialization. */
+	if (builder->c.n_recipients > 1)
+		builder->c.format = JWE_FORMAT_JSON_GENERAL;
+
+	return r;
+}
+
+/* @rfc{7518,4.6.2} Per-recipient apu/apv. */
+int jwe_recipient_set_partyinfo(jwe_recipient_t *recipient,
+				const unsigned char *apu, size_t apu_len,
+				const unsigned char *apv, size_t apv_len)
+{
+	if (recipient == NULL)
+		return 1;
+
+	return jwe_recip_set_partyinfo(recipient, apu, apu_len, apv, apv_len);
+}
+
+/* @rfc{7516,7.2.1} Add an application parameter to a recipient's unprotected
+ * header. The recipient's own "header" object is created on first use; the
+ * library-managed names land there during generate(), so guard against an
+ * application setting them. */
+int jwe_recipient_add_header_json(jwe_recipient_t *recipient, const char *key,
+				  const char *value_json)
+{
+	jwt_json_t *val;
+
+	if (recipient == NULL)
+		return 1;
+
+	if (key == NULL || value_json == NULL)
+		return 1;
+
+	if (jwe_header_name_reserved(key))
+		return 1;
+
+	if (recipient->header == NULL) {
+		recipient->header = jwt_json_create();
+		if (recipient->header == NULL)
+			return 1; // LCOV_EXCL_LINE
+	}
+
+	if (jwt_json_obj_get(recipient->header, key) != NULL)
+		return 1;
+
+	val = jwt_json_parse(value_json, JWT_JSON_DECODE_ANY, NULL);
+	if (val == NULL)
+		return 1;
+
+	/* obj_set steals the reference to val on success and on failure. */
+	if (jwt_json_obj_set(recipient->header, key, val))
+		return 1; // LCOV_EXCL_LINE
+
+	return 0;
 }
 
 /* Parse @value_json (a JSON fragment) and set it on @obj under @key. Rejects a
@@ -368,20 +495,44 @@ static char *jwe_assemble_compact(const char *hdr_b64, const char *ek_b64,
 	return out;
 }
 
-/* @rfc{7516,7.2} Assemble a JSON Serialization. @recip_hdr is the single
- * recipient's per-recipient header (may be NULL/empty) and @ek_b64 its
- * Encrypted Key (NULL for dir / ECDH-ES Direct). For JWE_FORMAT_JSON_FLAT the
- * header and encrypted_key are hoisted to the top level; for
- * JWE_FORMAT_JSON_GENERAL they go inside a one-element "recipients" array.
- * Returns a newly allocated string or NULL on error. */
+/* Populate a JSON recipient object @dst from @r: its "header" (cloned, if it
+ * carries any parameter) and "encrypted_key" (its base64url, if @r wrapped the
+ * CEK). Returns 0 on success, non-zero on allocation failure. */
+static int FUNC(fill_recipient_json)(jwt_json_t *dst, struct jwe_recipient *r)
+{
+	if (r->header != NULL && jwt_json_obj_get(r->header, "alg") != NULL) {
+		jwt_json_t *cl = jwt_json_clone(r->header);
+
+		if (cl == NULL || jwt_json_obj_set(dst, "header", cl))
+			return 1; // LCOV_EXCL_LINE
+	}
+
+	if (r->enckey != NULL && r->enckey_len) {
+		char_auto *ek_b64 = NULL;
+
+		if (jwt_base64uri_encode(&ek_b64, (char *)r->enckey,
+					 (int)r->enckey_len) <= 0)
+			return 1; // LCOV_EXCL_LINE
+		if (jwt_json_obj_set(dst, "encrypted_key",
+				     jwt_json_create_str(ek_b64)))
+			return 1; // LCOV_EXCL_LINE
+	}
+
+	return 0;
+}
+
+/* @rfc{7516,7.2} Assemble a JSON Serialization from the recipient list. Each
+ * recipient's "header" and "encrypted_key" were populated by generate(). For
+ * JWE_FORMAT_JSON_FLAT (exactly one recipient) the header and encrypted_key are
+ * hoisted to the top level; for JWE_FORMAT_JSON_GENERAL they go inside a
+ * "recipients" array with one entry per recipient. Returns a newly allocated
+ * string or NULL on error. */
 static char *FUNC(assemble_json)(jwe_common_t *__cmd, const char *hdr_b64,
-				 jwt_json_t *recip_hdr, const char *ek_b64,
 				 const char *iv_b64, const char *ct_b64,
 				 const char *tag_b64)
 {
 	jwt_json_auto_t *obj = NULL;
-	jwt_json_t *rcp_arr = NULL, *rcp = NULL;
-	int recip_hdr_used = 0;
+	struct jwe_recipient *r;
 	char *out = NULL;
 
 	obj = jwt_json_create();
@@ -404,40 +555,27 @@ static char *FUNC(assemble_json)(jwe_common_t *__cmd, const char *hdr_b64,
 	    jwt_json_obj_set(obj, "tag", jwt_json_create_str(tag_b64)))
 		goto oom; // LCOV_EXCL_LINE
 
-	/* A non-empty per-recipient header is emitted; an empty one is omitted. */
-	if (recip_hdr != NULL && jwt_json_obj_get(recip_hdr, "alg") != NULL)
-		recip_hdr_used = 1;
-
 	if (__cmd->c.format == JWE_FORMAT_JSON_FLAT) {
-		/* @rfc{7516,7.2.2} Flattened: header / encrypted_key at top level. */
-		if (recip_hdr_used) {
-			jwt_json_t *cl = jwt_json_clone(recip_hdr);
-			if (cl == NULL || jwt_json_obj_set(obj, "header", cl))
-				goto oom; // LCOV_EXCL_LINE
-		}
-		if (ek_b64 != NULL &&
-		    jwt_json_obj_set(obj, "encrypted_key",
-				     jwt_json_create_str(ek_b64)))
+		/* @rfc{7516,7.2.2} Flattened: the single recipient's header and
+		 * encrypted_key are hoisted to the top level. */
+		r = jwe_recipient_first(&__cmd->c);
+		if (FUNC(fill_recipient_json)(obj, r))
 			goto oom; // LCOV_EXCL_LINE
 	} else {
-		/* @rfc{7516,7.2.1} General: a one-element "recipients" array. */
-		rcp_arr = jwt_json_create_arr();
+		/* @rfc{7516,7.2.1} General: one "recipients" array entry each. */
+		jwt_json_t *rcp_arr = jwt_json_create_arr();
+
 		if (rcp_arr == NULL || jwt_json_obj_set(obj, "recipients", rcp_arr))
 			goto oom; // LCOV_EXCL_LINE
 
-		rcp = jwt_json_create();
-		if (rcp == NULL || jwt_json_arr_append(rcp_arr, rcp))
-			goto oom; // LCOV_EXCL_LINE
+		list_for_each_entry(r, &__cmd->c.recipients, node) {
+			jwt_json_t *rcp = jwt_json_create();
 
-		if (recip_hdr_used) {
-			jwt_json_t *cl = jwt_json_clone(recip_hdr);
-			if (cl == NULL || jwt_json_obj_set(rcp, "header", cl))
+			if (rcp == NULL || jwt_json_arr_append(rcp_arr, rcp))
+				goto oom; // LCOV_EXCL_LINE
+			if (FUNC(fill_recipient_json)(rcp, r))
 				goto oom; // LCOV_EXCL_LINE
 		}
-		if (ek_b64 != NULL &&
-		    jwt_json_obj_set(rcp, "encrypted_key",
-				     jwt_json_create_str(ek_b64)))
-			goto oom; // LCOV_EXCL_LINE
 	}
 
 	/* The protected header was already serialized with sorted keys; the
@@ -456,34 +594,182 @@ oom:
 	// LCOV_EXCL_STOP
 }
 
+/* @rfc{7516,5.1} Produce one recipient's key-management output, writing into
+ * @kmhdr (its key-management header: the per-recipient header for the JSON
+ * serializations, or the shared protected header for Compact) and, for wrapping
+ * algorithms, into @r->enckey. @cek/@cek_len is the shared CEK; for a single
+ * dir / ECDH-ES Direct recipient the CEK is instead PRODUCED here and returned
+ * via *@cek_out / *@cek_out_len (the caller passes cek=NULL in that case).
+ * Returns 0 on success, non-zero with the error set. */
+static int FUNC(wrap_recipient)(jwe_common_t *__cmd, struct jwe_recipient *r,
+				jwt_json_t *kmhdr, const unsigned char *cek,
+				size_t cek_len, unsigned char **cek_out,
+				size_t *cek_out_len)
+{
+	const unsigned char *k;
+	int ret;
+
+	if (jwt_json_obj_set(kmhdr, "alg",
+			     jwt_json_create_str(jwe_alg_str(r->key_alg))))
+		return 1; // LCOV_EXCL_LINE
+
+	/* @rfc{7518,4.6.2} For ECDH-ES, emit apu/apv into the key-management
+	 * header before the agreement, so they bind into the Concat KDF. */
+	if (jwe_alg_is_ecdh(r->key_alg)) {
+		if (r->apu &&
+		    jwt_json_obj_set(kmhdr, "apu", jwt_json_create_str(r->apu)))
+			return 1; // LCOV_EXCL_LINE
+		if (r->apv &&
+		    jwt_json_obj_set(kmhdr, "apv", jwt_json_create_str(r->apv)))
+			return 1; // LCOV_EXCL_LINE
+	}
+
+	if (jwe_alg_is_ecdh(r->key_alg)) {
+		/* @rfc{7518,4.6} Derive the agreed key and write "epk" into the
+		 * key-management header. Direct: the agreed key is the CEK.
+		 * +A*KW: it is the KEK that wraps the shared CEK. */
+		unsigned char *agreed = NULL;
+		size_t agreed_len = 0;
+
+		if (jwe_ecdh_derive(r->key_alg, __cmd->c.enc, r->key, 1, kmhdr,
+				    &agreed, &agreed_len)) {
+			jwt_write_error(__cmd, "ECDH-ES key agreement failed");
+			return 1;
+		}
+
+		if (jwe_alg_is_ecdh_direct(r->key_alg)) {
+			*cek_out = agreed;
+			*cek_out_len = agreed_len;
+			return 0;
+		}
+
+		ret = jwe_aeskw_wrap_raw(agreed, agreed_len, cek, cek_len,
+					 &r->enckey, &r->enckey_len);
+		jwt_scrub_and_free(agreed, agreed_len);
+		if (ret) {
+			jwt_write_error(__cmd, "ECDH-ES key wrap failed"); // LCOV_EXCL_LINE
+			return 1; // LCOV_EXCL_LINE
+		}
+		return 0;
+	}
+
+	if (r->key_alg == JWE_ALG_DIR) {
+		/* dir: the CEK is the shared symmetric key; no Encrypted Key. */
+		size_t need = jwe_enc_cek_len(__cmd->c.enc), klen = 0;
+
+		ret = jwks_item_key_oct(r->key, &k, &klen);
+		if (ret || k == NULL || klen != need) {
+			jwt_write_error(__cmd, "dir key length does not match enc");
+			return 1;
+		}
+		*cek_out = jwt_malloc(klen);
+		if (*cek_out == NULL)
+			return 1; // LCOV_EXCL_LINE
+		memcpy(*cek_out, k, klen);
+		*cek_out_len = klen;
+		return 0;
+	}
+
+	/* A*KW / RSA-OAEP: wrap or encrypt the shared CEK to this recipient. */
+	if (jwe_encrypt_cek(r->key_alg, r->key, cek, cek_len, &r->enckey,
+			    &r->enckey_len)) {
+		jwt_write_error(__cmd, "Could not encrypt the CEK");
+		return 1;
+	}
+
+	return 0;
+}
+
+/* Disjointness accumulator: record every key seen; flag a duplicate. */
+struct jwe_seen_ctx {
+	jwt_json_t *seen;
+	int dup;
+};
+
+static int FUNC(seen_key_cb)(const char *key, jwt_json_t *value, void *p)
+{
+	struct jwe_seen_ctx *ctx = p;
+
+	(void)value;
+	if (jwt_json_obj_get(ctx->seen, key) != NULL) {
+		ctx->dup = 1;
+		return 1;
+	}
+	/* Record the name (value is irrelevant); reuse a small bool. */
+	if (jwt_json_obj_set(ctx->seen, key, jwt_json_create_bool(1)))
+		return 1; // LCOV_EXCL_LINE
+	return 0;
+}
+
+/* @rfc{7516,7.2.1} Verify the application-supplied protected, shared
+ * unprotected and per-recipient headers use pairwise-disjoint parameter names,
+ * so the builder never emits a token its own checker would reject. Called
+ * before the wrap loop adds the library-managed names. Returns 0 if disjoint,
+ * non-zero (with the error set) otherwise. */
+static int FUNC(check_disjoint)(jwe_common_t *__cmd)
+{
+	jwt_json_auto_t *seen = NULL;
+	struct jwe_seen_ctx ctx;
+	struct jwe_recipient *r;
+
+	seen = jwt_json_create();
+	if (seen == NULL)
+		return 0; // LCOV_EXCL_LINE
+	ctx.seen = seen;
+	ctx.dup = 0;
+
+	/* "enc" is always in the protected header; seed it so an application
+	 * cannot duplicate it elsewhere. */
+	if (jwt_json_obj_set(seen, "enc", jwt_json_create_bool(1)))
+		return 0; // LCOV_EXCL_LINE
+
+	jwt_json_obj_foreach(__cmd->c.headers, FUNC(seen_key_cb), &ctx);
+	if (!ctx.dup && __cmd->c.unprotected != NULL)
+		jwt_json_obj_foreach(__cmd->c.unprotected, FUNC(seen_key_cb),
+				     &ctx);
+	if (!ctx.dup) {
+		list_for_each_entry(r, &__cmd->c.recipients, node) {
+			if (r->header != NULL)
+				jwt_json_obj_foreach(r->header,
+						     FUNC(seen_key_cb), &ctx);
+			if (ctx.dup)
+				break;
+		}
+	}
+
+	if (ctx.dup) {
+		jwt_write_error(__cmd,
+			"JWE header parameters are not disjoint");
+		return 1;
+	}
+
+	return 0;
+}
+
 /* @rfc{7516,5.1} Encrypt @plaintext into a JWE. The Compact Serialization is
  * produced unless a JSON format was selected with set_format. */
 char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 		     size_t plaintext_len)
 {
-	struct jwe_recipient *recip;
+	struct jwe_recipient *recip, *first;
 	jwt_json_auto_t *hdr = NULL;
-	jwt_json_t *kmhdr;
-	char_auto *hdr_json = NULL, *hdr_b64 = NULL, *ek_b64 = NULL;
+	char_auto *hdr_json = NULL, *hdr_b64 = NULL;
 	char_auto *iv_b64 = NULL, *ct_b64 = NULL, *tag_b64 = NULL;
 	unsigned char *cek = NULL, *iv = NULL, *ct = NULL, *tag = NULL;
-	unsigned char *enckey = NULL;
 	const unsigned char *aad = NULL;
-	size_t cek_len = 0, iv_len, ct_len = 0, tag_len = 0, enckey_len = 0;
-	size_t aad_len = 0;
-	int aad_owned = 0, is_json;
-	const unsigned char *k;
+	size_t cek_len = 0, iv_len, ct_len = 0, tag_len = 0, aad_len = 0;
+	int aad_owned = 0, is_json, n, has_direct = 0;
 	char *out = NULL;
 	int hdr_len, ret;
 
 	if (__cmd == NULL)
 		return NULL;
 
-	/* @rfc{7516,7.2.1} The Compact and Flattened serializations have exactly
-	 * one recipient, configured via setkey. */
-	recip = jwe_recipient_first(&__cmd->c);
-	if (recip == NULL || recip->key == NULL ||
-	    recip->key_alg == JWE_ALG_NONE) {
+	/* @rfc{7516,7.2.1} At least one recipient must be configured (via setkey
+	 * or add_recipient). */
+	first = jwe_recipient_first(&__cmd->c);
+	if (first == NULL || first->key == NULL ||
+	    first->key_alg == JWE_ALG_NONE) {
 		jwt_write_error(__cmd, "No key/algorithm set");
 		return NULL;
 	}
@@ -493,25 +779,55 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 		return NULL;
 	}
 
+	n = __cmd->c.n_recipients;
 	is_json = (__cmd->c.format != JWE_FORMAT_COMPACT);
 
-	/* @rfc{7516,7.1} The Compact Serialization cannot carry a shared
-	 * unprotected header or a JWE AAD member; only the JSON serializations
-	 * can. (Multi-recipient is enforced in a later stage.) */
+	/* @rfc{7516,7.2.1} dir / ECDH-ES Direct dictate the CEK from the key, so
+	 * they cannot share a token with other recipients. */
+	list_for_each_entry(recip, &__cmd->c.recipients, node) {
+		if (jwe_alg_is_direct(recip->key_alg))
+			has_direct = 1;
+	}
+	/* add_recipient already rejects mixing a direct alg with others, so this
+	 * is a defensive backstop. */
+	if (has_direct && n > 1) {
+		// LCOV_EXCL_START
+		jwt_write_error(__cmd,
+			"dir/ECDH-ES Direct cannot be combined with other recipients");
+		return NULL;
+		// LCOV_EXCL_STOP
+	}
+
+	/* @rfc{7516,7.1} @rfc{7516,7.2.2} The Compact and Flattened
+	 * serializations carry exactly one recipient; Compact additionally
+	 * cannot carry a shared unprotected header or a JWE AAD member. */
 	if (!is_json &&
 	    (__cmd->c.unprotected != NULL || __cmd->c.aad_b64 != NULL)) {
 		jwt_write_error(__cmd,
 			"Compact Serialization cannot carry unprotected header or aad");
 		return NULL;
 	}
+	if (!is_json && n > 1) {
+		jwt_write_error(__cmd,
+			"Compact Serialization supports only one recipient");
+		return NULL;
+	}
+	if (__cmd->c.format == JWE_FORMAT_JSON_FLAT && n > 1) {
+		jwt_write_error(__cmd,
+			"Flattened JSON Serialization supports only one recipient");
+		return NULL;
+	}
 
-	/* @rfc{7516,5.1} step 12-13: build the protected header. It always
-	 * carries "enc". For the Compact Serialization the key-management
-	 * parameters ("alg", and the ECDH-ES "epk"/"apu"/"apv") also live in the
-	 * protected header, so they are bound into the single AAD. For the JSON
-	 * serializations they belong in the per-recipient header instead, since
-	 * each recipient agrees its own "epk". @kmhdr is whichever object
-	 * receives those key-management parameters. */
+	/* @rfc{7516,7.2.1} For the JSON serializations, the application-supplied
+	 * protected / shared-unprotected / per-recipient header parameter names
+	 * must be pairwise disjoint. (Compact has only the protected header.) */
+	if (is_json && FUNC(check_disjoint)(__cmd))
+		return NULL;
+
+	/* @rfc{7516,5.1} step 12-13: the protected header always carries "enc".
+	 * For the Compact Serialization the key-management parameters ("alg" and
+	 * the ECDH-ES "epk"/"apu"/"apv") also live here (bound into the AAD); for
+	 * the JSON serializations they go in each recipient's own header. */
 	hdr = jwt_json_create();
 	if (hdr == NULL)
 		goto oom; // LCOV_EXCL_LINE
@@ -521,123 +837,53 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 		return NULL; // LCOV_EXCL_LINE
 	}
 
-	if (is_json) {
-		if (recip->header == NULL) {
-			recip->header = jwt_json_create();
-			if (recip->header == NULL)
-				goto oom; // LCOV_EXCL_LINE
-		}
-		kmhdr = recip->header;
-	} else {
-		kmhdr = hdr;
+	/* @rfc{7516,5.1} step 2: produce the single shared CEK. A lone dir /
+	 * ECDH-ES Direct recipient instead dictates the CEK during its wrap pass
+	 * below, so only generate a random CEK when no direct recipient is used. */
+	if (!has_direct && jwe_generate_cek(__cmd->c.enc, &cek, &cek_len)) {
+		// LCOV_EXCL_START
+		jwt_write_error(__cmd, "Could not generate CEK");
+		return NULL;
+		// LCOV_EXCL_STOP
 	}
 
-	if (jwt_json_obj_set(kmhdr, "alg",
-			     jwt_json_create_str(jwe_alg_str(recip->key_alg))))
-		goto oom; // LCOV_EXCL_LINE
+	/* @rfc{7516,5.1} Per recipient: build its key-management header and wrap
+	 * the shared CEK (or, for a lone direct recipient, derive the CEK). */
+	list_for_each_entry(recip, &__cmd->c.recipients, node) {
+		jwt_json_t *kmhdr;
 
-	/* @rfc{7518,4.6.2} For ECDH-ES, emit any apu/apv into the key-management
-	 * header before the agreement runs, so they are bound into the Concat
-	 * KDF. */
-	if (jwe_alg_is_ecdh(recip->key_alg)) {
-		if (recip->apu &&
-		    jwt_json_obj_set(kmhdr, "apu",
-				     jwt_json_create_str(recip->apu)))
-			goto oom; // LCOV_EXCL_LINE
-		if (recip->apv &&
-		    jwt_json_obj_set(kmhdr, "apv",
-				     jwt_json_create_str(recip->apv)))
-			goto oom; // LCOV_EXCL_LINE
-	}
-
-	/* @rfc{7518,4.6} ECDH-ES (Direct): derive the CEK and add the "epk"
-	 * to the key-management header BEFORE the protected header is serialized,
-	 * since the protected header bytes are (part of) the AAD. The Encrypted
-	 * Key stays empty (like dir). */
-	if (jwe_alg_is_ecdh(recip->key_alg)) {
-		/* @rfc{7518,4.6} Derive the agreed key and emit "epk" while the
-		 * header object can still be modified. For Direct mode the
-		 * agreed key is the CEK; for +A*KW it is the KEK. */
-		unsigned char *agreed = NULL;
-		size_t agreed_len = 0;
-
-		if (jwe_ecdh_derive(recip->key_alg, __cmd->c.enc,
-				    recip->key, 1, kmhdr, &agreed, &agreed_len)) {
-			jwt_write_error(__cmd, "ECDH-ES key agreement failed");
-			return NULL;
-		}
-
-		if (jwe_alg_is_ecdh_direct(recip->key_alg)) {
-			cek = agreed;
-			cek_len = agreed_len;
+		if (is_json) {
+			if (recip->header == NULL) {
+				recip->header = jwt_json_create();
+				if (recip->header == NULL)
+					goto oom; // LCOV_EXCL_LINE
+			}
+			kmhdr = recip->header;
 		} else {
-			/* +A*KW: wrap a fresh CEK with the agreed KEK. */
-			int werr;
+			kmhdr = hdr;
+		}
 
-			if (jwe_generate_cek(__cmd->c.enc, &cek, &cek_len)) {
-				// LCOV_EXCL_START
-				jwt_scrub_and_free(agreed, agreed_len);
-				jwt_write_error(__cmd, "Could not generate CEK");
-				return NULL;
-				// LCOV_EXCL_STOP
-			}
-			werr = jwe_aeskw_wrap_raw(agreed, agreed_len, cek,
-						 cek_len, &enckey, &enckey_len);
-			jwt_scrub_and_free(agreed, agreed_len);
-			if (werr) {
-				jwt_write_error(__cmd, "ECDH-ES key wrap failed"); // LCOV_EXCL_LINE
-				goto fail; // LCOV_EXCL_LINE
-			}
+		if (has_direct) {
+			/* The lone direct recipient produces the CEK. */
+			if (FUNC(wrap_recipient)(__cmd, recip, kmhdr, NULL, 0,
+						 &cek, &cek_len))
+				goto fail;
+		} else {
+			if (FUNC(wrap_recipient)(__cmd, recip, kmhdr, cek,
+						 cek_len, &cek, &cek_len))
+				goto fail;
 		}
 	}
 
+	/* @rfc{7516,5.1} Serialize the protected header (after the wrap loop,
+	 * which for the Compact Serialization populated it with alg/epk/apu/apv).
+	 * The JSON serializations leave it as just enc + application params. */
 	hdr_json = jwt_json_serialize(hdr, JWT_JSON_SORT_KEYS | JWT_JSON_COMPACT);
 	if (hdr_json == NULL)
 		goto oom; // LCOV_EXCL_LINE
 
 	hdr_len = jwt_base64uri_encode(&hdr_b64, hdr_json, (int)strlen(hdr_json));
 	if (hdr_len <= 0)
-		goto oom; // LCOV_EXCL_LINE
-
-	/* @rfc{7516,5.1} Produce the CEK and the JWE Encrypted Key per the key
-	 * management algorithm. */
-	if (jwe_alg_is_ecdh(recip->key_alg)) {
-		/* ECDH-ES: the CEK (Direct) or CEK+Encrypted Key (+A*KW) was
-		 * already produced above, before the header was serialized. */
-	} else if (recip->key_alg == JWE_ALG_DIR) {
-		/* dir: the CEK is the shared symmetric key; Encrypted Key is
-		 * empty. */
-		size_t need = jwe_enc_cek_len(__cmd->c.enc);
-
-		ret = jwks_item_key_oct(recip->key, &k, &cek_len);
-		if (ret || k == NULL || cek_len != need) {
-			jwt_write_error(__cmd,
-				"dir key length does not match enc");
-			return NULL;
-		}
-		cek = jwt_malloc(cek_len);
-		if (cek == NULL)
-			goto oom; // LCOV_EXCL_LINE
-		memcpy(cek, k, cek_len);
-	} else {
-		/* A*KW / RSA-OAEP: generate a random CEK and wrap or encrypt it
-		 * to the recipient. */
-		if (jwe_generate_cek(__cmd->c.enc, &cek, &cek_len)) {
-			// LCOV_EXCL_START
-			jwt_write_error(__cmd, "Could not generate CEK");
-			return NULL;
-			// LCOV_EXCL_STOP
-		}
-		if (jwe_encrypt_cek(recip->key_alg, recip->key, cek, cek_len,
-				    &enckey, &enckey_len)) {
-			jwt_write_error(__cmd, "Could not encrypt the CEK");
-			goto fail;
-		}
-	}
-
-	/* Encode the Encrypted Key (empty for dir). */
-	if (enckey_len &&
-	    jwt_base64uri_encode(&ek_b64, (char *)enckey, (int)enckey_len) <= 0)
 		goto oom; // LCOV_EXCL_LINE
 
 	/* @rfc{7516,5.1} step 9: generate the IV. */
@@ -652,10 +898,9 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 		// LCOV_EXCL_STOP
 	}
 
-	/* @rfc{7516,5.1} step 14-15: build the AAD and encrypt the content. For
-	 * the Compact Serialization there is no "aad" member, so jwe_build_aad
-	 * aliases hdr_b64 (byte-identical). For the JSON serializations a present
-	 * "aad" member appends '.' || BASE64URL(aad). */
+	/* @rfc{7516,5.1} step 14-15: build the AAD and encrypt the content once.
+	 * No "aad" member -> jwe_build_aad aliases hdr_b64 (byte-identical to
+	 * Compact); a present "aad" member appends '.' || BASE64URL(aad). */
 	if (jwe_build_aad(hdr_b64, __cmd->c.aad_b64, &aad, &aad_len, &aad_owned))
 		goto oom; // LCOV_EXCL_LINE
 	ret = jwe_encrypt_content(__cmd->c.enc, cek, cek_len, iv, iv_len,
@@ -677,11 +922,18 @@ char *FUNC(generate)(jwe_common_t *__cmd, const unsigned char *plaintext,
 	/* @rfc{7516,7} Assemble in the configured serialization. assemble_json
 	 * sets its own error; the compact path only fails on OOM. */
 	if (is_json) {
-		out = FUNC(assemble_json)(__cmd, hdr_b64, recip->header, ek_b64,
-					  iv_b64, ct_b64, tag_b64);
+		out = FUNC(assemble_json)(__cmd, hdr_b64, iv_b64, ct_b64, tag_b64);
 		if (out == NULL)
 			goto fail; // LCOV_EXCL_LINE
 	} else {
+		char_auto *ek_b64 = NULL;
+
+		/* Compact has exactly one recipient; its Encrypted Key (if any)
+		 * is the second segment. */
+		if (first->enckey != NULL && first->enckey_len &&
+		    jwt_base64uri_encode(&ek_b64, (char *)first->enckey,
+					 (int)first->enckey_len) <= 0)
+			goto oom; // LCOV_EXCL_LINE
 		out = jwe_assemble_compact(hdr_b64, ek_b64, iv_b64, ct_b64,
 					   tag_b64);
 		if (out == NULL)
@@ -702,7 +954,6 @@ done:
 		jwt_freemem(aad_free);
 	}
 	jwt_scrub_and_free(cek, cek_len);
-	jwt_freemem(enckey);
 	jwt_freemem(iv);
 	jwt_freemem(ct);
 	jwt_freemem(tag);
@@ -1041,21 +1292,91 @@ static const char *FUNC(json_str_member)(jwe_common_t *__cmd, jwt_json_t *obj,
 	return jwt_json_str_val(m);
 }
 
-/* @rfc{7516,7.2} Decrypt a JSON Serialization (Flattened or single-recipient
- * General). The protected header is authenticated; the per-recipient header
- * supplies "alg" (and the ECDH-ES "epk"). Multi-recipient selection and full
- * header-disjointness enforcement are added in a later stage. */
+/* Context for the disjointness check: merge each visited key into @dst and flag
+ * @dup if a key is already present (it then appeared in more than one header). */
+struct jwe_merge_ctx {
+	jwt_json_t *dst;
+	int dup;
+	int err;
+};
+
+static int FUNC(merge_disjoint_cb)(const char *key, jwt_json_t *value, void *p)
+{
+	struct jwe_merge_ctx *ctx = p;
+
+	if (jwt_json_obj_get(ctx->dst, key) != NULL) {
+		ctx->dup = 1;
+		return 1;	/* stop: a parameter occurred in two headers */
+	}
+
+	{
+		jwt_json_t *cl = jwt_json_clone(value);
+
+		if (cl == NULL || jwt_json_obj_set(ctx->dst, key, cl)) {
+			ctx->err = 1; // LCOV_EXCL_LINE
+			return 1; // LCOV_EXCL_LINE
+		}
+	}
+
+	return 0;
+}
+
+/* @rfc{7516,7.2.1} Build the effective JOSE header as the union of @prot, the
+ * shared @unprot and the per-recipient @rhdr, enforcing that the same parameter
+ * name does not occur in more than one of them. @unprot/@rhdr may be NULL.
+ * Returns the new header (caller releases) or NULL; *@dup is set when the
+ * disjointness rule is violated (a structural error, distinct from OOM). */
+static jwt_json_t *FUNC(effective_header)(jwt_json_t *prot, jwt_json_t *unprot,
+					  jwt_json_t *rhdr, int *dup)
+{
+	struct jwe_merge_ctx ctx;
+
+	*dup = 0;
+
+	ctx.dst = jwt_json_clone(prot);
+	if (ctx.dst == NULL)
+		return NULL; // LCOV_EXCL_LINE
+	ctx.dup = 0;
+	ctx.err = 0;
+
+	if (unprot != NULL)
+		jwt_json_obj_foreach(unprot, FUNC(merge_disjoint_cb), &ctx);
+	if (!ctx.dup && !ctx.err && rhdr != NULL)
+		jwt_json_obj_foreach(rhdr, FUNC(merge_disjoint_cb), &ctx);
+
+	if (ctx.err) {
+		// LCOV_EXCL_START
+		jwt_json_release(ctx.dst);
+		return NULL;
+		// LCOV_EXCL_STOP
+	}
+	if (ctx.dup) {
+		jwt_json_release(ctx.dst);
+		*dup = 1;
+		return NULL;
+	}
+
+	return ctx.dst;
+}
+
+/* @rfc{7516,7.2} Decrypt a JSON Serialization (Flattened or General). The
+ * protected header is authenticated; each recipient's per-recipient header
+ * supplies "alg" (and the ECDH-ES "epk"). For the General form the recipient
+ * whose "alg" matches the checker configuration is selected; @rfc{7516,11.5}
+ * if none matches (or selection/unwrap fails) a random CEK is used so the AEAD
+ * tag fails uniformly. */
 static unsigned char *FUNC(decrypt_json)(jwe_common_t *__cmd,
 		struct jwe_recipient *recip, const char *token,
 		size_t *plaintext_len)
 {
 	jwt_json_auto_t *obj = NULL, *prot = NULL, *eff = NULL;
 	char_auto *prot_json = NULL;
-	jwt_json_t *recips, *rcp, *rhdr, *unprot, *jenc;
-	const char *prot_b64, *iv_b64, *ct_b64, *tag_b64, *aad_b64, *ek_b64;
-	const char *alg_str, *enc_str;
-	int prot_dlen = 0;
-	jwe_key_alg_t alg;
+	jwt_json_t *recips, *rcp, *rhdr, *unprot, *jenc, *sel_rcp = NULL;
+	const char *prot_b64, *iv_b64, *ct_b64, *tag_b64, *aad_b64;
+	const char *ek_b64 = NULL, *enc_str;
+	unsigned char *aad_raw = NULL, *out = NULL;
+	size_t aad_raw_len = 0;
+	int prot_dlen = 0, n_rcp, idx;
 	jwe_enc_t enc;
 
 	obj = jwt_json_parse(token, 0, NULL);
@@ -1091,11 +1412,24 @@ static unsigned char *FUNC(decrypt_json)(jwe_common_t *__cmd,
 		jwt_write_error(__cmd, "JWE \"zip\" is not supported");
 		return NULL;
 	}
+	enc_str = jwt_json_str_val(jenc);
+	enc = jwe_str_enc(enc_str);
+	if (enc != __cmd->c.enc) {
+		jwt_write_error(__cmd, "JWE enc does not match expected");
+		return NULL;
+	}
 
-	/* @rfc{7516,7.2.1} Locate the recipient. General form has a "recipients"
-	 * array; Flattened hoists "header"/"encrypted_key" to the top level. The
-	 * two forms are mutually exclusive. This stage decrypts a single
-	 * recipient (the first); multi-recipient selection lands later. */
+	/* @rfc{7516,7.2.1} The shared unprotected header (if any) must be an
+	 * object. */
+	unprot = jwt_json_obj_get(obj, "unprotected");
+	if (unprot != NULL && !jwt_json_is_object(unprot)) {
+		jwt_write_error(__cmd, "JWE JSON \"unprotected\" is not an object");
+		return NULL;
+	}
+
+	/* @rfc{7516,7.2.1} General form has a "recipients" array; Flattened
+	 * hoists "header"/"encrypted_key" to the top level; the two forms are
+	 * mutually exclusive. */
 	recips = jwt_json_obj_get(obj, "recipients");
 	if (recips != NULL) {
 		if (jwt_json_obj_get(obj, "header") != NULL ||
@@ -1109,74 +1443,74 @@ static unsigned char *FUNC(decrypt_json)(jwe_common_t *__cmd,
 				"JWE JSON \"recipients\" must be a non-empty array");
 			return NULL;
 		}
-		rcp = jwt_json_arr_get(recips, 0);
-		if (rcp == NULL) {
-			jwt_write_error(__cmd, "JWE JSON recipient is invalid"); // LCOV_EXCL_LINE
-			return NULL; // LCOV_EXCL_LINE
-		}
-		rhdr = jwt_json_obj_get(rcp, "header");
-		ek_b64 = FUNC(json_str_member)(__cmd, rcp, "encrypted_key", 0);
-		if (ek_b64 == NULL && jwt_json_obj_get(rcp, "encrypted_key"))
-			return NULL;
+		n_rcp = (int)jwt_json_arr_size(recips);
 	} else {
-		rcp = NULL;
-		rhdr = jwt_json_obj_get(obj, "header");
-		ek_b64 = FUNC(json_str_member)(__cmd, obj, "encrypted_key", 0);
-		if (ek_b64 == NULL && jwt_json_obj_get(obj, "encrypted_key"))
-			return NULL;
+		n_rcp = 1;	/* synthetic single recipient (Flattened) */
 	}
 
-	/* @rfc{7516,7.2.1} The effective JOSE header is the union of the
-	 * protected, shared-unprotected and per-recipient headers. (Strict
-	 * disjointness enforcement is added in the multi-recipient stage; here a
-	 * later source simply overrides an earlier one.) "alg" and "epk" are read
-	 * from this union. */
-	eff = jwt_json_clone(prot);
-	if (eff == NULL)
-		goto oom; // LCOV_EXCL_LINE
-	unprot = jwt_json_obj_get(obj, "unprotected");
-	if (unprot != NULL) {
-		if (!jwt_json_is_object(unprot)) {
-			jwt_write_error(__cmd,
-				"JWE JSON \"unprotected\" is not an object");
-			return NULL;
+	/* @rfc{7516,7.2.1} @rfc{7516,11.5} Select the recipient whose effective
+	 * "alg" matches the checker configuration. Matching on the public "alg"
+	 * (and not on key-recovery success) leaks nothing. Build the matching
+	 * recipient's effective header, enforcing header disjointness. */
+	for (idx = 0; idx < n_rcp; idx++) {
+		jwt_json_t *cand_eff;
+		const char *alg_str;
+		int d = 0;
+
+		if (recips != NULL) {
+			rcp = jwt_json_arr_get(recips, (size_t)idx);
+			if (rcp == NULL) {
+				jwt_write_error(__cmd, "JWE JSON recipient is invalid"); // LCOV_EXCL_LINE
+				return NULL; // LCOV_EXCL_LINE
+			}
+		} else {
+			rcp = obj;	/* Flattened: header/encrypted_key at top */
 		}
-		if (jwt_json_obj_merge(eff, unprot))
-			goto oom; // LCOV_EXCL_LINE
-	}
-	if (rhdr != NULL) {
-		if (!jwt_json_is_object(rhdr)) {
+
+		rhdr = jwt_json_obj_get(rcp, "header");
+		if (rhdr != NULL && !jwt_json_is_object(rhdr)) {
 			jwt_write_error(__cmd,
 				"JWE JSON recipient \"header\" is not an object");
 			return NULL;
 		}
-		if (jwt_json_obj_merge(eff, rhdr))
+
+		/* @rfc{7516,7.2.1} A header parameter must not occur in more than
+		 * one of protected / shared-unprotected / per-recipient. This is a
+		 * structural error (pre-crypto), not a key-recovery oracle. */
+		cand_eff = FUNC(effective_header)(prot, unprot, rhdr, &d);
+		if (cand_eff == NULL) {
+			if (d) {
+				jwt_write_error(__cmd,
+					"JWE header parameters are not disjoint");
+				return NULL;
+			}
 			goto oom; // LCOV_EXCL_LINE
+		}
+
+		alg_str = jwt_json_str_val(jwt_json_obj_get(cand_eff, "alg"));
+		if (alg_str != NULL && jwe_str_alg(alg_str) == recip->key_alg &&
+		    sel_rcp == NULL) {
+			/* First alg-match wins; keep its effective header. */
+			sel_rcp = rcp;
+			eff = cand_eff;
+		} else {
+			jwt_json_release(cand_eff);
+		}
 	}
 
-	alg_str = FUNC(json_str_member)(__cmd, eff, "alg", 1);
-	enc_str = jwt_json_str_val(jenc);
-	if (alg_str == NULL)
-		return NULL;
-	alg = jwe_str_alg(alg_str);
-	enc = jwe_str_enc(enc_str);
-	if (alg != recip->key_alg || enc != __cmd->c.enc) {
-		jwt_write_error(__cmd, "JWE alg/enc does not match expected");
-		return NULL;
-	}
-
-	/* Required content members. */
+	/* Required content members (per token). */
 	iv_b64 = FUNC(json_str_member)(__cmd, obj, "iv", 1);
 	ct_b64 = FUNC(json_str_member)(__cmd, obj, "ciphertext", 1);
 	tag_b64 = FUNC(json_str_member)(__cmd, obj, "tag", 1);
 	if (iv_b64 == NULL || ct_b64 == NULL || tag_b64 == NULL)
 		return NULL;
 
-	/* Optional "aad" member: authenticated, and surfaced via get_aad. */
+	/* Optional "aad" member: validate and decode it now, but only surface it
+	 * via get_aad AFTER the content authenticates (an unauthenticated aad
+	 * must not be returned). */
 	aad_b64 = FUNC(json_str_member)(__cmd, obj, "aad", 0);
 	if (aad_b64 == NULL && jwt_json_obj_get(obj, "aad"))
 		return NULL;
-	/* recovered_aad was already reset by decrypt_all; only repopulate it. */
 	if (aad_b64 != NULL) {
 		int raw_len = 0;
 		unsigned char *raw = jwt_base64uri_decode(aad_b64, &raw_len);
@@ -1186,14 +1520,43 @@ static unsigned char *FUNC(decrypt_json)(jwe_common_t *__cmd,
 			jwt_write_error(__cmd, "Error decoding JWE aad");
 			return NULL;
 		}
-		__cmd->c.recovered_aad = raw;
-		__cmd->c.recovered_aad_len = (size_t)raw_len;
+		aad_raw = raw;
+		aad_raw_len = (size_t)raw_len;
 	}
 
-	/* The ECDH-ES "epk" is read from the effective header. */
-	return FUNC(recover_and_decrypt)(__cmd, recip, eff, alg, enc, prot_b64,
-					 aad_b64, ek_b64, iv_b64, ct_b64,
-					 tag_b64, plaintext_len);
+	/* @rfc{7516,11.5} No recipient carried our (public) "alg": fail with the
+	 * generic authentication error. The alg is not secret, so this leaks
+	 * nothing a padding oracle could exploit; it is indistinguishable from a
+	 * wrong-key tag failure at the API surface (NULL + the same message). */
+	if (sel_rcp == NULL) {
+		jwt_scrub_and_free(aad_raw, aad_raw_len);
+		jwt_write_error(__cmd, "JWE authentication/decryption failed");
+		return NULL;
+	}
+
+	/* The selected recipient's Encrypted Key (absent for dir / ECDH Direct);
+	 * a present-but-non-string encrypted_key is a structural error. */
+	ek_b64 = FUNC(json_str_member)(__cmd, sel_rcp, "encrypted_key", 0);
+	if (ek_b64 == NULL && jwt_json_obj_get(sel_rcp, "encrypted_key")) {
+		jwt_scrub_and_free(aad_raw, aad_raw_len);
+		return NULL;
+	}
+
+	/* The ECDH-ES "epk" is read from the selected effective header.
+	 * recover_and_decrypt funnels any CEK-recovery failure to a random CEK so
+	 * the tag check fails uniformly (no Bleichenbacher-style oracle). */
+	out = FUNC(recover_and_decrypt)(__cmd, recip, eff, recip->key_alg, enc,
+					prot_b64, aad_b64, ek_b64, iv_b64,
+					ct_b64, tag_b64, plaintext_len);
+
+	/* Surface the (now authenticated) aad only on success. */
+	if (out != NULL && aad_raw != NULL) {
+		__cmd->c.recovered_aad = aad_raw;
+		__cmd->c.recovered_aad_len = aad_raw_len;
+		aad_raw = NULL;
+	}
+	jwt_scrub_and_free(aad_raw, aad_raw_len);
+	return out;
 
 	// LCOV_EXCL_START
 oom:

--- a/libjwt/jwe.c
+++ b/libjwt/jwe.c
@@ -135,6 +135,14 @@ int jwe_alg_is_ecdh_direct(jwe_key_alg_t alg)
 	return alg == JWE_ALG_ECDH_ES;
 }
 
+/* @rfc{7516,7.2.1} Does this algorithm dictate the CEK from the recipient key
+ * (dir or ECDH-ES Direct)? Such an algorithm constrains the single shared CEK,
+ * so it cannot be combined with other recipients. */
+int jwe_alg_is_direct(jwe_key_alg_t alg)
+{
+	return alg == JWE_ALG_DIR || jwe_alg_is_ecdh_direct(alg);
+}
+
 /* @rfc{7518,4.6} Run ECDH-ES agreement to derive the agreed key: the CEK in
  * Direct mode, or the KEK that wraps the CEK in +A*KW mode. On encrypt this
  * also writes "epk" into @hdr. */

--- a/libjwt/jwt-json-ops.h
+++ b/libjwt/jwt-json-ops.h
@@ -100,6 +100,26 @@ int jwt_json_obj_merge(jwt_json_t *object, jwt_json_t *other);
 JWT_NO_EXPORT
 int jwt_json_obj_merge_new(jwt_json_t *object, jwt_json_t *other);
 
+/**
+ * Iterate the members of a JSON object, invoking @cb for each (key, value).
+ *
+ * Backends differ in how they enumerate object members (Jansson's
+ * json_object_foreach vs json-c's json_object_object_foreach), and the
+ * loop variables are backend-internal types, so a public iterator macro
+ * (like jwt_json_arr_foreach) is not portable here. A callback is.
+ *
+ * @cb returning non-zero stops iteration early and that value becomes the
+ * return value; if @cb returns 0 for every member (or the object is empty),
+ * the return is 0. A NULL object or a non-object @object is a no-op
+ * returning 0 (mirroring the abort-safety of jwt_json_arr_size on json-c).
+ * The value handed to @cb is BORROWED (not a new reference).
+ */
+typedef int (*jwt_json_obj_iter_cb)(const char *key, jwt_json_t *value,
+				    void *ctx);
+JWT_NO_EXPORT
+int jwt_json_obj_foreach(const jwt_json_t *object, jwt_json_obj_iter_cb cb,
+			 void *ctx);
+
 /* ================================================================
  * Array operations
  * ================================================================ */

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -571,6 +571,8 @@ int jwe_alg_is_ecdh(jwe_key_alg_t alg);
 JWT_NO_EXPORT
 int jwe_alg_is_ecdh_direct(jwe_key_alg_t alg);
 JWT_NO_EXPORT
+int jwe_alg_is_direct(jwe_key_alg_t alg);
+JWT_NO_EXPORT
 int jwe_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc, const jwk_item_t *key,
 		    int for_encrypt, jwt_json_t *hdr,
 		    unsigned char **dk, size_t *dk_len);

--- a/tests/jwe_json_neg.c
+++ b/tests/jwe_json_neg.c
@@ -1,0 +1,220 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* These tokens all carry enc=A256GCM, alg=A256KW (in the per-recipient header)
+ * with a syntactically valid but irrelevant encrypted_key/iv/ct/tag. The point
+ * is that each is rejected for a STRUCTURAL reason before any crypto, so the
+ * exact dummy values do not matter. protected = base64url({"enc":"A256GCM"}).
+ * The disjointness cases put a duplicate parameter across two headers. */
+static void reject(const char *json)
+{
+	jwe_checker_auto_t *checker = NULL;
+	unsigned char *pt;
+	size_t pt_len = 0;
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, json, &pt_len);
+	ck_assert_ptr_null(pt);
+	ck_assert_int_eq(jwe_checker_error(checker), 1);
+}
+
+#define PROT "\"protected\":\"eyJlbmMiOiJBMjU2R0NNIn0\""
+#define BODY "\"iv\":\"aa\",\"ciphertext\":\"bb\",\"tag\":\"cc\""
+
+/* @rfc{7516,7.2.1} A parameter must not appear in more than one of the
+ * protected / shared-unprotected / per-recipient headers. */
+START_TEST(disjoint_unprotected_vs_recipient)
+{
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	/* "kid" in both the shared unprotected header and the recipient header. */
+	reject("{" PROT ","
+	       "\"unprotected\":{\"kid\":\"a\"},"
+	       "\"header\":{\"alg\":\"A256KW\",\"kid\":\"b\"},"
+	       "\"encrypted_key\":\"x\"," BODY "}");
+
+	free_key();
+}
+END_TEST
+
+START_TEST(disjoint_protected_vs_recipient)
+{
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	/* protected = {"cty":"x","enc":"A256GCM"}; recipient also sets "cty". */
+	reject("{\"protected\":\"eyJjdHkiOiJ4IiwiZW5jIjoiQTI1NkdDTSJ9\","
+	       "\"header\":{\"alg\":\"A256KW\",\"cty\":\"y\"},"
+	       "\"encrypted_key\":\"x\"," BODY "}");
+
+	free_key();
+}
+END_TEST
+
+START_TEST(disjoint_protected_vs_unprotected)
+{
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	/* protected = {"cty":"x","enc":"A256GCM"}; unprotected also sets "cty". */
+	reject("{\"protected\":\"eyJjdHkiOiJ4IiwiZW5jIjoiQTI1NkdDTSJ9\","
+	       "\"unprotected\":{\"cty\":\"y\"},"
+	       "\"header\":{\"alg\":\"A256KW\"},"
+	       "\"encrypted_key\":\"x\"," BODY "}");
+
+	free_key();
+}
+END_TEST
+
+/* A General token where a non-matching recipient carries a disjointness
+ * violation is still rejected (the check runs per recipient, pre-crypto). */
+START_TEST(disjoint_in_general_array)
+{
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	reject("{" PROT ",\"unprotected\":{\"kid\":\"a\"},"
+	       "\"recipients\":[{\"header\":{\"alg\":\"A256KW\",\"kid\":\"b\"},"
+	       "\"encrypted_key\":\"x\"}]," BODY "}");
+
+	free_key();
+}
+END_TEST
+
+/* Well-formed disjoint headers are accepted (the duplicate check does not
+ * false-positive on distinct names). This one actually decrypts. */
+START_TEST(disjoint_ok_roundtrip)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+	static const char MSG[] = "disjoint headers are fine";
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder,
+						JWE_FORMAT_JSON_GENERAL), 0);
+	/* distinct names across protected and shared-unprotected. */
+	ck_assert_int_eq(jwe_builder_add_protected_json(builder, "cty",
+							"\"text\""), 0);
+	ck_assert_int_eq(jwe_builder_add_unprotected_json(builder, "kid",
+							  "\"k1\""), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)MSG,
+				   strlen(MSG));
+	ck_assert_ptr_nonnull(tok);
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_mem_eq(pt, MSG, pt_len);
+
+	free(pt);
+	free_key();
+}
+END_TEST
+
+/* A General recipient entry that is not an object, and a recipient with a
+ * non-string encrypted_key, are rejected. */
+START_TEST(bad_general_entries)
+{
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	/* recipient entry is a scalar, not an object. The effective-header build
+	 * treats a non-object header as absent, so alg is missing -> no match ->
+	 * uniform failure (rejected). */
+	reject("{" PROT ",\"recipients\":[5]," BODY "}");
+
+	/* recipient with a matching alg but a non-string encrypted_key. */
+	reject("{" PROT ",\"recipients\":[{\"header\":{\"alg\":\"A256KW\"},"
+	       "\"encrypted_key\":5}]," BODY "}");
+
+	free_key();
+}
+END_TEST
+
+/* @rfc{7516,7.2.1} The builder must not EMIT a non-disjoint token: generate
+ * rejects an application parameter set in two of the three header locations. */
+START_TEST(builder_rejects_nondisjoint)
+{
+	jwe_builder_auto_t *b1 = NULL, *b2 = NULL;
+	jwe_recipient_t *r;
+	char *tok;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	/* "kid" in both protected and shared-unprotected. */
+	b1 = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(b1, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(b1, JWE_FORMAT_JSON_FLAT), 0);
+	ck_assert_int_eq(jwe_builder_add_protected_json(b1, "kid", "\"a\""), 0);
+	ck_assert_int_eq(jwe_builder_add_unprotected_json(b1, "kid", "\"b\""), 0);
+	tok = jwe_builder_generate(b1, (const unsigned char *)"x", 1);
+	ck_assert_ptr_null(tok);
+	ck_assert_int_eq(jwe_builder_error(b1), 1);
+
+	/* "kid" in both protected and a per-recipient header. Two A256KW
+	 * recipients sharing the oct key keeps the test backend-agnostic; the
+	 * disjointness check runs before any wrap, so generate fails on it. */
+	b2 = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(b2, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(b2, JWE_FORMAT_JSON_GENERAL), 0);
+	ck_assert_int_eq(jwe_builder_add_protected_json(b2, "kid", "\"a\""), 0);
+	r = jwe_builder_add_recipient(b2, JWE_ALG_A256KW, g_item);
+	ck_assert_ptr_nonnull(r);
+	ck_assert_int_eq(jwe_recipient_add_header_json(r, "kid", "\"b\""), 0);
+	tok = jwe_builder_generate(b2, (const unsigned char *)"x", 1);
+	ck_assert_ptr_null(tok);
+	ck_assert_int_eq(jwe_builder_error(b2), 1);
+
+	free_key();
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+
+	tc_core = tcase_create("JWE JSON Negatives");
+
+	tcase_add_loop_test(tc_core, disjoint_unprotected_vs_recipient, 0, i);
+	tcase_add_loop_test(tc_core, disjoint_protected_vs_recipient, 0, i);
+	tcase_add_loop_test(tc_core, disjoint_protected_vs_unprotected, 0, i);
+	tcase_add_loop_test(tc_core, disjoint_in_general_array, 0, i);
+	tcase_add_loop_test(tc_core, disjoint_ok_roundtrip, 0, i);
+	tcase_add_loop_test(tc_core, bad_general_entries, 0, i);
+	tcase_add_loop_test(tc_core, builder_rejects_nondisjoint, 0, i);
+
+	tcase_set_timeout(tc_core, 30);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT JWE JSON Negatives");
+}

--- a/tests/jwe_multi.c
+++ b/tests/jwe_multi.c
@@ -1,0 +1,458 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+static const char PT[] = "one plaintext, many recipients";
+
+/* Decrypt @tok with (@alg, @key) from @keyfile and assert it returns PT. */
+static void decrypt_ok(const char *tok, const char *keyfile,
+		       jwe_key_alg_t alg, jwe_enc_t enc)
+{
+	jwe_checker_auto_t *checker = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	read_json(keyfile);
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, alg, enc, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_int_eq(pt_len, strlen(PT));
+	ck_assert_mem_eq(pt, PT, pt_len);
+	free(pt);
+	free_key();
+}
+
+/* A token encrypted to three recipients (A256KW, RSA-OAEP-256, ECDH-ES+A128KW)
+ * decrypts with any one recipient's key. The content is encrypted once (one iv,
+ * one ciphertext, one tag) and each recipient gets its own encrypted_key. */
+START_TEST(three_recipients)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_recipient_t *r;
+	char_auto *tok = NULL;
+	jwk_set_auto_t *ks_rsa = NULL, *ks_ec = NULL;
+	const jwk_item_t *k_rsa, *k_ec;
+
+	SET_OPS();
+
+	/* Recipient 0 via setkey (oct A256KW). */
+	read_json("oct_key_256_enc.json");
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+
+	/* Recipients 1 and 2 via add_recipient. */
+	ks_rsa = jwks_create_fromfile(KEYDIR "/rsa_key_2048_enc.json");
+	ck_assert_ptr_nonnull(ks_rsa);
+	k_rsa = jwks_item_get(ks_rsa, 0);
+	r = jwe_builder_add_recipient(builder, JWE_ALG_RSA_OAEP_256, k_rsa);
+	ck_assert_ptr_nonnull(r);
+
+	ks_ec = jwks_create_fromfile(KEYDIR "/ec_key_prime256v1_enc.json");
+	ck_assert_ptr_nonnull(ks_ec);
+	k_ec = jwks_item_get(ks_ec, 0);
+	r = jwe_builder_add_recipient(builder, JWE_ALG_ECDH_ES_A128KW, k_ec);
+	ck_assert_ptr_nonnull(r);
+
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	/* General form: a recipients array, exactly one iv/ciphertext/tag. */
+	ck_assert_int_eq(tok[0], '{');
+	ck_assert_ptr_nonnull(strstr(tok, "\"recipients\":"));
+	ck_assert_ptr_nonnull(strstr(tok, "\"ciphertext\":"));
+
+	/* Each recipient's key decrypts the same token. */
+	decrypt_ok(tok, "oct_key_256_enc.json", JWE_ALG_A256KW, JWE_ENC_A256GCM);
+	decrypt_ok(tok, "rsa_key_2048_enc.json", JWE_ALG_RSA_OAEP_256,
+		   JWE_ENC_A256GCM);
+	decrypt_ok(tok, "ec_key_prime256v1_enc.json", JWE_ALG_ECDH_ES_A128KW,
+		   JWE_ENC_A256GCM);
+
+	free_key();
+}
+END_TEST
+
+/* The recipient that matches our key may be the second one in the array; it
+ * still decrypts (selection iterates all recipients). */
+START_TEST(second_recipient_matches)
+{
+	jwe_builder_auto_t *builder = NULL;
+	char_auto *tok = NULL;
+	jwk_set_auto_t *ks_rsa = NULL;
+	const jwk_item_t *k_rsa;
+
+	SET_OPS();
+
+	read_json("oct_key_256_enc.json");
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ks_rsa = jwks_create_fromfile(KEYDIR "/rsa_key_2048_enc.json");
+	k_rsa = jwks_item_get(ks_rsa, 0);
+	ck_assert_ptr_nonnull(jwe_builder_add_recipient(builder,
+					JWE_ALG_RSA_OAEP_256, k_rsa));
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	/* Our key is recipient #2 (RSA), not #1 (A256KW). */
+	decrypt_ok(tok, "rsa_key_2048_enc.json", JWE_ALG_RSA_OAEP_256,
+		   JWE_ENC_A256GCM);
+
+	free_key();
+}
+END_TEST
+
+/* Per-recipient partyinfo and an application header parameter survive to the
+ * per-recipient header. */
+START_TEST(recipient_header_and_partyinfo)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_recipient_t *r;
+	char_auto *tok = NULL;
+
+	SET_OPS();
+
+	read_json("oct_key_256_enc.json");
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder,
+						JWE_FORMAT_JSON_GENERAL), 0);
+
+	/* setkey configures recipient 0 (no handle); add a second recipient
+	 * whose handle we use for per-recipient partyinfo/header. */
+	read_json("ec_key_secp521r1_enc.json");
+	r = jwe_builder_add_recipient(builder, JWE_ALG_ECDH_ES_A256KW, g_item);
+	ck_assert_ptr_nonnull(r);
+	ck_assert_int_eq(jwe_recipient_set_partyinfo(r,
+				(const unsigned char *)"Alice", 5,
+				(const unsigned char *)"Bob", 3), 0);
+	ck_assert_int_eq(jwe_recipient_add_header_json(r, "kid", "\"ec-1\""), 0);
+	/* Reserved names and NULLs are rejected. */
+	ck_assert_int_ne(jwe_recipient_add_header_json(r, "alg", "\"x\""), 0);
+	ck_assert_int_ne(jwe_recipient_add_header_json(r, "kid", "\"dup\""), 0);
+	ck_assert_int_ne(jwe_recipient_add_header_json(NULL, "a", "1"), 0);
+	ck_assert_int_ne(jwe_recipient_set_partyinfo(NULL, NULL, 0, NULL, 0), 0);
+
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+	ck_assert_ptr_nonnull(strstr(tok, "\"kid\":\"ec-1\""));
+	ck_assert_ptr_nonnull(strstr(tok, "\"apu\":"));
+
+	/* Recipient 1 (the EC one) decrypts. */
+	decrypt_ok(tok, "ec_key_secp521r1_enc.json", JWE_ALG_ECDH_ES_A256KW,
+		   JWE_ENC_A256GCM);
+
+	free_key();
+}
+END_TEST
+
+/* add_recipient and the recipient setters validate their inputs. */
+START_TEST(add_recipient_errors)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_recipient_t *r;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	/* NULL builder. */
+	ck_assert_ptr_null(jwe_builder_add_recipient(NULL, JWE_ALG_A256KW,
+						     g_item));
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+
+	/* Invalid alg. */
+	ck_assert_ptr_null(jwe_builder_add_recipient(builder, JWE_ALG_NONE,
+						     g_item));
+	jwe_builder_error_clear(builder);
+	ck_assert_ptr_null(jwe_builder_add_recipient(builder, JWE_ALG_INVAL,
+						     g_item));
+	jwe_builder_error_clear(builder);
+	/* NULL key. */
+	ck_assert_ptr_null(jwe_builder_add_recipient(builder, JWE_ALG_A256KW,
+						     NULL));
+	jwe_builder_error_clear(builder);
+
+	/* A signing key is rejected by the usage gate. */
+	free_key();
+	read_json("rsa_key_2048.json");
+	r = jwe_builder_add_recipient(builder, JWE_ALG_RSA_OAEP_256, g_item);
+	if (r == NULL)
+		ck_assert_int_eq(jwe_builder_error(builder), 1);
+	jwe_builder_error_clear(builder);
+
+	/* Recipient setter input validation. */
+	free_key();
+	read_json("oct_key_256_enc.json");
+	r = jwe_builder_add_recipient(builder, JWE_ALG_A256KW, g_item);
+	ck_assert_ptr_nonnull(r);
+	ck_assert_int_ne(jwe_recipient_add_header_json(r, NULL, "1"), 0);
+	ck_assert_int_ne(jwe_recipient_add_header_json(r, "x", NULL), 0);
+	ck_assert_int_ne(jwe_recipient_add_header_json(r, "x", "{bad json"), 0);
+
+	free_key();
+}
+END_TEST
+
+/* dir cannot be combined with another recipient (both orderings). */
+START_TEST(dir_rejects_multi)
+{
+	jwe_builder_auto_t *b1 = NULL, *b2 = NULL;
+	jwk_set_auto_t *ks_rsa = NULL;
+	const jwk_item_t *k_rsa;
+
+	SET_OPS();
+
+	ks_rsa = jwks_create_fromfile(KEYDIR "/rsa_key_2048_enc.json");
+	k_rsa = jwks_item_get(ks_rsa, 0);
+
+	/* dir first, then add another recipient -> rejected. */
+	read_json("oct_dir_256.json");
+	b1 = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(b1, JWE_ALG_DIR,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_ptr_null(jwe_builder_add_recipient(b1, JWE_ALG_RSA_OAEP_256,
+						     k_rsa));
+	ck_assert_int_eq(jwe_builder_error(b1), 1);
+
+	/* Another recipient first, then dir -> rejected. */
+	b2 = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(b2, JWE_ALG_RSA_OAEP_256,
+					    JWE_ENC_A256GCM, k_rsa), 0);
+	read_json("oct_dir_256.json");
+	ck_assert_ptr_null(jwe_builder_add_recipient(b2, JWE_ALG_DIR, g_item));
+	ck_assert_int_eq(jwe_builder_error(b2), 1);
+
+	free_key();
+}
+END_TEST
+
+/* ECDH-ES Direct also cannot be combined with another recipient. */
+START_TEST(ecdh_direct_rejects_multi)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwk_set_auto_t *ks_rsa = NULL;
+	const jwk_item_t *k_rsa;
+
+	SET_OPS();
+
+	ks_rsa = jwks_create_fromfile(KEYDIR "/rsa_key_2048_enc.json");
+	k_rsa = jwks_item_get(ks_rsa, 0);
+
+	read_json("ec_key_prime256v1_enc.json");
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_ECDH_ES,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_ptr_null(jwe_builder_add_recipient(builder,
+					JWE_ALG_RSA_OAEP_256, k_rsa));
+	ck_assert_int_eq(jwe_builder_error(builder), 1);
+
+	free_key();
+}
+END_TEST
+
+/* Flattened and Compact reject a second recipient at generate time. */
+START_TEST(flat_compact_reject_multi)
+{
+	jwe_builder_auto_t *bf = NULL, *bc = NULL;
+	jwk_set_auto_t *ks_rsa = NULL;
+	const jwk_item_t *k_rsa;
+	char *tok;
+
+	SET_OPS();
+
+	ks_rsa = jwks_create_fromfile(KEYDIR "/rsa_key_2048_enc.json");
+	k_rsa = jwks_item_get(ks_rsa, 0);
+
+	/* Flattened + 2 recipients -> generate fails. */
+	read_json("oct_key_256_enc.json");
+	bf = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(bf, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_ptr_nonnull(jwe_builder_add_recipient(bf, JWE_ALG_RSA_OAEP_256,
+							k_rsa));
+	/* add_recipient forced GENERAL; force it back to FLAT to trip the gate. */
+	ck_assert_int_eq(jwe_builder_set_format(bf, JWE_FORMAT_JSON_FLAT), 0);
+	tok = jwe_builder_generate(bf, (const unsigned char *)PT, strlen(PT));
+	ck_assert_ptr_null(tok);
+	ck_assert_int_eq(jwe_builder_error(bf), 1);
+
+	/* Compact + 2 recipients -> generate fails. */
+	read_json("oct_key_256_enc.json");
+	bc = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(bc, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_ptr_nonnull(jwe_builder_add_recipient(bc, JWE_ALG_RSA_OAEP_256,
+							k_rsa));
+	ck_assert_int_eq(jwe_builder_set_format(bc, JWE_FORMAT_COMPACT), 0);
+	tok = jwe_builder_generate(bc, (const unsigned char *)PT, strlen(PT));
+	ck_assert_ptr_null(tok);
+	ck_assert_int_eq(jwe_builder_error(bc), 1);
+
+	free_key();
+}
+END_TEST
+
+/* A checker whose key/alg matches no recipient fails with the generic auth
+ * error (RFC 7516 11.5: no oracle revealing which recipient, if any, matched). */
+START_TEST(no_matching_recipient)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	jwk_set_auto_t *ks_rsa = NULL;
+	const jwk_item_t *k_rsa;
+	unsigned char *pt;
+	size_t pt_len = 0;
+
+	SET_OPS();
+
+	read_json("oct_key_256_enc.json");
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ks_rsa = jwks_create_fromfile(KEYDIR "/rsa_key_2048_enc.json");
+	k_rsa = jwks_item_get(ks_rsa, 0);
+	ck_assert_ptr_nonnull(jwe_builder_add_recipient(builder,
+					JWE_ALG_RSA_OAEP_256, k_rsa));
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+	free_key();
+
+	/* Checker configured for ECDH-ES, which no recipient uses. */
+	read_json("ec_key_prime256v1_enc.json");
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_ECDH_ES_A128KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_null(pt);
+	ck_assert_int_eq(jwe_checker_error(checker), 1);
+
+	free_key();
+}
+END_TEST
+
+/* The right key but wrong recipient's key still fails (wrong A256KW KEK while
+ * the matching alg recipient exists). */
+START_TEST(matching_alg_wrong_key)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	jwk_set_auto_t *ks_rsa = NULL;
+	const jwk_item_t *k_rsa;
+	unsigned char *pt;
+	size_t pt_len = 0;
+
+	SET_OPS();
+
+	read_json("oct_key_256_enc.json");
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ks_rsa = jwks_create_fromfile(KEYDIR "/rsa_key_2048_enc.json");
+	k_rsa = jwks_item_get(ks_rsa, 0);
+	ck_assert_ptr_nonnull(jwe_builder_add_recipient(builder,
+					JWE_ALG_RSA_OAEP_256, k_rsa));
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+	free_key();
+
+	/* A256KW alg matches recipient #1, but a different 256-bit KEK. */
+	read_json("oct_dir_256.json");
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_null(pt);
+	ck_assert_int_eq(jwe_checker_error(checker), 1);
+
+	free_key();
+}
+END_TEST
+
+/* No matching recipient AND an aad member present: the uniform-failure path
+ * must build (and free) the AAD too. */
+START_TEST(no_match_with_aad)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt;
+	size_t pt_len = 0;
+
+	SET_OPS();
+
+	read_json("oct_key_256_enc.json");
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder,
+						JWE_FORMAT_JSON_GENERAL), 0);
+	ck_assert_int_eq(jwe_builder_set_aad(builder,
+				(const unsigned char *)"aad", 3), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+	free_key();
+
+	/* Checker configured for an alg no recipient uses. */
+	read_json("rsa_key_2048_enc.json");
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_RSA_OAEP_256,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_null(pt);
+	ck_assert_int_eq(jwe_checker_error(checker), 1);
+	/* No AAD surfaced on failure. */
+	ck_assert_ptr_null(jwe_checker_get_aad(checker, NULL));
+
+	free_key();
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+
+	tc_core = tcase_create("JWE Multi-Recipient");
+
+	tcase_add_loop_test(tc_core, three_recipients, 0, i);
+	tcase_add_loop_test(tc_core, second_recipient_matches, 0, i);
+	tcase_add_loop_test(tc_core, recipient_header_and_partyinfo, 0, i);
+	tcase_add_loop_test(tc_core, add_recipient_errors, 0, i);
+	tcase_add_loop_test(tc_core, dir_rejects_multi, 0, i);
+	tcase_add_loop_test(tc_core, ecdh_direct_rejects_multi, 0, i);
+	tcase_add_loop_test(tc_core, flat_compact_reject_multi, 0, i);
+	tcase_add_loop_test(tc_core, no_matching_recipient, 0, i);
+	tcase_add_loop_test(tc_core, no_match_with_aad, 0, i);
+	tcase_add_loop_test(tc_core, matching_alg_wrong_key, 0, i);
+
+	tcase_set_timeout(tc_core, 30);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT JWE Multi-Recipient");
+}


### PR DESCRIPTION
Third stage of #262: the RFC 7516 **General JSON Serialization with one or more recipients**, plus **header disjointness** enforcement. Stacked on #271. The plaintext is encrypted once with a single shared CEK; each recipient wraps that same CEK independently with its own key management algorithm and key.

## Builder
- `jwe_builder_add_recipient(builder, alg, key)` → opaque, borrowed `jwe_recipient_t` handle (the first recipient may still come from `jwe_builder_setkey`). A second recipient forces `JWE_FORMAT_JSON_GENERAL`.
- `jwe_recipient_set_partyinfo` / `jwe_recipient_add_header_json` address a specific recipient.
- `generate()` rewritten into phases: validate → one shared CEK → per-recipient wrap loop → encrypt content once → assemble. A lone `dir`/ECDH-ES Direct recipient dictates the CEK; otherwise a random CEK is wrapped per recipient.
- Constraints: `dir`/ECDH-ES Direct cannot be combined with other recipients; Compact and Flattened carry exactly one recipient.

## Checker
- `decrypt_json` enumerates recipients (General array or the synthetic Flattened single), builds each candidate's effective header as the **disjoint union** of protected / shared-unprotected / per-recipient, and selects the first whose `alg` matches the configured key.
- **§11.5**: a non-matching token fails with the generic auth error (alg is public — not an oracle); a matching recipient's unwrap failure still funnels to a random CEK and uniform tag failure.

## Disjointness (§7.2.1)
Enforced at **build** time (`check_disjoint`, before library names are added) *and* **decrypt** time (`effective_header` via the new `jwt_json_obj_foreach` iterator added to both JSON backends). The same parameter never appears in more than one header.

## A bug caught in self-review
`jwe_checker_get_aad` populated the recovered AAD *before* authentication, so a failed decrypt could surface unauthenticated AAD. Fixed: the AAD is decoded into a local and assigned to the checker only after the content authenticates (regression-tested).

## Verification
- `tests/jwe_multi.c`: 3-recipient round-trip decrypted by each key; recipient-as-#2; per-recipient partyinfo/header; all the dir/direct/flat/compact + multi rejections; no-match and matching-alg/wrong-key uniform failure; `add_recipient` input validation.
- `tests/jwe_json_neg.c`: disjointness violations across all three header pairs and inside the General array; the disjoint-OK round-trip; bad General entries; builder-side disjointness rejection.
- 22/22 tests under OpenSSL+GnuTLS+MbedTLS; `jwe.c`/`jwe-common.c`/`jwe-setget.c` at 100% line coverage; JWE code paths ASan-clean. A high-effort code review found no memory/security bugs.

Refs #262 — remaining: the CLI tools + man pages + BATS + doc matrices (final stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)