### PR TITLE
jwks: require full TLS verification for any verify >= 1 (M1, #282)

### DIFF
--- a/include/jwt.h
+++ b/include/jwt.h
@@ -1977,8 +1977,12 @@ jwk_set_t *jwks_load_fromfp(jwk_set_t *jwk_set, FILE *input);
  *   to add new keys to it.
  * @param url A string URL to where the JSON representation of a single key
  *   or array of "keys" can be retrieved from. Generally a json file.
- * @param verify Set to 1 to verify the Host, 2 to verify Host and Peer.
- *   2 is recommended unless you really need to disable with 0.
+ * @param verify Set to non-zero to fully verify the TLS connection
+ *   (certificate chain/peer @b and hostname); set to 0 to disable
+ *   verification entirely. Non-zero is strongly recommended: hostname
+ *   verification on its own is meaningless, so any value >= 1 enables
+ *   both peer and host verification. 0 disables all verification and is
+ *   insecure (use only for testing).
  * @return A valid jwt_set_t on success. On failure, either NULL
  *   or a jwt_set_t with error set. NULL generally means ENOMEM.
  */

--- a/libjwt/jwks-curl.c
+++ b/libjwt/jwks-curl.c
@@ -89,8 +89,14 @@ static char *__curl_get(jwk_set_t *jwk_set, const char *url, size_t *len,
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&data);
 
+	/* Hostname verification is meaningless without peer (CA chain)
+	 * verification: anyone can present a self-signed certificate bearing
+	 * the target hostname, so VERIFYHOST without VERIFYPEER provides no
+	 * protection against an active MITM. Tie the two together: any
+	 * verify >= 1 enables full verification; only verify == 0 (explicitly
+	 * insecure) disables it. */
 	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, (verify > 0) ? 2L : 0L);
-	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, (verify > 1) ? 1L : 0L);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, (verify > 0) ? 1L : 0L);
 
         res = curl_easy_perform(curl);
 

--- a/tests/jwt_jwks.c
+++ b/tests/jwt_jwks.c
@@ -149,6 +149,12 @@ START_TEST(load_fromurl)
 	ck_assert_ptr_nonnull(jwk_set);
 
 	ck_assert_int_gt(jwks_item_count(jwk_set), 0);
+
+	/* verify=1 now requests full TLS verification (peer + host), the same
+	 * as verify=2; both must still load a plain file:// URL successfully. */
+	jwk_set = jwks_load_fromurl(jwk_set, test_url, 1);
+	ck_assert_ptr_nonnull(jwk_set);
+	ck_assert_int_gt(jwks_item_count(jwk_set), 0);
 }
 #else
 START_TEST(load_fromurl)


### PR DESCRIPTION
## Summary

Fixes the Medium-severity finding **M1** from the security review (#282): the remote-JWKS fetch did not verify the TLS certificate chain when `verify == 1`.

`__curl_get()` set `CURLOPT_SSL_VERIFYHOST` for `verify > 0` but `CURLOPT_SSL_VERIFYPEER` only for `verify > 1`:

```c
curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, (verify > 0) ? 2L : 0L);
curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, (verify > 1) ? 1L : 0L);  // <- gap
```

With `verify == 1`, the hostname was matched but the CA chain was **not** validated. Hostname verification without peer verification is meaningless — an on-path attacker can present a self-signed certificate bearing the target hostname, pass the host check, and serve an attacker-controlled JWKS, defeating signature verification for any JWT checked against that keyring. The public `jwks_load_fromurl`/`jwks_create_fromurl` doc made it worse by presenting "1 to verify the Host" as a meaningful security level.

## Fix

Tie the two options together: any `verify >= 1` enables **both** `VERIFYHOST` and `VERIFYPEER` (full verification); only `verify == 0` (explicitly insecure) disables it. Update the public documentation to describe the non-zero/zero behavior and drop the misleading host-only middle state.

Note: this is a behavior change for callers passing `verify == 1` — they now get full verification (strictly more secure). `verify == 0` and `verify == 2` are unchanged.

## Testing

- Extended `load_fromurl` to also exercise the `verify == 1` path (over `file://`, as the existing tests do — a live bad-cert TLS endpoint isn't available in CI).
- Full suite passes (OpenSSL + GnuTLS + MbedTLS, Jansson, libcurl).

Part of #282 (this addresses M1; the other JWKS/curl items in that umbrella issue — M3, L10, L11, L15 — are handled in follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)