### PR TITLE
mbedtls: reject RSA signatures not equal to the modulus length (H1, #281)

### DIFF
--- a/libjwt/mbedtls/sign-verify.c
+++ b/libjwt/mbedtls/sign-verify.c
@@ -344,6 +344,14 @@ static int mbedtls_verify_sha_pem(jwt_t *jwt, const char *head,
 	} else if (key->kty == JWK_KEY_TYPE_RSA) {
 		mbedtls_rsa_context *rsa = (mbedtls_rsa_context *)&key->rsa;
 
+		/* The MbedTLS RSA verify functions take no length argument and
+		 * unconditionally read mbedtls_rsa_get_len(rsa) bytes from sig.
+		 * Reject a signature that is not exactly the modulus length so a
+		 * short attacker-controlled segment cannot cause an out-of-bounds
+		 * read of the heap buffer (which is sized to the decoded length). */
+		if (sig_len < 0 || (size_t)sig_len != mbedtls_rsa_get_len(rsa))
+			VERIFY_ERROR("Invalid RSA signature size");
+
 		if (jwt->alg == JWT_ALG_PS256 || jwt->alg == JWT_ALG_PS384 ||
 		    jwt->alg == JWT_ALG_PS512) {
 			if (mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V21,

--- a/tests/jwt_checker.c
+++ b/tests/jwt_checker.c
@@ -1008,7 +1008,12 @@ START_TEST(verify_ps256_bad_sig)
 
 	err = jwt_checker_error_msg(checker);
 	ck_assert_ptr_nonnull(err);
-	ck_assert_ptr_nonnull(strstr(err, "Failed to verify signature"));
+	/* The signature segment here decodes to 27 bytes, far short of the
+	 * 256-byte RSA-2048 modulus. OpenSSL/GnuTLS run the verify and report
+	 * a verification failure; MbedTLS rejects the mismatched length up
+	 * front ("Invalid RSA signature size"). Either is a correct rejection. */
+	ck_assert(strstr(err, "Failed to verify signature") != NULL ||
+		  strstr(err, "Invalid RSA signature size") != NULL);
 
 	free_key();
 }

--- a/tests/jwt_security.c
+++ b/tests/jwt_security.c
@@ -1057,6 +1057,40 @@ START_TEST(test_alg_confusion_malformed_jwk_kty_alg)
 }
 END_TEST
 
+/* A token with alg=RS256 but a signature segment far shorter than the RSA
+ * modulus must be rejected, not read past the end of the heap-allocated
+ * signature buffer. The MbedTLS RSA verify functions take no length argument
+ * and read mbedtls_rsa_get_len() bytes unconditionally; without an explicit
+ * size check the 3-byte signature here (base64url "AAAA") caused an ~253-byte
+ * out-of-bounds heap read on the MbedTLS backend. All backends must reject it.
+ */
+START_TEST(test_rsa_short_signature_oob)
+{
+	jwt_checker_auto_t *checker = NULL;
+	const char token[] =
+		"eyJhbGciOiJSUzI1NiJ9"
+		".eyJzdWIiOiJhZG1pbiJ9"
+		".AAAA";
+	int ret;
+
+	SET_OPS();
+
+	checker = jwt_checker_new();
+	ck_assert_ptr_nonnull(checker);
+
+	read_json("rsa_key_2048_pub.json");
+
+	ret = jwt_checker_setkey(checker, JWT_ALG_RS256, g_item);
+	ck_assert_int_eq(ret, 0);
+
+	/* Must be rejected on every backend, and must not over-read. */
+	ret = jwt_checker_verify(checker, token);
+	ck_assert_int_ne(ret, 0);
+
+	free_key();
+}
+END_TEST
+
 /*
  * === Suite Setup ===
  */
@@ -1150,6 +1184,8 @@ static Suite *libjwt_suite(const char *title)
 			    test_alg_confusion_callback_rsa_no_alg, 0, i);
 	tcase_add_loop_test(tc_alg_confusion,
 			    test_alg_confusion_malformed_jwk_kty_alg, 0, i);
+	tcase_add_loop_test(tc_alg_confusion,
+			    test_rsa_short_signature_oob, 0, i);
 
 	tcase_set_timeout(tc_alg_confusion, 30);
 	suite_add_tcase(s, tc_alg_confusion);


### PR DESCRIPTION
## Summary

Fixes the High-severity finding **H1** from the security review (#281): a remotely-triggerable out-of-bounds heap read in the MbedTLS RSA verify path.

`mbedtls_rsa_rsassa_pss_verify()` / `mbedtls_rsa_rsassa_pkcs1_v15_verify()` take no signature-length argument and read `mbedtls_rsa_get_len(rsa)` bytes unconditionally. `mbedtls_verify_sha_pem()` passed the attacker-controlled signature buffer straight through with no length check; the buffer is heap-allocated to exactly the decoded length of the token's third segment.

A token with `alg=RS256` (or RS384/512, PS256/384/512) and a short signature segment — e.g. base64url `AAAA` (3 bytes) against a 256-byte RSA-2048 modulus — caused an OOB heap read of up to ~modulus-length bytes. Unauthenticated, reachable through the public verify API. Realistic impact: DoS (reliable crash under hardened allocators/ASan). **OpenSSL and GnuTLS backends are unaffected.**

## Fix

Reject any signature whose length is not exactly the modulus length at the top of the RSA branch, mirroring the existing EC-branch length check (`sig_len == 64 || 96 || 132`) and the sign path's use of `mbedtls_rsa_get_len()`.

```c
if (sig_len < 0 || (size_t)sig_len != mbedtls_rsa_get_len(rsa))
        VERIFY_ERROR("Invalid RSA signature size");
```

## Testing

- New regression test `test_rsa_short_signature_oob` runs on all three backends. **With the fix reverted and built under ASan, it reproduces** `heap-buffer-overflow READ of size 256` inside `mbedtls_rsa_public` (via `mbedtls_rsa_rsassa_pkcs1_v15_verify`). With the fix, ASan is clean.
- Relaxed the error-message assertion in `verify_ps256_bad_sig`: its 27-byte signature now hits the new length check on MbedTLS before reaching the verify call, so the test accepts either "Failed to verify signature" (OpenSSL/GnuTLS) or "Invalid RSA signature size" (MbedTLS) — both correct rejections.
- Full suite: 24/24 pass (OpenSSL + GnuTLS + MbedTLS, Jansson, libcurl). Coverage confirmed on the new guard lines (no new uncovered lines).

Part of #281 (this addresses H1 only; the other items in that umbrella issue are handled in follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)