### PR TITLE
build: hide JWE backend crypto ops from the shared library ABI

### DIFF
--- a/libjwt/gnutls/jwt-gnutls.h
+++ b/libjwt/gnutls/jwt-gnutls.h
@@ -49,71 +49,93 @@ void gnutls_process_item_free(jwk_item_t *item);
 
 /* OpenSSL fallbacks: JWK parsing and RSA-OAEP/ECDH-ES, used when the GnuTLS
  * version predates the native path. Declared unconditionally so the ops table
- * can select them under the version #if. */
+ * can select them under the version #if. Backend internals; keep out of ABI. */
+JWT_NO_EXPORT
 int openssl_process_eddsa(jwt_json_t *jwk, jwk_item_t *item);
+JWT_NO_EXPORT
 int openssl_process_rsa(jwt_json_t *jwk, jwk_item_t *item);
+JWT_NO_EXPORT
 int openssl_process_ec(jwt_json_t *jwk, jwk_item_t *item);
+JWT_NO_EXPORT
 void openssl_process_item_free(jwk_item_t *item);
+JWT_NO_EXPORT
 int openssl_encrypt_cek_rsa(jwe_key_alg_t alg, const jwk_item_t *key,
 	const unsigned char *cek, size_t cek_len,
 	unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
 int openssl_encrypt_cek_rsa_pem(jwe_key_alg_t alg, const char *pem,
 	const unsigned char *cek, size_t cek_len,
 	unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
 int openssl_decrypt_cek_rsa(jwe_key_alg_t alg, const jwk_item_t *key,
 	const unsigned char *in, size_t in_len,
 	unsigned char **cek, size_t *cek_len);
+JWT_NO_EXPORT
 int openssl_decrypt_cek_rsa_pem(jwe_key_alg_t alg, const char *pem,
 	const unsigned char *in, size_t in_len,
 	unsigned char **cek, size_t *cek_len);
+JWT_NO_EXPORT
 int openssl_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc,
 	const jwk_item_t *key, int for_encrypt, jwt_json_t *hdr,
 	unsigned char **dk, size_t *dk_len);
 
-/* JWE (RFC 7516/7518) — native GnuTLS implementations. */
+/* JWE (RFC 7516/7518) — native GnuTLS implementations. Backend internals
+ * reached only through the jwt_crypto_ops table; keep out of ABI. */
+JWT_NO_EXPORT
 int gnutls_rng(unsigned char *out, size_t len);
+JWT_NO_EXPORT
 int gnutls_encrypt_aes_gcm(jwe_enc_t enc, const unsigned char *cek,
 	size_t cek_len, const unsigned char *iv, size_t iv_len,
 	const unsigned char *aad, size_t aad_len,
 	const unsigned char *pt, size_t pt_len,
 	unsigned char **ct, size_t *ct_len,
 	unsigned char **tag, size_t *tag_len);
+JWT_NO_EXPORT
 int gnutls_decrypt_aes_gcm(jwe_enc_t enc, const unsigned char *cek,
 	size_t cek_len, const unsigned char *iv, size_t iv_len,
 	const unsigned char *aad, size_t aad_len,
 	const unsigned char *ct, size_t ct_len,
 	const unsigned char *tag, size_t tag_len,
 	unsigned char **pt, size_t *pt_len);
+JWT_NO_EXPORT
 int gnutls_encrypt_aes_cbc_hmac(jwe_enc_t enc, const unsigned char *cek,
 	size_t cek_len, const unsigned char *iv, size_t iv_len,
 	const unsigned char *aad, size_t aad_len,
 	const unsigned char *pt, size_t pt_len,
 	unsigned char **ct, size_t *ct_len,
 	unsigned char **tag, size_t *tag_len);
+JWT_NO_EXPORT
 int gnutls_decrypt_aes_cbc_hmac(jwe_enc_t enc, const unsigned char *cek,
 	size_t cek_len, const unsigned char *iv, size_t iv_len,
 	const unsigned char *aad, size_t aad_len,
 	const unsigned char *ct, size_t ct_len,
 	const unsigned char *tag, size_t tag_len,
 	unsigned char **pt, size_t *pt_len);
+JWT_NO_EXPORT
 int gnutls_wrap_aes_kw(const jwk_item_t *key, const unsigned char *cek,
 	size_t cek_len, unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
 int gnutls_unwrap_aes_kw(const jwk_item_t *key, const unsigned char *in,
 	size_t in_len, unsigned char **cek, size_t *cek_len);
+JWT_NO_EXPORT
 int gnutls_wrap_aes_kw_raw(const unsigned char *kek, size_t kek_len,
 	const unsigned char *cek, size_t cek_len,
 	unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
 int gnutls_unwrap_aes_kw_raw(const unsigned char *kek, size_t kek_len,
 	const unsigned char *in, size_t in_len,
 	unsigned char **cek, size_t *cek_len);
 
 #if JWT_GNUTLS_NATIVE_JWE
+JWT_NO_EXPORT
 int gnutls_encrypt_cek_rsa(jwe_key_alg_t alg, const jwk_item_t *key,
 	const unsigned char *cek, size_t cek_len,
 	unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
 int gnutls_decrypt_cek_rsa(jwe_key_alg_t alg, const jwk_item_t *key,
 	const unsigned char *in, size_t in_len,
 	unsigned char **cek, size_t *cek_len);
+JWT_NO_EXPORT
 int gnutls_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc,
 	const jwk_item_t *key, int for_encrypt, jwt_json_t *hdr,
 	unsigned char **dk, size_t *dk_len);

--- a/libjwt/openssl/jwt-openssl.h
+++ b/libjwt/openssl/jwt-openssl.h
@@ -14,54 +14,69 @@ int openssl_process_rsa(jwt_json_t *jwk, jwk_item_t *item);
 int openssl_process_ec(jwt_json_t *jwk, jwk_item_t *item);
 void openssl_process_item_free(jwk_item_t *item);
 
-/* JWE (RFC 7516/7518) */
+/* JWE (RFC 7516/7518). These are backend internals reached only through the
+ * jwt_crypto_ops table, so they must stay out of the shared library's ABI. */
+JWT_NO_EXPORT
 int openssl_rng(unsigned char *out, size_t len);
+JWT_NO_EXPORT
 int openssl_encrypt_aes_gcm(jwe_enc_t enc, const unsigned char *cek,
 	size_t cek_len, const unsigned char *iv, size_t iv_len,
 	const unsigned char *aad, size_t aad_len,
 	const unsigned char *pt, size_t pt_len,
 	unsigned char **ct, size_t *ct_len,
 	unsigned char **tag, size_t *tag_len);
+JWT_NO_EXPORT
 int openssl_decrypt_aes_gcm(jwe_enc_t enc, const unsigned char *cek,
 	size_t cek_len, const unsigned char *iv, size_t iv_len,
 	const unsigned char *aad, size_t aad_len,
 	const unsigned char *ct, size_t ct_len,
 	const unsigned char *tag, size_t tag_len,
 	unsigned char **pt, size_t *pt_len);
+JWT_NO_EXPORT
 int openssl_encrypt_aes_cbc_hmac(jwe_enc_t enc, const unsigned char *cek,
 	size_t cek_len, const unsigned char *iv, size_t iv_len,
 	const unsigned char *aad, size_t aad_len,
 	const unsigned char *pt, size_t pt_len,
 	unsigned char **ct, size_t *ct_len,
 	unsigned char **tag, size_t *tag_len);
+JWT_NO_EXPORT
 int openssl_decrypt_aes_cbc_hmac(jwe_enc_t enc, const unsigned char *cek,
 	size_t cek_len, const unsigned char *iv, size_t iv_len,
 	const unsigned char *aad, size_t aad_len,
 	const unsigned char *ct, size_t ct_len,
 	const unsigned char *tag, size_t tag_len,
 	unsigned char **pt, size_t *pt_len);
+JWT_NO_EXPORT
 int openssl_wrap_aes_kw(const jwk_item_t *key, const unsigned char *cek,
 	size_t cek_len, unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
 int openssl_unwrap_aes_kw(const jwk_item_t *key, const unsigned char *in,
 	size_t in_len, unsigned char **cek, size_t *cek_len);
+JWT_NO_EXPORT
 int openssl_wrap_aes_kw_raw(const unsigned char *kek, size_t kek_len,
 	const unsigned char *cek, size_t cek_len,
 	unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
 int openssl_unwrap_aes_kw_raw(const unsigned char *kek, size_t kek_len,
 	const unsigned char *in, size_t in_len,
 	unsigned char **cek, size_t *cek_len);
+JWT_NO_EXPORT
 int openssl_encrypt_cek_rsa(jwe_key_alg_t alg, const jwk_item_t *key,
 	const unsigned char *cek, size_t cek_len,
 	unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
 int openssl_encrypt_cek_rsa_pem(jwe_key_alg_t alg, const char *pem,
 	const unsigned char *cek, size_t cek_len,
 	unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
 int openssl_decrypt_cek_rsa(jwe_key_alg_t alg, const jwk_item_t *key,
 	const unsigned char *in, size_t in_len,
 	unsigned char **cek, size_t *cek_len);
+JWT_NO_EXPORT
 int openssl_decrypt_cek_rsa_pem(jwe_key_alg_t alg, const char *pem,
 	const unsigned char *in, size_t in_len,
 	unsigned char **cek, size_t *cek_len);
+JWT_NO_EXPORT
 int openssl_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc,
 	const jwk_item_t *key, int for_encrypt, jwt_json_t *hdr,
 	unsigned char **dk, size_t *dk_len);


### PR DESCRIPTION
## Summary

The OpenSSL and GnuTLS JWE op declarations were missing `JWT_NO_EXPORT`, so **26 backend-internal functions leaked into `libjwt.so`'s dynamic symbol table**. At v3.3.3 no backend-prefixed symbols were exported; these crept in with the JWE work.

These functions are reached only through the `jwt_crypto_ops` function-pointer table and are not declared in the public `include/jwt.h`. The pre-existing JWK-parse ops and **all** mbedtls JWE ops already carry `JWT_NO_EXPORT` — this brings OpenSSL and GnuTLS in line.

## Changes

- `libjwt/openssl/jwt-openssl.h` — `JWT_NO_EXPORT` on the `openssl_*` JWE/RSA/ECDH declarations.
- `libjwt/gnutls/jwt-gnutls.h` — `JWT_NO_EXPORT` on the native `gnutls_*` JWE declarations and the `openssl_*` fallback declarations.

No `.c` logic changes (the attribute on the declaration propagates to the definition, as mbedtls already does).

## Verification

| | Before | After |
|---|---|---|
| Exported symbols | 138 | **112** |
| `openssl_*`/`gnutls_*`/`mbedtls_*` exported | 26 | **0** |
| Public JWE/JWT symbols (added since v3.3.3) | 32 | **32** (intact) |

- Confirmed zero backend-prefixed exports in both OpenSSL-only and GnuTLS+MbedTLS+OpenSSL builds.
- 22/22 unit tests pass; all JWE BATS round-trips pass; clean `-Wall -Werror`.
- Clean coverage build: **99.45% (5396/5426)**, identical before/after — hidden ops still fully exercised via the ops table.

## ABI / SONAME

Removes only unintended exports; no public symbol changed or removed. **No SONAME bump required.**

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)