### PR TITLE
Release v3.4.0

### DIFF
--- a/cmake/LibJWTVersions.cmake
+++ b/cmake/LibJWTVersions.cmake
@@ -4,9 +4,9 @@ set(LIBJWT_PROJECT		"LibJWT")
 set(LIBJWT_DESCRIPTION		"The C JSON Web Token Library +JWK +JWKS")
 set(LIBJWT_HOMEPAGE_URL		"https://libjwt.io")
 
-set(LIBJWT_VERSION_SET		3 3 3)
+set(LIBJWT_VERSION_SET		3 4 0)
 
-set(LIBJWT_SO_CRA		16 7 2)
+set(LIBJWT_SO_CRA		17 0 3)
 # SONAME History
 # v1.12.1      0 => 1
 # v1.15.0      1 => 2

--- a/doxygen/mainpage.dox
+++ b/doxygen/mainpage.dox
@@ -1,8 +1,5 @@
 @mainpage Welcome to LibJWT
 
-> [!WARNING]
-> Version 3 of LibJWT is a complete overhaul of the code. Please see documentation for usage.
-
 @section standards \emoji :bulb: Supported Standards
 
 Standard | RFC        | Description


### PR DESCRIPTION
Prepares the **v3.4.0** release.

## Version / ABI
- Bumps the project version `3.3.3` → `3.4.0`.
- Bumps the SONAME triple (libtool `c:r:a`) `16:7:2` → `17:0:3`. This cycle **only adds interfaces** (38 new public symbols; none removed or changed in signature; existing enums/structs untouched), so per the [libtool rules](http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html) it's `current++, revision=0, age++`. The **SONAME stays `libjwt.so.14`** and existing binaries remain compatible.
- Removes the stale "Version 3 is a complete overhaul" warning from the docs main page.

## What's in 3.4.0 (since v3.3.3)

**Major feature — JWE (RFC 7516/7518):** full JSON Web Encryption support, built up over a series of PRs:
- Content encryption: AES-GCM (A128/192/256GCM) and AES-CBC-HMAC (A128CBC-HS256 … A256CBC-HS512), with the RFC 7516 §11.5 random-CEK mitigation and constant-time tag handling.
- Key management: `dir`, AES Key Wrap (A128/192/256KW), RSA-OAEP / RSA-OAEP-256, and ECDH-ES (Direct, and +A128/192/256KW) with Concat KDF — including the OKP X25519/X448 curves and `apu`/`apv` PartyInfo.
- Serializations: Compact, plus Flattened and General JSON serialization with multiple recipients, AAD, and header disjointness checks.
- Native MbedTLS and GnuTLS JWE backends (in addition to OpenSSL), plus JWK parsing on those backends.
- `jwe-encrypt` / `jwe-decrypt` CLI tools, BATS coverage, and an RFC 7518 App C ECDH-ES known-answer test.

**Other API additions:**
- Public **PEM/DER ↔ JWK** conversion moved into libjwt (`jwks_create_fromkey*`, `jwks_load_fromkey*`, `jwks_export`, `jwks_item_export`).
- **jti** (JWT ID) generation/verification callbacks on the builder/checker.
- RFC 7515 §4.1.11 **`crit`** header support (`jwt_builder_setcrit`, `jwt_checker_understands`).

**Security / robustness hardening:**
- Strict base64url enforcement on decode; claim-validation and JOSE-conformance tightening.
- Crypto strictness: IV/ECDSA/OKP checks, MbedTLS RSA signature-length check, verify-return strictness.
- JWKS: streamed curl response with a bounded buffer, full TLS verification for any `verify >= 1`, OOM-path fix.
- json-c: reject out-of-range integers to match Jansson; `size_t`/`int` length-math hardening.

**Build/ABI/docs:** JWE backend crypto ops hidden from the shared-library ABI; CLI tools dynamically linked against libjwt; Usage Examples doc page; Doxygen `@brief` group descriptions.

## Testing
- All 24 tests pass locally (`make check`) with OpenSSL + GnuTLS + Jansson.