### PR TITLE
mbedtls: migrate the native backend to the PSA Crypto API (4.x support)

### DIFF
--- a/libjwt/mbedtls/jwe.c
+++ b/libjwt/mbedtls/jwe.c
@@ -8,19 +8,10 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
-#include <mbedtls/gcm.h>
-#include <mbedtls/aes.h>
-#include <mbedtls/md.h>
-#include <mbedtls/nist_kw.h>
-#include <mbedtls/rsa.h>
-#include <mbedtls/ecp.h>
-#include <mbedtls/ecdh.h>
-#include <mbedtls/bignum.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
-#include <mbedtls/constant_time.h>
 #include <mbedtls/platform_util.h>
+#include <psa/crypto.h>
 
 #include <jwt.h>
 
@@ -37,54 +28,44 @@ static int enc_is_gcm(jwe_enc_t enc)
 	       enc == JWE_ENC_A256GCM;
 }
 
-/* Seed a fresh CTR-DRBG from the entropy source. The caller frees both with
- * drbg_free(). Returns 0 on success. Seeding per-call mirrors the MbedTLS
- * sign path; it is simple and avoids global state. */
-static int drbg_init(mbedtls_entropy_context *entropy,
-		     mbedtls_ctr_drbg_context *drbg)
+/* Import a raw symmetric key as a volatile PSA AES key with the given policy. */
+static int import_aes_key(const unsigned char *key, size_t key_len,
+			  psa_algorithm_t alg, psa_key_usage_t usage,
+			  mbedtls_svc_key_id_t *kid)
 {
-	const char *pers = "libjwt_jwe";
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	psa_status_t st;
 
-	mbedtls_entropy_init(entropy);
-	mbedtls_ctr_drbg_init(drbg);
+	*kid = MBEDTLS_SVC_KEY_ID_INIT;
 
-	if (mbedtls_ctr_drbg_seed(drbg, mbedtls_entropy_func, entropy,
-				  (const unsigned char *)pers, strlen(pers)))
+	if (psa_crypto_init() != PSA_SUCCESS)
 		return 1; // LCOV_EXCL_LINE
 
-	return 0;
-}
+	psa_set_key_type(&attr, PSA_KEY_TYPE_AES);
+	psa_set_key_usage_flags(&attr, usage);
+	psa_set_key_algorithm(&attr, alg);
 
-static void drbg_free(mbedtls_entropy_context *entropy,
-		      mbedtls_ctr_drbg_context *drbg)
-{
-	mbedtls_ctr_drbg_free(drbg);
-	mbedtls_entropy_free(entropy);
+	st = psa_import_key(&attr, key, key_len, kid);
+	psa_reset_key_attributes(&attr);
+
+	return st != PSA_SUCCESS;
 }
 
 /* @rfc{7516,5.1} CSPRNG for CEK/IV generation and the @rfc{7516,11.5}
- * random-CEK fallback. Backed by MbedTLS CTR-DRBG. */
+ * random-CEK fallback. Backed by the PSA RNG. */
 int mbedtls_rng(unsigned char *out, size_t len)
 {
-	mbedtls_entropy_context entropy;
-	mbedtls_ctr_drbg_context drbg;
-	int ret = 1;
-
 	if (out == NULL || len == 0)
 		return 1; // LCOV_EXCL_LINE
 
-	if (drbg_init(&entropy, &drbg))
+	if (psa_crypto_init() != PSA_SUCCESS)
 		return 1; // LCOV_EXCL_LINE
 
-	if (mbedtls_ctr_drbg_random(&drbg, out, len) == 0)
-		ret = 0;
-
-	drbg_free(&entropy, &drbg);
-
-	return ret;
+	return psa_generate_random(out, len) != PSA_SUCCESS;
 }
 
-/* @rfc{7518,5.3} AES GCM content encryption. */
+/* @rfc{7518,5.3} AES GCM content encryption. PSA returns ciphertext||tag, which
+ * we split into the separate JWE fields. */
 int mbedtls_encrypt_aes_gcm(jwe_enc_t enc, const unsigned char *cek,
 	size_t cek_len, const unsigned char *iv, size_t iv_len,
 	const unsigned char *aad, size_t aad_len,
@@ -92,42 +73,53 @@ int mbedtls_encrypt_aes_gcm(jwe_enc_t enc, const unsigned char *cek,
 	unsigned char **ct, size_t *ct_len,
 	unsigned char **tag, size_t *tag_len)
 {
-	mbedtls_gcm_context gcm;
-	unsigned char *out = NULL, *t = NULL;
+	mbedtls_svc_key_id_t kid = MBEDTLS_SVC_KEY_ID_INIT;
+	unsigned char *buf = NULL, *ct_out = NULL, *tag_out = NULL;
+	size_t buf_size, out_len = 0, ctl;
 	int ret = 1;
 
 	if (!enc_is_gcm(enc) || cek_len != jwe_enc_cek_len(enc))
 		return 1; // LCOV_EXCL_LINE
 
-	mbedtls_gcm_init(&gcm);
+	if (import_aes_key(cek, cek_len, PSA_ALG_GCM, PSA_KEY_USAGE_ENCRYPT, &kid))
+		return 1; // LCOV_EXCL_LINE
 
-	out = jwt_malloc(pt_len ? pt_len : 1);
-	t = jwt_malloc(GCM_TAG_LEN);
-	if (out == NULL || t == NULL)
+	buf_size = PSA_AEAD_ENCRYPT_OUTPUT_SIZE(PSA_KEY_TYPE_AES, PSA_ALG_GCM,
+						pt_len);
+	buf = jwt_malloc(buf_size);
+	if (buf == NULL)
 		goto out; // LCOV_EXCL_LINE
 
-	/* setkey takes the key length in BITS. */
-	if (mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, cek,
-			       (unsigned int)(cek_len * 8)))
+	if (psa_aead_encrypt(kid, PSA_ALG_GCM, iv, iv_len, aad, aad_len,
+			     pt, pt_len, buf, buf_size, &out_len))
+		goto out; // LCOV_EXCL_LINE
+	if (out_len < GCM_TAG_LEN)
 		goto out; // LCOV_EXCL_LINE
 
-	if (mbedtls_gcm_crypt_and_tag(&gcm, MBEDTLS_GCM_ENCRYPT, pt_len,
-				      iv, iv_len, aad, aad_len, pt, out,
-				      GCM_TAG_LEN, t))
+	ctl = out_len - GCM_TAG_LEN;
+
+	ct_out = jwt_malloc(ctl ? ctl : 1);
+	tag_out = jwt_malloc(GCM_TAG_LEN);
+	if (ct_out == NULL || tag_out == NULL)
 		goto out; // LCOV_EXCL_LINE
 
-	*ct = out;
-	*ct_len = pt_len;
-	*tag = t;
+	if (ctl)
+		memcpy(ct_out, buf, ctl);
+	memcpy(tag_out, buf + ctl, GCM_TAG_LEN);
+
+	*ct = ct_out;
+	*ct_len = ctl;
+	*tag = tag_out;
 	*tag_len = GCM_TAG_LEN;
-	out = NULL;
-	t = NULL;
+	ct_out = NULL;
+	tag_out = NULL;
 	ret = 0;
 
 out:
-	jwt_freemem(out);
-	jwt_freemem(t);
-	mbedtls_gcm_free(&gcm);
+	jwt_freemem(buf);
+	jwt_freemem(ct_out);
+	jwt_freemem(tag_out);
+	psa_destroy_key(kid);
 
 	return ret;
 }
@@ -140,56 +132,64 @@ int mbedtls_decrypt_aes_gcm(jwe_enc_t enc, const unsigned char *cek,
 	const unsigned char *tag, size_t tag_len,
 	unsigned char **pt, size_t *pt_len)
 {
-	mbedtls_gcm_context gcm;
-	unsigned char *out = NULL;
+	mbedtls_svc_key_id_t kid = MBEDTLS_SVC_KEY_ID_INIT;
+	unsigned char *in = NULL, *out = NULL;
+	size_t in_len, out_size = 0, out_len = 0;
 	int ret = 1;
 
 	if (!enc_is_gcm(enc) || cek_len != jwe_enc_cek_len(enc) ||
 	    tag_len != GCM_TAG_LEN)
 		return 1; // LCOV_EXCL_LINE
 
-	mbedtls_gcm_init(&gcm);
+	if (import_aes_key(cek, cek_len, PSA_ALG_GCM, PSA_KEY_USAGE_DECRYPT, &kid))
+		return 1; // LCOV_EXCL_LINE
 
-	out = jwt_malloc(ct_len ? ct_len : 1);
+	/* PSA AEAD wants ciphertext||tag contiguous. */
+	in_len = ct_len + tag_len;
+	in = jwt_malloc(in_len);
+	if (in == NULL)
+		goto out; // LCOV_EXCL_LINE
+	if (ct_len)
+		memcpy(in, ct, ct_len);
+	memcpy(in + ct_len, tag, tag_len);
+
+	out_size = PSA_AEAD_DECRYPT_OUTPUT_SIZE(PSA_KEY_TYPE_AES, PSA_ALG_GCM,
+						in_len);
+	out = jwt_malloc(out_size ? out_size : 1);
 	if (out == NULL)
 		goto out; // LCOV_EXCL_LINE
 
-	if (mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, cek,
-			       (unsigned int)(cek_len * 8)))
-		goto out; // LCOV_EXCL_LINE
-
-	/* auth_decrypt performs a constant-time tag check; a non-zero return
-	 * (MBEDTLS_ERR_GCM_AUTH_FAILED) is the authentication failure. */
-	if (mbedtls_gcm_auth_decrypt(&gcm, ct_len, iv, iv_len, aad, aad_len,
-				     tag, GCM_TAG_LEN, ct, out))
+	/* A non-zero return is the constant-time authentication failure. */
+	if (psa_aead_decrypt(kid, PSA_ALG_GCM, iv, iv_len, aad, aad_len,
+			     in, in_len, out, out_size ? out_size : 1, &out_len))
 		goto out;
 
 	*pt = out;
-	*pt_len = ct_len;
+	*pt_len = out_len;
 	out = NULL;
 	ret = 0;
 
 out:
-	jwt_scrub_and_free(out, ct_len ? ct_len : 1);
-	mbedtls_gcm_free(&gcm);
+	jwt_freemem(in);
+	jwt_scrub_and_free(out, out_size);
+	psa_destroy_key(kid);
 
 	return ret;
 }
 
-/* @rfc{7518,5.2} Map a CBC-HMAC enc to its AES key bits, HMAC digest, and the
- * (equal) MAC/ENC key half-length, which is also the truncated tag length. */
-static int cbc_params(jwe_enc_t enc, unsigned int *keybits,
-		      mbedtls_md_type_t *md, size_t *half)
+/* @rfc{7518,5.2} Map a CBC-HMAC enc to its HMAC digest and the (equal) MAC/ENC
+ * key half-length, which is also the truncated tag length. */
+static int cbc_params(jwe_enc_t enc, psa_algorithm_t *hash, size_t *half)
 {
 	switch (enc) {
 	case JWE_ENC_A128CBC_HS256:
-		*keybits = 128; *md = MBEDTLS_MD_SHA256; *half = 16;
+		*hash = PSA_ALG_SHA_256; *half = 16;
 		return 0;
 	case JWE_ENC_A192CBC_HS384:
-		*keybits = 192; *md = MBEDTLS_MD_SHA384; *half = 24;
+		*hash = PSA_ALG_SHA_384; *half = 24;
 		return 0;
 	case JWE_ENC_A256CBC_HS512:
-		*keybits = 256; *md = MBEDTLS_MD_SHA512; *half = 32;
+		*hash = PSA_ALG_SHA_512; *half = 32;
 		return 0;
 	// LCOV_EXCL_START
 	default:
@@ -198,21 +198,17 @@ static int cbc_params(jwe_enc_t enc, unsigned int *keybits,
 	}
 }
 
-/* @rfc{7518,5.2.2.1} HMAC over AAD || IV || CT || AL, where AL is the 64-bit
- * big-endian bit-length of the AAD, truncated to the leftmost @half octets.
- * @out must hold at least 64 bytes (max SHA-512). */
-static int cbc_hmac_tag(mbedtls_md_type_t mdtype, const unsigned char *mac_key,
-			size_t half, const unsigned char *aad, size_t aad_len,
-			const unsigned char *iv, size_t iv_len,
-			const unsigned char *ct, size_t ct_len,
-			unsigned char *out)
+/* @rfc{7518,5.2.2.1} Assemble AAD || IV || CT || AL into a heap buffer, where AL
+ * is the 64-bit big-endian bit length of the AAD. The caller frees it. */
+static unsigned char *cbc_mac_input(const unsigned char *aad, size_t aad_len,
+		const unsigned char *iv, size_t iv_len,
+		const unsigned char *ct, size_t ct_len, size_t *out_len)
 {
-	const mbedtls_md_info_t *md = mbedtls_md_info_from_type(mdtype);
 	unsigned char al[8];
 	uint64_t aad_bits = (uint64_t)aad_len * 8;
 	unsigned char *buf;
 	size_t buf_len, off = 0;
-	int i, ret = 1;
+	int i;
 
 	for (i = 7; i >= 0; i--) {
 		al[i] = (unsigned char)(aad_bits & 0xff);
@@ -222,20 +218,41 @@ static int cbc_hmac_tag(mbedtls_md_type_t mdtype, const unsigned char *mac_key,
 	buf_len = aad_len + iv_len + ct_len + sizeof(al);
 	buf = jwt_malloc(buf_len ? buf_len : 1);
 	if (buf == NULL)
-		return 1; // LCOV_EXCL_LINE
+		return NULL; // LCOV_EXCL_LINE
 
 	if (aad_len) { memcpy(buf + off, aad, aad_len); off += aad_len; }
 	memcpy(buf + off, iv, iv_len); off += iv_len;
 	if (ct_len) { memcpy(buf + off, ct, ct_len); off += ct_len; }
 	memcpy(buf + off, al, sizeof(al));
 
-	if (md != NULL &&
-	    mbedtls_md_hmac(md, mac_key, half, buf, buf_len, out) == 0)
-		ret = 0;
+	*out_len = buf_len;
 
-	jwt_freemem(buf);
+	return buf;
+}
 
-	return ret;
+/* Import the MAC key with a TRUNCATED-MAC HMAC policy (the JWE auth tag is the
+ * leftmost @half octets of the HMAC), returning the matching alg in @mac_alg. */
+static int import_hmac_key(const unsigned char *mac_key, size_t half,
+		psa_algorithm_t hash, psa_key_usage_t usage,
+		psa_algorithm_t *mac_alg, mbedtls_svc_key_id_t *kid)
+{
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	psa_status_t st;
+
+	*mac_alg = PSA_ALG_TRUNCATED_MAC(PSA_ALG_HMAC(hash), half);
+	*kid = MBEDTLS_SVC_KEY_ID_INIT;
+
+	if (psa_crypto_init() != PSA_SUCCESS)
+		return 1; // LCOV_EXCL_LINE
+
+	psa_set_key_type(&attr, PSA_KEY_TYPE_HMAC);
+	psa_set_key_usage_flags(&attr, usage);
+	psa_set_key_algorithm(&attr, *mac_alg);
+
+	st = psa_import_key(&attr, mac_key, half, kid);
+	psa_reset_key_attributes(&attr);
+
+	return st != PSA_SUCCESS;
 }
 
 /* @rfc{7518,5.2} AES-CBC + HMAC content encryption (encrypt-then-MAC). */
@@ -246,61 +263,79 @@ int mbedtls_encrypt_aes_cbc_hmac(jwe_enc_t enc, const unsigned char *cek,
 	unsigned char **ct, size_t *ct_len,
 	unsigned char **tag, size_t *tag_len)
 {
-	mbedtls_aes_context aes;
-	mbedtls_md_type_t mdtype;
-	unsigned int keybits;
-	unsigned char hmac[64], ivc[16];
-	unsigned char *out = NULL, *t = NULL;
+	mbedtls_svc_key_id_t enc_kid = MBEDTLS_SVC_KEY_ID_INIT;
+	mbedtls_svc_key_id_t mac_kid = MBEDTLS_SVC_KEY_ID_INIT;
+	psa_cipher_operation_t op = PSA_CIPHER_OPERATION_INIT;
+	psa_algorithm_t hash, mac_alg;
 	const unsigned char *mac_key, *enc_key;
-	size_t half, padded, pad, bs = 16;
-	int ret = 1;
+	unsigned char *pin = NULL, *out = NULL, *tag_out = NULL, *macbuf = NULL;
+	size_t half, padded, pad, bs = 16, o1 = 0, o2 = 0, mac_in_len, tl = 0;
+	int ret = 1, op_active = 0;
 
-	if (cbc_params(enc, &keybits, &mdtype, &half) ||
-	    cek_len != jwe_enc_cek_len(enc) || iv_len != 16)
+	if (cbc_params(enc, &hash, &half) || cek_len != jwe_enc_cek_len(enc) ||
+	    iv_len != 16)
 		return 1; // LCOV_EXCL_LINE
 
 	/* @rfc{7518,5.2.2.1} MAC_KEY is the first half, ENC_KEY the second. */
 	mac_key = cek;
 	enc_key = cek + half;
 
-	mbedtls_aes_init(&aes);
-
 	/* PKCS#7: always add 1..bs padding bytes. */
 	pad = bs - (pt_len % bs);
 	padded = pt_len + pad;
 
-	out = jwt_malloc(padded);
-	t = jwt_malloc(half);
-	if (out == NULL || t == NULL)
+	pin = jwt_malloc(padded);
+	out = jwt_malloc(padded + bs);
+	tag_out = jwt_malloc(half);
+	if (pin == NULL || out == NULL || tag_out == NULL)
 		goto out; // LCOV_EXCL_LINE
 	if (pt_len)
-		memcpy(out, pt, pt_len);
-	memset(out + pt_len, (int)pad, pad);
+		memcpy(pin, pt, pt_len);
+	memset(pin + pt_len, (int)pad, pad);
 
-	/* mbedtls_aes_crypt_cbc updates the IV buffer in place; use a copy. */
-	memcpy(ivc, iv, 16);
-	if (mbedtls_aes_setkey_enc(&aes, enc_key, keybits) ||
-	    mbedtls_aes_crypt_cbc(&aes, MBEDTLS_AES_ENCRYPT, padded, ivc,
-				  out, out))
+	/* AES-CBC with the supplied IV (multipart, so we can set the IV; the
+	 * one-shot psa_cipher_encrypt would generate a random IV of its own). */
+	if (import_aes_key(enc_key, half, PSA_ALG_CBC_NO_PADDING,
+			   PSA_KEY_USAGE_ENCRYPT, &enc_kid))
 		goto out; // LCOV_EXCL_LINE
+	if (psa_cipher_encrypt_setup(&op, enc_kid, PSA_ALG_CBC_NO_PADDING))
+		goto out; // LCOV_EXCL_LINE
+	op_active = 1;
+	if (psa_cipher_set_iv(&op, iv, iv_len) ||
+	    psa_cipher_update(&op, pin, padded, out, padded + bs, &o1) ||
+	    psa_cipher_finish(&op, out + o1, padded + bs - o1, &o2))
+		goto out; // LCOV_EXCL_LINE
+	op_active = 0;
 
-	if (cbc_hmac_tag(mdtype, mac_key, half, aad, aad_len, iv, iv_len,
-			 out, padded, hmac))
+	/* Tag = leftmost half of HMAC over AAD || IV || CT || AL. */
+	macbuf = cbc_mac_input(aad, aad_len, iv, iv_len, out, o1 + o2,
+			       &mac_in_len);
+	if (macbuf == NULL)
 		goto out; // LCOV_EXCL_LINE
-	memcpy(t, hmac, half);
+	if (import_hmac_key(mac_key, half, hash, PSA_KEY_USAGE_SIGN_MESSAGE,
+			    &mac_alg, &mac_kid))
+		goto out; // LCOV_EXCL_LINE
+	if (psa_mac_compute(mac_kid, mac_alg, macbuf, mac_in_len, tag_out, half,
+			    &tl))
+		goto out; // LCOV_EXCL_LINE
 
 	*ct = out;
-	*ct_len = padded;
-	*tag = t;
+	*ct_len = o1 + o2;
+	*tag = tag_out;
 	*tag_len = half;
 	out = NULL;
-	t = NULL;
+	tag_out = NULL;
 	ret = 0;
 
 out:
+	if (op_active)
+		psa_cipher_abort(&op); // LCOV_EXCL_LINE
+	jwt_scrub_and_free(pin, padded);
 	jwt_freemem(out);
-	jwt_freemem(t);
-	mbedtls_aes_free(&aes);
+	jwt_freemem(tag_out);
+	jwt_freemem(macbuf);
+	psa_destroy_key(enc_kid);
+	psa_destroy_key(mac_kid);
 
 	return ret;
 }
@@ -314,142 +349,223 @@ int mbedtls_decrypt_aes_cbc_hmac(jwe_enc_t enc, const unsigned char *cek,
 	const unsigned char *tag, size_t tag_len,
 	unsigned char **pt, size_t *pt_len)
 {
-	mbedtls_aes_context aes;
-	mbedtls_md_type_t mdtype;
-	unsigned int keybits;
-	unsigned char hmac[64], ivc[16];
-	unsigned char *out = NULL;
+	mbedtls_svc_key_id_t enc_kid = MBEDTLS_SVC_KEY_ID_INIT;
+	mbedtls_svc_key_id_t mac_kid = MBEDTLS_SVC_KEY_ID_INIT;
+	psa_cipher_operation_t op = PSA_CIPHER_OPERATION_INIT;
+	psa_algorithm_t hash, mac_alg;
 	const unsigned char *mac_key, *enc_key;
-	size_t half, pad, bs = 16;
-	int ret = 1;
+	unsigned char *out = NULL, *macbuf = NULL;
+	size_t half, pad, bs = 16, o1 = 0, o2 = 0, mac_in_len, outlen;
+	int ret = 1, op_active = 0;
 
-	if (cbc_params(enc, &keybits, &mdtype, &half) ||
-	    cek_len != jwe_enc_cek_len(enc) || iv_len != 16 ||
-	    tag_len != half || ct_len == 0 || (ct_len % bs) != 0)
+	if (cbc_params(enc, &hash, &half) || cek_len != jwe_enc_cek_len(enc) ||
+	    iv_len != 16 || tag_len != half || ct_len == 0 || (ct_len % bs) != 0)
 		return 1; // LCOV_EXCL_LINE
 
 	mac_key = cek;
 	enc_key = cek + half;
 
-	/* @rfc{7518,5.2.2.2} Recompute and compare the tag in constant time
-	 * before touching the ciphertext. */
-	if (cbc_hmac_tag(mdtype, mac_key, half, aad, aad_len, iv, iv_len,
-			 ct, ct_len, hmac))
+	/* @rfc{7518,5.2.2.2} Recompute and compare the tag in constant time before
+	 * touching the ciphertext (psa_mac_verify is constant-time). */
+	macbuf = cbc_mac_input(aad, aad_len, iv, iv_len, ct, ct_len, &mac_in_len);
+	if (macbuf == NULL)
 		return 1; // LCOV_EXCL_LINE
-	if (mbedtls_ct_memcmp(hmac, tag, half) != 0)
+	if (import_hmac_key(mac_key, half, hash, PSA_KEY_USAGE_VERIFY_MESSAGE,
+			    &mac_alg, &mac_kid)) {
+		// LCOV_EXCL_START
+		jwt_freemem(macbuf);
+		return 1;
+		// LCOV_EXCL_STOP
+	}
+	ret = psa_mac_verify(mac_kid, mac_alg, macbuf, mac_in_len, tag, half) ? 1 : 0;
+	jwt_freemem(macbuf);
+	psa_destroy_key(mac_kid);
+	mac_kid = MBEDTLS_SVC_KEY_ID_INIT;
+	if (ret)
 		return 1;
 
-	mbedtls_aes_init(&aes);
+	ret = 1;
 
-	out = jwt_malloc(ct_len);
+	out = jwt_malloc(ct_len + bs);
 	if (out == NULL)
 		goto out; // LCOV_EXCL_LINE
 
-	memcpy(ivc, iv, 16);
-	if (mbedtls_aes_setkey_dec(&aes, enc_key, keybits) ||
-	    mbedtls_aes_crypt_cbc(&aes, MBEDTLS_AES_DECRYPT, ct_len, ivc,
-				  ct, out))
+	if (import_aes_key(enc_key, half, PSA_ALG_CBC_NO_PADDING,
+			   PSA_KEY_USAGE_DECRYPT, &enc_kid))
 		goto out; // LCOV_EXCL_LINE
+	if (psa_cipher_decrypt_setup(&op, enc_kid, PSA_ALG_CBC_NO_PADDING))
+		goto out; // LCOV_EXCL_LINE
+	op_active = 1;
+	if (psa_cipher_set_iv(&op, iv, iv_len) ||
+	    psa_cipher_update(&op, ct, ct_len, out, ct_len + bs, &o1) ||
+	    psa_cipher_finish(&op, out + o1, ct_len + bs - o1, &o2))
+		goto out; // LCOV_EXCL_LINE
+	op_active = 0;
+	outlen = o1 + o2;
 
 	/* Strip and validate PKCS#7 padding. The tag already authenticated the
-	 * ciphertext, so a corrupt-padding path is not reachable with a valid
-	 * tag; the check stays as defense in depth. */
-	pad = out[ct_len - 1];
-	if (pad == 0 || pad > bs || pad > ct_len)
+	 * ciphertext, so a corrupt-padding path is not reachable with a valid tag;
+	 * the check stays as defense in depth. */
+	pad = out[outlen - 1];
+	if (pad == 0 || pad > bs || pad > outlen)
 		goto out; // LCOV_EXCL_LINE
 
 	*pt = out;
-	*pt_len = ct_len - pad;
+	*pt_len = outlen - pad;
 	out = NULL;
 	ret = 0;
 
 out:
-	jwt_scrub_and_free(out, ct_len);
-	mbedtls_aes_free(&aes);
+	if (op_active)
+		psa_cipher_abort(&op); // LCOV_EXCL_LINE
+	jwt_scrub_and_free(out, ct_len + bs);
+	psa_destroy_key(enc_kid);
+	psa_destroy_key(mac_kid);
 
 	return ret;
 }
 
-/* @rfc{7518,4.4} AES Key Wrap (RFC 3394) with a raw KEK via mbedtls_nist_kw.
- * MBEDTLS_KW_MODE_KW is RFC 3394 (the A6A6… ICV); KWP is RFC 5649 and must not
- * be used for JWE. */
+/* One AES-ECB block (16 bytes), the primitive under RFC 3394 key wrap. ECB has
+ * no IV, so PSA returns exactly the 16-byte block. */
+static int aes_ecb_block(mbedtls_svc_key_id_t kid, int encrypt,
+			 const unsigned char in[16], unsigned char out[16])
+{
+	unsigned char tmp[32];
+	size_t olen = 0;
+	psa_status_t st;
+
+	if (encrypt)
+		st = psa_cipher_encrypt(kid, PSA_ALG_ECB_NO_PADDING, in, 16,
+					tmp, sizeof(tmp), &olen);
+	else
+		st = psa_cipher_decrypt(kid, PSA_ALG_ECB_NO_PADDING, in, 16,
+					tmp, sizeof(tmp), &olen);
+
+	if (st != PSA_SUCCESS || olen != 16)
+		return 1; // LCOV_EXCL_LINE
+
+	memcpy(out, tmp, 16);
+
+	return 0;
+}
+
+/* @rfc{3394} AES Key Wrap with a raw KEK, built on AES-ECB. (RFC 3394 / the KW
+ * "A6A6..." ICV, NOT RFC 5649 KWP, which must not be used for JWE.) */
 static int kw_wrap_raw(const unsigned char *kek, size_t kek_len,
 		       const unsigned char *in, size_t in_len,
 		       unsigned char **out, size_t *out_len)
 {
-	mbedtls_nist_kw_context kw;
+	mbedtls_svc_key_id_t kid = MBEDTLS_SVC_KEY_ID_INIT;
+	unsigned char a[8], b[16], *r;
 	unsigned char *buf = NULL;
-	size_t olen = 0;
-	int ret = 1;
+	size_t n, i, j;
+	int k, ret = 1;
 
 	if ((kek_len != 16 && kek_len != 24 && kek_len != 32) ||
 	    in_len < 16 || (in_len % 8) != 0)
 		return 1; // LCOV_EXCL_LINE
 
-	mbedtls_nist_kw_init(&kw);
+	n = in_len / 8;
+
+	if (import_aes_key(kek, kek_len, PSA_ALG_ECB_NO_PADDING,
+			   PSA_KEY_USAGE_ENCRYPT, &kid))
+		return 1; // LCOV_EXCL_LINE
 
 	buf = jwt_malloc(in_len + 8);
 	if (buf == NULL)
 		goto out; // LCOV_EXCL_LINE
 
-	if (mbedtls_nist_kw_setkey(&kw, MBEDTLS_CIPHER_ID_AES, kek,
-				   (unsigned int)(kek_len * 8), 1))
-		goto out; // LCOV_EXCL_LINE
+	memset(a, 0xA6, 8);		/* A = default IV */
+	memcpy(buf + 8, in, in_len);	/* R[1..n] = P[1..n] */
 
-	if (mbedtls_nist_kw_wrap(&kw, MBEDTLS_KW_MODE_KW, in, in_len,
-				 buf, &olen, in_len + 8))
-		goto out; // LCOV_EXCL_LINE
+	for (j = 0; j < 6; j++) {
+		for (i = 1; i <= n; i++) {
+			uint64_t t = (uint64_t)(n * j + i);
+
+			r = buf + i * 8;
+			memcpy(b, a, 8);
+			memcpy(b + 8, r, 8);
+			if (aes_ecb_block(kid, 1, b, b))
+				goto out; // LCOV_EXCL_LINE
+			memcpy(a, b, 8);	/* A = MSB64(B) ^ t */
+			for (k = 0; k < 8; k++)
+				a[7 - k] ^= (unsigned char)(t >> (8 * k));
+			memcpy(r, b + 8, 8);	/* R[i] = LSB64(B) */
+		}
+	}
+
+	memcpy(buf, a, 8);		/* C[0] = A */
 
 	*out = buf;
-	*out_len = olen;
+	*out_len = in_len + 8;
 	buf = NULL;
 	ret = 0;
 
 out:
 	jwt_freemem(buf);
-	mbedtls_nist_kw_free(&kw);
+	psa_destroy_key(kid);
 
 	return ret;
 }
 
-/* @rfc{7518,4.4} AES Key Unwrap (RFC 3394) with a raw KEK. */
+/* @rfc{3394} AES Key Unwrap with a raw KEK. */
 static int kw_unwrap_raw(const unsigned char *kek, size_t kek_len,
 			 const unsigned char *in, size_t in_len,
 			 unsigned char **out, size_t *out_len)
 {
-	mbedtls_nist_kw_context kw;
+	mbedtls_svc_key_id_t kid = MBEDTLS_SVC_KEY_ID_INIT;
+	unsigned char a[8], b[16], diff = 0, *r;
 	unsigned char *buf = NULL;
-	size_t olen = 0;
-	int ret = 1;
+	size_t n, i, j;
+	int k, ret = 1;
 
 	if ((kek_len != 16 && kek_len != 24 && kek_len != 32) ||
 	    in_len < 24 || (in_len % 8) != 0)
 		return 1;
 
-	mbedtls_nist_kw_init(&kw);
+	n = in_len / 8 - 1;
 
-	buf = jwt_malloc(in_len);
+	if (import_aes_key(kek, kek_len, PSA_ALG_ECB_NO_PADDING,
+			   PSA_KEY_USAGE_DECRYPT, &kid))
+		return 1; // LCOV_EXCL_LINE
+
+	buf = jwt_malloc(in_len - 8);
 	if (buf == NULL)
 		goto out; // LCOV_EXCL_LINE
 
-	if (mbedtls_nist_kw_setkey(&kw, MBEDTLS_CIPHER_ID_AES, kek,
-				   (unsigned int)(kek_len * 8), 0))
-		goto out; // LCOV_EXCL_LINE
+	memcpy(a, in, 8);		/* A = C[0] */
+	memcpy(buf, in + 8, in_len - 8);/* R[1..n] = C[1..n] */
 
-	/* A non-zero return (MBEDTLS_ERR_CIPHER_AUTH_FAILED) is the RFC 3394
-	 * integrity-check failure on the recovered A6 IV. */
-	if (mbedtls_nist_kw_unwrap(&kw, MBEDTLS_KW_MODE_KW, in, in_len,
-				   buf, &olen, in_len))
+	for (j = 6; j-- > 0; ) {
+		for (i = n; i >= 1; i--) {
+			uint64_t t = (uint64_t)(n * j + i);
+
+			r = buf + (i - 1) * 8;
+			for (k = 0; k < 8; k++)
+				a[7 - k] ^= (unsigned char)(t >> (8 * k));
+			memcpy(b, a, 8);
+			memcpy(b + 8, r, 8);
+			if (aes_ecb_block(kid, 0, b, b))
+				goto out; // LCOV_EXCL_LINE
+			memcpy(a, b, 8);	/* A = MSB64(B) */
+			memcpy(r, b + 8, 8);	/* R[i] = LSB64(B) */
+		}
+	}
+
+	/* Integrity: the recovered A must equal the RFC 3394 default IV. */
+	for (i = 0; i < 8; i++)
+		diff |= a[i] ^ 0xA6;
+	if (diff)
 		goto out;
 
 	*out = buf;
-	*out_len = olen;
+	*out_len = in_len - 8;
 	buf = NULL;
 	ret = 0;
 
 out:
-	jwt_scrub_and_free(buf, in_len);
-	mbedtls_nist_kw_free(&kw);
+	jwt_scrub_and_free(buf, in_len - 8);
+	psa_destroy_key(kid);
 
 	return ret;
 }
@@ -495,103 +611,91 @@ int mbedtls_unwrap_aes_kw_raw(const unsigned char *kek, size_t kek_len,
 	return kw_unwrap_raw(kek, kek_len, in, in_len, cek, cek_len);
 }
 
-/* Map an RSA-OAEP alg to its MbedTLS digest. In MbedTLS the same hash is used
- * for the OAEP encoding AND the MGF1 (mbedtls_rsa_set_padding has no separate
- * MGF1 setter), exactly what JWE requires. */
-static mbedtls_md_type_t oaep_md(jwe_key_alg_t alg)
+/* Map an RSA-OAEP alg to its PSA hash. The same hash is used for the OAEP label
+ * digest and the MGF1, exactly what JWE requires. */
+static psa_algorithm_t oaep_hash(jwe_key_alg_t alg)
 {
 	if (alg == JWE_ALG_RSA_OAEP)
-		return MBEDTLS_MD_SHA1;
+		return PSA_ALG_SHA_1;
 	if (alg == JWE_ALG_RSA_OAEP_256)
-		return MBEDTLS_MD_SHA256;
+		return PSA_ALG_SHA_256;
 
-	return MBEDTLS_MD_NONE; // LCOV_EXCL_LINE
+	return PSA_ALG_NONE; // LCOV_EXCL_LINE
 }
 
-/* @rfc{7518,4.3} RSAES-OAEP encryption of the CEK to the recipient public key.
- * The recipient's native MbedTLS RSA key is on the JWK. */
+/* @rfc{7518,4.3} RSAES-OAEP encryption of the CEK to the recipient public key. */
 int mbedtls_encrypt_cek_rsa(jwe_key_alg_t alg, const jwk_item_t *key,
 			    const unsigned char *cek, size_t cek_len,
 			    unsigned char **out, size_t *out_len)
 {
 	const mbedtls_jwk_t *jk = key->provider_data;
-	mbedtls_rsa_context *rsa;
-	mbedtls_entropy_context entropy;
-	mbedtls_ctr_drbg_context drbg;
-	mbedtls_md_type_t md = oaep_md(alg);
+	mbedtls_svc_key_id_t kid = MBEDTLS_SVC_KEY_ID_INIT;
+	psa_algorithm_t hash = oaep_hash(alg), oalg;
 	unsigned char *buf = NULL;
-	size_t rsa_len;
+	size_t rsa_len, olen = 0;
 	int ret = 1;
 
-	if (jk == NULL || jk->kty != JWK_KEY_TYPE_RSA || md == MBEDTLS_MD_NONE)
+	if (jk == NULL || jk->kty != JWK_KEY_TYPE_RSA || hash == PSA_ALG_NONE)
 		return 1; // LCOV_EXCL_LINE
 
-	rsa = (mbedtls_rsa_context *)&jk->rsa;
-	rsa_len = mbedtls_rsa_get_len(rsa);
+	oalg = PSA_ALG_RSA_OAEP(hash);
+	rsa_len = (jk->bits + 7) / 8;
 
-	if (drbg_init(&entropy, &drbg))
+	if (mbedtls_jwk_to_psa(jk, 0, oalg, PSA_KEY_USAGE_ENCRYPT, &kid))
 		return 1; // LCOV_EXCL_LINE
 
 	buf = jwt_malloc(rsa_len);
 	if (buf == NULL)
 		goto out; // LCOV_EXCL_LINE
 
-	if (mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V21, md))
-		goto out; // LCOV_EXCL_LINE
-
-	if (mbedtls_rsa_rsaes_oaep_encrypt(rsa, mbedtls_ctr_drbg_random, &drbg,
-					   NULL, 0, cek_len, cek, buf))
+	if (psa_asymmetric_encrypt(kid, oalg, cek, cek_len, NULL, 0,
+				   buf, rsa_len, &olen))
 		goto out; // LCOV_EXCL_LINE
 
 	*out = buf;
-	*out_len = rsa_len;
+	*out_len = olen;
 	buf = NULL;
 	ret = 0;
 
 out:
 	jwt_freemem(buf);
-	drbg_free(&entropy, &drbg);
+	psa_destroy_key(kid);
 
 	return ret;
 }
 
-/* @rfc{7518,4.3} RSAES-OAEP decryption of the JWE Encrypted Key. A failure
- * here is funnelled by the caller into the uniform random-CEK path (11.5). */
+/* @rfc{7518,4.3} RSAES-OAEP decryption of the JWE Encrypted Key. A failure here
+ * is funnelled by the caller into the uniform random-CEK path (11.5). */
 int mbedtls_decrypt_cek_rsa(jwe_key_alg_t alg, const jwk_item_t *key,
 			    const unsigned char *in, size_t in_len,
 			    unsigned char **cek, size_t *cek_len)
 {
 	const mbedtls_jwk_t *jk = key->provider_data;
-	mbedtls_rsa_context *rsa;
-	mbedtls_entropy_context entropy;
-	mbedtls_ctr_drbg_context drbg;
-	mbedtls_md_type_t md = oaep_md(alg);
+	mbedtls_svc_key_id_t kid = MBEDTLS_SVC_KEY_ID_INIT;
+	psa_algorithm_t hash = oaep_hash(alg), oalg;
 	unsigned char *buf = NULL;
 	size_t rsa_len, olen = 0;
 	int ret = 1;
 
-	if (jk == NULL || jk->kty != JWK_KEY_TYPE_RSA || md == MBEDTLS_MD_NONE)
+	if (jk == NULL || jk->kty != JWK_KEY_TYPE_RSA || hash == PSA_ALG_NONE)
 		return 1; // LCOV_EXCL_LINE
 
-	rsa = (mbedtls_rsa_context *)&jk->rsa;
-	rsa_len = mbedtls_rsa_get_len(rsa);
+	oalg = PSA_ALG_RSA_OAEP(hash);
+	rsa_len = (jk->bits + 7) / 8;
 
 	if (in_len != rsa_len)
 		return 1;
 
-	if (drbg_init(&entropy, &drbg))
+	if (mbedtls_jwk_to_psa(jk, 1, oalg, PSA_KEY_USAGE_DECRYPT, &kid))
 		return 1; // LCOV_EXCL_LINE
 
 	buf = jwt_malloc(rsa_len);
 	if (buf == NULL)
 		goto out; // LCOV_EXCL_LINE
 
-	if (mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V21, md))
-		goto out; // LCOV_EXCL_LINE
-
 	/* A decryption/padding failure returns non-zero here. */
-	if (mbedtls_rsa_rsaes_oaep_decrypt(rsa, mbedtls_ctr_drbg_random, &drbg,
-					   NULL, 0, &olen, in, buf, rsa_len))
+	if (psa_asymmetric_decrypt(kid, oalg, in, in_len, NULL, 0,
+				   buf, rsa_len, &olen))
 		goto out;
 
 	*cek = buf;
@@ -601,7 +705,7 @@ int mbedtls_decrypt_cek_rsa(jwe_key_alg_t alg, const jwk_item_t *key,
 
 out:
 	jwt_scrub_and_free(buf, rsa_len);
-	drbg_free(&entropy, &drbg);
+	psa_destroy_key(kid);
 
 	return ret;
 }
@@ -656,7 +760,7 @@ static int concat_kdf(const unsigned char *z, size_t z_len,
 	unsigned char hash[32];
 	unsigned char *buf;
 	size_t algid_len = strlen(algid);
-	size_t buf_len, off = 0;
+	size_t buf_len, off = 0, hlen = 0;
 	uint32_t bits = (uint32_t)(keydatalen * 8);
 	unsigned char counter[4] = { 0, 0, 0, 1 };
 	unsigned char supppub[4];
@@ -683,8 +787,8 @@ static int concat_kdf(const unsigned char *z, size_t z_len,
 	concat_put_data(buf, &off, apv, apv_len);
 	memcpy(buf + off, supppub, 4); off += 4;
 
-	if (mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256),
-		       buf, off, hash) == 0) {
+	if (psa_hash_compute(PSA_ALG_SHA_256, buf, off, hash, sizeof(hash),
+			     &hlen) == 0) {
 		memcpy(out, hash, keydatalen);
 		ret = 0;
 	}
@@ -694,58 +798,20 @@ static int concat_kdf(const unsigned char *z, size_t z_len,
 	return ret;
 }
 
-/* NIST curve coordinate length in octets, and the JWK "crv" name. */
-static int nist_crv_info(mbedtls_ecp_group_id gid, size_t *fieldlen,
-			 const char **crv)
+/* Build an "epk" {kty:EC,crv,x,y} JWK from a PSA-exported NIST public point
+ * (0x04 || X || Y, each @fieldlen bytes). */
+static jwt_json_t *epk_ec_to_json(const unsigned char *pub, size_t pub_len,
+				  const char *crv, size_t fieldlen)
 {
-	switch (gid) {
-	case MBEDTLS_ECP_DP_SECP256R1:
-		*fieldlen = 32; *crv = "P-256"; return 0;
-	case MBEDTLS_ECP_DP_SECP384R1:
-		*fieldlen = 48; *crv = "P-384"; return 0;
-	case MBEDTLS_ECP_DP_SECP521R1:
-		*fieldlen = 66; *crv = "P-521"; return 0;
-	// LCOV_EXCL_START
-	default:
-		return 1;
-	// LCOV_EXCL_STOP
-	}
-}
-
-/* Is this a Montgomery X-curve (X25519/X448)? */
-static int gid_is_montgomery(mbedtls_ecp_group_id gid)
-{
-	return gid == MBEDTLS_ECP_DP_CURVE25519 ||
-	       gid == MBEDTLS_ECP_DP_CURVE448;
-}
-
-/* X25519/X448 raw key length and JWK "crv" name. */
-static int okp_crv_info(mbedtls_ecp_group_id gid, size_t *keylen,
-			const char **crv)
-{
-	if (gid == MBEDTLS_ECP_DP_CURVE25519) {
-		*keylen = 32; *crv = "X25519"; return 0;
-	}
-	if (gid == MBEDTLS_ECP_DP_CURVE448) {
-		*keylen = 56; *crv = "X448"; return 0;
-	}
-	return 1; // LCOV_EXCL_LINE
-}
-
-/* Build an "epk" {kty:EC,crv,x,y} JWK from an ephemeral NIST public point. */
-static jwt_json_t *epk_ec_to_json(const mbedtls_ecp_point *Q, const char *crv,
-				  size_t fieldlen)
-{
-	jwt_json_t *epk = NULL;
+	jwt_json_t *epk;
 	char_auto *x_b64 = NULL, *y_b64 = NULL;
-	unsigned char xb[66], yb[66];
 
-	if (mbedtls_mpi_write_binary(&Q->MBEDTLS_PRIVATE(X), xb, fieldlen) ||
-	    mbedtls_mpi_write_binary(&Q->MBEDTLS_PRIVATE(Y), yb, fieldlen))
+	if (pub_len != 1 + fieldlen * 2 || pub[0] != 0x04)
 		return NULL; // LCOV_EXCL_LINE
 
-	if (jwt_base64uri_encode(&x_b64, (char *)xb, (int)fieldlen) <= 0 ||
-	    jwt_base64uri_encode(&y_b64, (char *)yb, (int)fieldlen) <= 0)
+	if (jwt_base64uri_encode(&x_b64, (char *)pub + 1, (int)fieldlen) <= 0 ||
+	    jwt_base64uri_encode(&y_b64, (char *)pub + 1 + fieldlen,
+				 (int)fieldlen) <= 0)
 		return NULL; // LCOV_EXCL_LINE
 
 	epk = jwt_json_create();
@@ -759,16 +825,20 @@ static jwt_json_t *epk_ec_to_json(const mbedtls_ecp_point *Q, const char *crv,
 	return epk;
 }
 
-/* Read a peer NIST public point from an "epk" {kty:EC,crv,x,y} JWK. */
+/* Read a peer NIST public point from an "epk" {kty:EC,crv,x,y} JWK into the
+ * uncompressed-point form (0x04 || X || Y) PSA agreement expects. */
 static int epk_ec_from_json(jwt_json_t *epk, const char *want_crv,
-			    const mbedtls_ecp_group *grp,
-			    mbedtls_ecp_point *Q, size_t fieldlen)
+			    size_t fieldlen, unsigned char *out, size_t out_cap,
+			    size_t *out_len)
 {
 	jwt_json_t *jkty, *jcrv, *jx, *jy;
 	const char *kty, *crv;
-	unsigned char *xb = NULL, *yb = NULL, *point = NULL;
+	unsigned char *xb = NULL, *yb = NULL;
 	int xlen = 0, ylen = 0, ret = 1;
-	size_t ptlen;
+	size_t ptlen = 1 + fieldlen * 2;
+
+	if (ptlen > out_cap)
+		return 1; // LCOV_EXCL_LINE
 
 	jkty = jwt_json_obj_get(epk, "kty");
 	jcrv = jwt_json_obj_get(epk, "crv");
@@ -790,42 +860,29 @@ static int epk_ec_from_json(jwt_json_t *epk, const char *want_crv,
 	    (size_t)ylen > fieldlen)
 		goto out; // LCOV_EXCL_LINE
 
-	/* Uncompressed point: 0x04 || X || Y, each left-padded to fieldlen. */
-	ptlen = 1 + fieldlen * 2;
-	point = jwt_malloc(ptlen);
-	if (point == NULL)
-		goto out; // LCOV_EXCL_LINE
-	memset(point, 0, ptlen);
-	point[0] = 0x04;
-	memcpy(point + 1 + (fieldlen - (size_t)xlen), xb, (size_t)xlen);
-	memcpy(point + 1 + fieldlen + (fieldlen - (size_t)ylen), yb,
-	       (size_t)ylen);
+	memset(out, 0, ptlen);
+	out[0] = 0x04;
+	memcpy(out + 1 + (fieldlen - (size_t)xlen), xb, (size_t)xlen);
+	memcpy(out + 1 + fieldlen + (fieldlen - (size_t)ylen), yb, (size_t)ylen);
+	*out_len = ptlen;
+	ret = 0;
 
-	if (mbedtls_ecp_point_read_binary(grp, Q, point, ptlen) == 0 &&
-	    mbedtls_ecp_check_pubkey(grp, Q) == 0)
-		ret = 0;
-
-out: // LCOV_EXCL_LINE (gcov mis-counts the bare label)
+out:
 	jwt_freemem(xb);
 	jwt_freemem(yb);
-	jwt_freemem(point);
 
 	return ret;
 }
 
-/* Build an "epk" {kty:OKP,crv,x} JWK from an ephemeral X-curve public point.
- * The Montgomery U-coordinate is emitted little-endian (RFC 7748/JWE wire). */
-static jwt_json_t *epk_okp_to_json(const mbedtls_ecp_point *Q, const char *crv,
-				   size_t keylen)
+/* Build an "epk" {kty:OKP,crv,x} JWK from a PSA-exported X-curve public key (the
+ * raw little-endian u-coordinate). */
+static jwt_json_t *epk_okp_to_json(const unsigned char *pub, size_t pub_len,
+				   const char *crv)
 {
-	jwt_json_t *epk = NULL;
+	jwt_json_t *epk;
 	char_auto *x_b64 = NULL;
-	unsigned char xb[56];
 
-	if (mbedtls_mpi_write_binary_le(&Q->MBEDTLS_PRIVATE(X), xb, keylen))
-		return NULL; // LCOV_EXCL_LINE
-
-	if (jwt_base64uri_encode(&x_b64, (char *)xb, (int)keylen) <= 0)
+	if (jwt_base64uri_encode(&x_b64, (char *)pub, (int)pub_len) <= 0)
 		return NULL; // LCOV_EXCL_LINE
 
 	epk = jwt_json_create();
@@ -838,10 +895,10 @@ static jwt_json_t *epk_okp_to_json(const mbedtls_ecp_point *Q, const char *crv,
 	return epk;
 }
 
-/* Read a peer X-curve public point from an "epk" {kty:OKP,crv,x} JWK. The
- * Montgomery U-coordinate "x" is little-endian on the wire. */
+/* Read a peer X-curve public key (raw little-endian u-coordinate) from an "epk"
+ * {kty:OKP,crv,x} JWK. */
 static int epk_okp_from_json(jwt_json_t *epk, const char *want_crv,
-			     mbedtls_ecp_point *Q, size_t keylen)
+			     size_t keylen, unsigned char *out, size_t *out_len)
 {
 	jwt_json_t *jkty, *jcrv, *jx;
 	const char *kty, *crv;
@@ -864,71 +921,93 @@ static int epk_okp_from_json(jwt_json_t *epk, const char *want_crv,
 	if (xb == NULL || (size_t)xlen != keylen)
 		goto out; // LCOV_EXCL_LINE
 
-	if (mbedtls_mpi_read_binary_le(&Q->MBEDTLS_PRIVATE(X), xb, keylen) == 0 &&
-	    mbedtls_mpi_lset(&Q->MBEDTLS_PRIVATE(Z), 1) == 0)
-		ret = 0;
+	memcpy(out, xb, keylen);
+	*out_len = keylen;
+	ret = 0;
 
-out: // LCOV_EXCL_LINE (gcov mis-counts the bare label)
+out:
 	jwt_freemem(xb);
 
 	return ret;
 }
 
-/* @rfc{7518,4.6} ECDH-ES key agreement using the native MbedTLS EC key. On
- * encrypt an ephemeral keypair is generated on the recipient's curve, its "epk"
- * public half is written to @hdr, and the agreed key derived. On decrypt the
- * "epk" is read from @hdr. The derived key (CEK for ECDH-ES, KEK for +A*KW) is
- * returned in @dk. */
+/* Generate an ephemeral ECDH keypair on the given curve. PSA here cannot
+ * psa_generate_key() a Montgomery pair, so for the X-curves we generate a random
+ * scalar and import it (any value of the right length is a valid X25519/X448
+ * secret; clamping is applied internally). NIST curves use psa_generate_key. */
+static int gen_ephemeral(psa_ecc_family_t fam, size_t bits, int is_okp,
+			 size_t fieldlen, mbedtls_svc_key_id_t *kid)
+{
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	psa_status_t st;
+
+	*kid = MBEDTLS_SVC_KEY_ID_INIT;
+
+	psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR(fam));
+	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_DERIVE);
+	psa_set_key_algorithm(&attr, PSA_ALG_ECDH);
+
+	if (is_okp) {
+		unsigned char scalar[PSA_BITS_TO_BYTES(521)];
+
+		if (psa_generate_random(scalar, fieldlen)) {
+			// LCOV_EXCL_START
+			psa_reset_key_attributes(&attr);
+			return 1;
+			// LCOV_EXCL_STOP
+		}
+		st = psa_import_key(&attr, scalar, fieldlen, kid);
+		mbedtls_platform_zeroize(scalar, sizeof(scalar));
+	} else {
+		psa_set_key_bits(&attr, bits);
+		st = psa_generate_key(&attr, kid);
+	}
+
+	psa_reset_key_attributes(&attr);
+
+	return st != PSA_SUCCESS;
+}
+
+/* @rfc{7518,4.6} ECDH-ES key agreement via PSA. On encrypt an ephemeral keypair
+ * is generated on the recipient's curve, its "epk" public half written to @hdr,
+ * and the agreed secret derived against the recipient's public key. On decrypt
+ * the "epk" is read from @hdr and agreement runs against the recipient private
+ * key. The Concat-KDF output (CEK for ECDH-ES, KEK for +A*KW) is returned in
+ * @dk. */
 int mbedtls_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc,
 			const jwk_item_t *key, int for_encrypt, jwt_json_t *hdr,
 			unsigned char **dk, size_t *dk_len)
 {
 	const mbedtls_jwk_t *jk = key->provider_data;
-	mbedtls_ecp_group grp;
-	mbedtls_ecp_point eph_Q, peer_Q;
-	mbedtls_mpi eph_d, z;
-	mbedtls_entropy_context entropy;
-	mbedtls_ctr_drbg_context drbg;
+	mbedtls_svc_key_id_t kid = MBEDTLS_SVC_KEY_ID_INIT;
+	const char *crv = key->curve, *algid = NULL;
+	unsigned char zbuf[PSA_BITS_TO_BYTES(521)];
+	unsigned char peer[1 + 2 * PSA_BITS_TO_BYTES(521)];
 	unsigned char *apu = NULL, *apv = NULL, *out = NULL;
-	unsigned char zbuf[66];
-	int apu_len = 0, apv_len = 0, drbg_ok = 0, ret = 1;
-	size_t z_len = 0, keydatalen = 0, fieldlen = 0;
-	const char *algid = NULL, *crv = NULL;
-	mbedtls_ecp_group_id gid;
-	int is_okp;
+	size_t fieldlen, keydatalen = 0, z_len = 0, peer_len = 0;
+	int apu_len = 0, apv_len = 0, is_okp, ret = 1;
 	jwt_json_t *japu, *japv, *jepk;
 
-	/* The recipient is an EC key (NIST) or an OKP X-curve key; both are held
-	 * as a native ecp keypair. An OKP Ed-curve wrapper has no ecp keypair
-	 * and is rejected (mbedtls has no Ed support anyway). */
+	/* The recipient is a NIST EC key or an OKP X-curve key (both held as
+	 * importable material). An OKP Ed-curve has no ECDH and is rejected. */
 	if (jk == NULL ||
 	    (jk->kty != JWK_KEY_TYPE_EC &&
 	     !(jk->kty == JWK_KEY_TYPE_OKP && !jk->okp_is_ed)))
-		return 1; // LCOV_EXCL_LINE  (gating rejects non-ECDH keys first)
+		return 1; // LCOV_EXCL_LINE
 
-	mbedtls_ecp_group_init(&grp);
-	mbedtls_ecp_point_init(&eph_Q);
-	mbedtls_ecp_point_init(&peer_Q);
-	mbedtls_mpi_init(&eph_d);
-	mbedtls_mpi_init(&z);
+	is_okp = (jk->kty == JWK_KEY_TYPE_OKP);
+	fieldlen = PSA_BITS_TO_BYTES(jk->bits);
 
-	gid = mbedtls_ecp_keypair_get_group_id(&jk->ec);
-	is_okp = gid_is_montgomery(gid);
+	/* Only the JOSE ECDH-ES curves are permitted: NIST P-256/384/521 and the
+	 * Montgomery X-curves. Other valid EC keys (e.g. secp256k1) are accepted
+	 * by setkey but must fail here. */
+	if (!is_okp && jk->ecc_family != PSA_ECC_FAMILY_SECP_R1)
+		goto out;
 
 	if (ecdh_keydatalen(alg, enc, &keydatalen, &algid))
 		goto out; // LCOV_EXCL_LINE
 
-	if (is_okp) {
-		size_t keylen;
-		if (okp_crv_info(gid, &keylen, &crv))
-			goto out; // LCOV_EXCL_LINE
-		fieldlen = keylen;
-	} else {
-		if (nist_crv_info(gid, &fieldlen, &crv))
-			goto out; // LCOV_EXCL_LINE
-	}
-
-	if (mbedtls_ecp_group_load(&grp, gid))
+	if (psa_crypto_init() != PSA_SUCCESS)
 		goto out; // LCOV_EXCL_LINE
 
 	out = jwt_malloc(keydatalen);
@@ -936,59 +1015,55 @@ int mbedtls_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc,
 		goto out; // LCOV_EXCL_LINE
 
 	if (for_encrypt) {
-		if (drbg_init(&entropy, &drbg))
-			goto out; // LCOV_EXCL_LINE
-		drbg_ok = 1;
+		unsigned char eph_pub[1 + 2 * PSA_BITS_TO_BYTES(521)];
+		size_t eph_pub_len = 0;
 
 		/* Ephemeral keypair on the recipient's curve. */
-		if (mbedtls_ecdh_gen_public(&grp, &eph_d, &eph_Q,
-					    mbedtls_ctr_drbg_random, &drbg))
+		if (gen_ephemeral(jk->ecc_family, jk->bits, is_okp, fieldlen, &kid))
 			goto out; // LCOV_EXCL_LINE
 
-		/* Z = ECDH(eph_priv, recipient_pub). */
-		if (mbedtls_ecdh_compute_shared(&grp, &z,
-				(mbedtls_ecp_point *)&jk->ec.MBEDTLS_PRIVATE(Q),
-				&eph_d, mbedtls_ctr_drbg_random, &drbg))
+		if (psa_export_public_key(kid, eph_pub, sizeof(eph_pub),
+					  &eph_pub_len))
 			goto out; // LCOV_EXCL_LINE
 
-		jepk = is_okp ? epk_okp_to_json(&eph_Q, crv, fieldlen)
-			      : epk_ec_to_json(&eph_Q, crv, fieldlen);
+		jepk = is_okp
+			? epk_okp_to_json(eph_pub, eph_pub_len, crv)
+			: epk_ec_to_json(eph_pub, eph_pub_len, crv, fieldlen);
 		if (jepk == NULL)
 			goto out; // LCOV_EXCL_LINE
 		jwt_json_obj_set(hdr, "epk", jepk);
+
+		/* peer = recipient public key material. */
+		if (jk->pub == NULL || jk->pub_len > sizeof(peer))
+			goto out; // LCOV_EXCL_LINE
+		memcpy(peer, jk->pub, jk->pub_len);
+		peer_len = jk->pub_len;
 	} else {
 		jepk = jwt_json_obj_get(hdr, "epk");
 		if (jepk == NULL)
 			goto out;
 		if (is_okp) {
-			if (epk_okp_from_json(jepk, crv, &peer_Q, fieldlen))
+			if (epk_okp_from_json(jepk, crv, fieldlen, peer,
+					      &peer_len))
 				goto out;
 		} else {
-			if (epk_ec_from_json(jepk, crv, &grp, &peer_Q, fieldlen))
+			if (epk_ec_from_json(jepk, crv, fieldlen, peer,
+					     sizeof(peer), &peer_len))
 				goto out;
 		}
 
-		if (drbg_init(&entropy, &drbg))
-			goto out; // LCOV_EXCL_LINE
-		drbg_ok = 1;
-
-		/* Z = ECDH(recipient_priv, eph_pub). */
-		if (mbedtls_ecdh_compute_shared(&grp, &z, &peer_Q,
-				&jk->ec.MBEDTLS_PRIVATE(d),
-				mbedtls_ctr_drbg_random, &drbg))
+		/* Import the recipient private key for agreement. */
+		if (mbedtls_jwk_to_psa(jk, 1, PSA_ALG_ECDH,
+				       PSA_KEY_USAGE_DERIVE, &kid))
 			goto out; // LCOV_EXCL_LINE
 	}
 
-	/* Z must be fixed field-length (left-padded). NIST Z is big-endian;
-	 * X-curve Z is the raw little-endian shared secret. */
-	z_len = fieldlen;
-	if (is_okp) {
-		if (mbedtls_mpi_write_binary_le(&z, zbuf, z_len))
-			goto out; // LCOV_EXCL_LINE
-	} else {
-		if (mbedtls_mpi_write_binary(&z, zbuf, z_len))
-			goto out; // LCOV_EXCL_LINE
-	}
+	/* Z = ECDH(our_priv, peer_pub). PSA returns the agreed secret of fixed
+	 * field length: the x-coordinate (NIST, big-endian) or the raw shared
+	 * value (Montgomery, little-endian) — exactly what the Concat-KDF wants. */
+	if (psa_raw_key_agreement(PSA_ALG_ECDH, kid, peer, peer_len,
+				  zbuf, sizeof(zbuf), &z_len))
+		goto out; // LCOV_EXCL_LINE
 
 	/* apu/apv (optional PartyU/PartyV info), fed to the KDF as-is. */
 	japu = jwt_json_obj_get(hdr, "apu");
@@ -1013,13 +1088,7 @@ out:
 	jwt_scrub_and_free(out, keydatalen);
 	jwt_freemem(apu);
 	jwt_freemem(apv);
-	if (drbg_ok)
-		drbg_free(&entropy, &drbg);
-	mbedtls_mpi_free(&eph_d);
-	mbedtls_mpi_free(&z);
-	mbedtls_ecp_point_free(&eph_Q);
-	mbedtls_ecp_point_free(&peer_Q);
-	mbedtls_ecp_group_free(&grp);
+	psa_destroy_key(kid);
 
 	return ret;
 }

--- a/libjwt/mbedtls/jwk-parse.c
+++ b/libjwt/mbedtls/jwk-parse.c
@@ -9,10 +9,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <mbedtls/rsa.h>
-#include <mbedtls/ecp.h>
+#include <mbedtls/asn1write.h>
 #include <mbedtls/pk.h>
-#include <mbedtls/bignum.h>
+#include <mbedtls/platform_util.h>
+#include <psa/crypto.h>
 
 #include <jwt.h>
 
@@ -51,58 +51,282 @@ static unsigned char *decode_member(jwt_json_t *jwk, const char *name, int *len)
 	return jwt_base64uri_decode(str, len);
 }
 
-/* Map a JWK "crv" to a MbedTLS EC group id (NIST + Montgomery X-curves). */
-static mbedtls_ecp_group_id ec_crv_to_group(const char *crv)
+/* Bit length of a big-endian unsigned integer held in @b[0..len). */
+static size_t be_bitlen(const unsigned char *b, size_t len)
 {
-	if (!strcmp(crv, "P-256"))
-		return MBEDTLS_ECP_DP_SECP256R1;
-	if (!strcmp(crv, "P-384"))
-		return MBEDTLS_ECP_DP_SECP384R1;
-	if (!strcmp(crv, "P-521"))
-		return MBEDTLS_ECP_DP_SECP521R1;
-	if (!strcmp(crv, "secp256k1"))
-		return MBEDTLS_ECP_DP_SECP256K1;
-	if (!strcmp(crv, "X25519"))
-		return MBEDTLS_ECP_DP_CURVE25519;
-	if (!strcmp(crv, "X448"))
-		return MBEDTLS_ECP_DP_CURVE448;
+	size_t i = 0, bits;
+	unsigned char top;
 
-	return MBEDTLS_ECP_DP_NONE;
+	while (i < len && b[i] == 0)
+		i++; // LCOV_EXCL_LINE
+	if (i == len)
+		return 0; // LCOV_EXCL_LINE
+
+	bits = (len - i - 1) * 8;
+	for (top = b[i]; top; top >>= 1)
+		bits++;
+
+	return bits;
 }
 
-/* Export a PEM string from a native RSA/EC key into item->pem (a convenience
- * exposed via jwks_item_pem and used by the jwk2key tool). Failure is
- * non-fatal: pem is optional, so we just leave it NULL. */
-static void set_pem_from_pk(jwk_item_t *item, mbedtls_pk_context *pk, int priv)
+/* Map a NIST/secp JWK "crv" to a PSA ECC family + key size. Returns 0 and fills
+ * @fam/@bits/@fieldlen on success, non-zero for an unknown curve. (Montgomery
+ * X-curves are handled in mbedtls_process_eddsa, not here.) */
+static int crv_to_psa(const char *crv, psa_ecc_family_t *fam, size_t *bits,
+		      size_t *fieldlen)
 {
+	if (!strcmp(crv, "P-256")) {
+		*fam = PSA_ECC_FAMILY_SECP_R1; *bits = 256;
+	} else if (!strcmp(crv, "P-384")) {
+		*fam = PSA_ECC_FAMILY_SECP_R1; *bits = 384;
+	} else if (!strcmp(crv, "P-521")) {
+		*fam = PSA_ECC_FAMILY_SECP_R1; *bits = 521;
+	} else if (!strcmp(crv, "secp256k1")) {
+		*fam = PSA_ECC_FAMILY_SECP_K1; *bits = 256;
+	} else {
+		return 1;
+	}
+
+	*fieldlen = (*bits + 7) / 8;
+
+	return 0;
+}
+
+/* Import a short-lived PSA key from the stored JWK material with the given
+ * policy. Public/private key form is selected by @want_private. See the header. */
+JWT_NO_EXPORT
+int mbedtls_jwk_to_psa(const mbedtls_jwk_t *key, int want_private,
+	psa_algorithm_t alg, psa_key_usage_t usage, mbedtls_svc_key_id_t *kid)
+{
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	psa_key_type_t type;
+	const unsigned char *data;
+	size_t data_len;
+	psa_status_t st;
+
+	*kid = MBEDTLS_SVC_KEY_ID_INIT;
+
+	if (psa_crypto_init() != PSA_SUCCESS)
+		return 1; // LCOV_EXCL_LINE
+
+	if (want_private) {
+		if (key->priv == NULL)
+			return 1; // LCOV_EXCL_LINE
+		data = key->priv;
+		data_len = key->priv_len;
+		type = (key->kty == JWK_KEY_TYPE_RSA)
+			? PSA_KEY_TYPE_RSA_KEY_PAIR
+			: PSA_KEY_TYPE_ECC_KEY_PAIR(key->ecc_family);
+	} else {
+		if (key->pub == NULL)
+			return 1; // LCOV_EXCL_LINE
+		data = key->pub;
+		data_len = key->pub_len;
+		type = (key->kty == JWK_KEY_TYPE_RSA)
+			? PSA_KEY_TYPE_RSA_PUBLIC_KEY
+			: PSA_KEY_TYPE_ECC_PUBLIC_KEY(key->ecc_family);
+	}
+
+	psa_set_key_type(&attr, type);
+	psa_set_key_usage_flags(&attr, usage);
+	psa_set_key_algorithm(&attr, alg);
+
+	st = psa_import_key(&attr, data, data_len, kid);
+	psa_reset_key_attributes(&attr);
+
+	return st != PSA_SUCCESS;
+}
+
+/* Write one ASN.1 INTEGER from a raw big-endian magnitude (the mbedtls asn1
+ * writers fill the buffer back-to-front from *p). Strips leading zero bytes and
+ * prepends a 0x00 sign byte when the high bit is set. Returns the encoded length
+ * or a negative error. */
+static int asn1_write_int_raw(unsigned char **p, unsigned char *start,
+			      const unsigned char *raw, size_t raw_len)
+{
+	const unsigned char *v = raw;
+	size_t n = raw_len;
+	int ret, len = 0;
+
+	while (n > 1 && v[0] == 0) {
+		v++; // LCOV_EXCL_LINE
+		n--; // LCOV_EXCL_LINE
+	}
+
+	if ((ret = mbedtls_asn1_write_raw_buffer(p, start, v, n)) < 0)
+		return ret; // LCOV_EXCL_LINE
+	len += ret;
+
+	if (v[0] & 0x80) {
+		if (*p <= start)
+			return -1; // LCOV_EXCL_LINE
+		*--(*p) = 0x00;
+		len += 1;
+	}
+
+	if ((ret = mbedtls_asn1_write_len(p, start, (size_t)len)) < 0)
+		return ret; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = mbedtls_asn1_write_tag(p, start, MBEDTLS_ASN1_INTEGER)) < 0)
+		return ret; // LCOV_EXCL_LINE
+	len += ret;
+
+	return len;
+}
+
+/* @rfc{8017} Build a DER PKCS#1 RSAPublicKey { n, e } from the raw components. */
+static unsigned char *build_rsa_pub_der(const unsigned char *n, size_t n_l,
+					const unsigned char *e, size_t e_l,
+					size_t *out_len)
+{
+	size_t cap = n_l + e_l + 32;
+	unsigned char *tmp, *p, *der;
+	int len = 0, ret;
+
+	tmp = jwt_malloc(cap);
+	if (tmp == NULL)
+		return NULL; // LCOV_EXCL_LINE
+	p = tmp + cap;
+
+	if ((ret = asn1_write_int_raw(&p, tmp, e, e_l)) < 0)
+		goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = asn1_write_int_raw(&p, tmp, n, n_l)) < 0)
+		goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = mbedtls_asn1_write_len(&p, tmp, (size_t)len)) < 0)
+		goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = mbedtls_asn1_write_tag(&p, tmp,
+			MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE)) < 0)
+		goto fail; // LCOV_EXCL_LINE
+	len += ret;
+
+	der = jwt_malloc((size_t)len);
+	if (der == NULL)
+		goto fail; // LCOV_EXCL_LINE
+	memcpy(der, p, (size_t)len);
+	*out_len = (size_t)len;
+	jwt_freemem(tmp);
+	return der;
+
+fail:
+	jwt_freemem(tmp); // LCOV_EXCL_LINE
+	return NULL; // LCOV_EXCL_LINE
+}
+
+/* @rfc{8017} Build a DER PKCS#1 RSAPrivateKey { 0, n, e, d, p, q, dp, dq, qi }
+ * from the raw components. The result is scrubbed/freed by the caller. */
+static unsigned char *build_rsa_priv_der(
+	const unsigned char *n, size_t n_l, const unsigned char *e, size_t e_l,
+	const unsigned char *d, size_t d_l, const unsigned char *p_, size_t p_l,
+	const unsigned char *q, size_t q_l, const unsigned char *dp, size_t dp_l,
+	const unsigned char *dq, size_t dq_l, const unsigned char *qi, size_t qi_l,
+	size_t *out_len)
+{
+	size_t cap = n_l + e_l + d_l + p_l + q_l + dp_l + dq_l + qi_l + 64;
+	unsigned char *tmp, *p, *der;
+	int len = 0, ret;
+
+	tmp = jwt_malloc(cap);
+	if (tmp == NULL)
+		return NULL; // LCOV_EXCL_LINE
+	p = tmp + cap;
+
+	/* Written back-to-front, so emit fields in reverse order. */
+	if ((ret = asn1_write_int_raw(&p, tmp, qi, qi_l)) < 0) goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = asn1_write_int_raw(&p, tmp, dq, dq_l)) < 0) goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = asn1_write_int_raw(&p, tmp, dp, dp_l)) < 0) goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = asn1_write_int_raw(&p, tmp, q, q_l)) < 0) goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = asn1_write_int_raw(&p, tmp, p_, p_l)) < 0) goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = asn1_write_int_raw(&p, tmp, d, d_l)) < 0) goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = asn1_write_int_raw(&p, tmp, e, e_l)) < 0) goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = asn1_write_int_raw(&p, tmp, n, n_l)) < 0) goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = mbedtls_asn1_write_int(&p, tmp, 0)) < 0) goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = mbedtls_asn1_write_len(&p, tmp, (size_t)len)) < 0) goto fail; // LCOV_EXCL_LINE
+	len += ret;
+	if ((ret = mbedtls_asn1_write_tag(&p, tmp,
+			MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE)) < 0)
+		goto fail; // LCOV_EXCL_LINE
+	len += ret;
+
+	der = jwt_malloc((size_t)len);
+	if (der == NULL)
+		goto fail; // LCOV_EXCL_LINE
+	memcpy(der, p, (size_t)len);
+	*out_len = (size_t)len;
+	mbedtls_platform_zeroize(tmp, cap);
+	jwt_freemem(tmp);
+	return der;
+
+fail:
+	// LCOV_EXCL_START
+	mbedtls_platform_zeroize(tmp, cap);
+	jwt_freemem(tmp);
+	return NULL;
+	// LCOV_EXCL_STOP
+}
+
+/* Best-effort PEM export into item->pem (a convenience surfaced by
+ * jwks_item_pem and the jwk2key tool). PEM is optional and backend-dependent;
+ * any failure simply leaves item->pem NULL. Only RSA and NIST EC keys are
+ * exported (pk has no representation for OKP/Montgomery). */
+static void set_pem_best_effort(jwk_item_t *item, const mbedtls_jwk_t *key)
+{
+	mbedtls_svc_key_id_t kid;
+	mbedtls_pk_context pk;
 	unsigned char buf[8192];
-	char *dest;
-	size_t len;
-	int ret;
+	psa_algorithm_t alg;
+	psa_key_usage_t usage = PSA_KEY_USAGE_EXPORT;
+	int priv = key->is_private, ret;
 
-	if (priv)
-		ret = mbedtls_pk_write_key_pem(pk, buf, sizeof(buf));
+	if (key->kty == JWK_KEY_TYPE_RSA)
+		alg = PSA_ALG_RSA_PSS(PSA_ALG_ANY_HASH);
+	else if (key->kty == JWK_KEY_TYPE_EC)
+		alg = PSA_ALG_ECDSA(PSA_ALG_ANY_HASH);
 	else
-		ret = mbedtls_pk_write_pubkey_pem(pk, buf, sizeof(buf));
+		return;	// LCOV_EXCL_LINE (OKP has no pk/PEM form; not called for OKP)
 
-	if (ret != 0)
+	usage |= priv ? PSA_KEY_USAGE_SIGN_MESSAGE : PSA_KEY_USAGE_VERIFY_MESSAGE;
+
+	if (mbedtls_jwk_to_psa(key, priv, alg, usage, &kid))
 		return; // LCOV_EXCL_LINE
 
-	len = strlen((char *)buf);
-	dest = jwt_malloc(len + 1);
-	if (dest == NULL)
-		return; // LCOV_EXCL_LINE
+	mbedtls_pk_init(&pk);
 
-	memcpy(dest, buf, len + 1);
-	item->pem = dest;
+	if (mbedtls_pk_copy_from_psa(kid, &pk) == 0) {
+		ret = priv ? mbedtls_pk_write_key_pem(&pk, buf, sizeof(buf))
+			   : mbedtls_pk_write_pubkey_pem(&pk, buf, sizeof(buf));
+		if (ret == 0) {
+			size_t len = strlen((char *)buf);
+			char *dest = jwt_malloc(len + 1);
+			if (dest != NULL) {
+				memcpy(dest, buf, len + 1);
+				item->pem = dest;
+			}
+		}
+	}
 
+	mbedtls_pk_free(&pk);
+	psa_destroy_key(kid);
 	mbedtls_platform_zeroize(buf, sizeof(buf));
 }
 
-/* @rfc{7518,6.3} Build a native RSA key from the JWK components. The same path
- * serves RSA and RSA-PSS; the PSS padding is applied at sign/verify, so we keep
- * a plain RSA context and never round-trip through an id-RSASSA-PSS PEM (which
- * mbedtls_pk_parse_key would reject). */
+/* @rfc{7518,6.3} Build the importable RSA material (DER PKCS#1) from the JWK
+ * components. The same path serves RSA and RSA-PSS — the padding scheme is a
+ * sign/verify-time choice, so we keep a single neutral RSA key. We deliberately
+ * defer all key validation to first use (psa_import_key at sign/verify/encrypt
+ * time): this matches the OpenSSL parser's loose fromdata for public keys, which
+ * the RSA error-path tests rely on. */
 JWT_NO_EXPORT
 int mbedtls_process_rsa(jwt_json_t *jwk, jwk_item_t *item)
 {
@@ -111,10 +335,7 @@ int mbedtls_process_rsa(jwt_json_t *jwk, jwk_item_t *item)
 	int n_l, e_l, d_l, p_l, q_l, dp_l, dq_l, qi_l;
 	jwt_json_t *jd, *jp, *jq, *jdp, *jdq, *jqi;
 	mbedtls_jwk_t *key = NULL;
-	mbedtls_pk_context pk;
-	int priv = 0, have_pem = 0, ret = -1;
-
-	mbedtls_pk_init(&pk);
+	int priv = 0, ret = -1;
 
 	/* Presence of the JSON members first (matches the OpenSSL parser's
 	 * "missing" vs "decode error" distinction the error-path tests rely on). */
@@ -149,7 +370,26 @@ int mbedtls_process_rsa(jwt_json_t *jwk, jwk_item_t *item)
 	key = jwk_new(JWK_KEY_TYPE_RSA);
 	if (key == NULL)
 		goto cleanup; // LCOV_EXCL_LINE
-	mbedtls_rsa_init(&key->rsa);
+
+	key->bits = be_bitlen(n, (size_t)n_l);
+	item->bits = key->bits;
+
+	/* PSA caps RSA at PSA_VENDOR_RSA_MAX_KEY_BITS (a property of the linked
+	 * crypto build, 4096 by default). The classic API had no such limit, so a
+	 * larger key would parse but fail at first use; reject it here with a clear
+	 * message instead. */
+	if (key->bits > PSA_VENDOR_RSA_MAX_KEY_BITS) {
+		jwt_write_error(item,
+			"RSA key size (%zu bits) exceeds the backend maximum "
+			"of %u bits", key->bits,
+			(unsigned int)PSA_VENDOR_RSA_MAX_KEY_BITS);
+		goto cleanup;
+	}
+
+	key->pub = build_rsa_pub_der(n, (size_t)n_l, e, (size_t)e_l,
+				     &key->pub_len);
+	if (key->pub == NULL)
+		goto cleanup; // LCOV_EXCL_LINE
 
 	if (priv) {
 		d = decode_member(jwk, "d", &d_l);
@@ -162,49 +402,29 @@ int mbedtls_process_rsa(jwt_json_t *jwk, jwk_item_t *item)
 			jwt_write_error(item, "Error decoding priv components");
 			goto cleanup;
 		}
-		if (mbedtls_rsa_import_raw(&key->rsa, n, n_l, p, p_l, q, q_l,
-					   d, d_l, e, e_l) ||
-		    mbedtls_rsa_complete(&key->rsa) ||
-		    mbedtls_rsa_check_privkey(&key->rsa)) {
-			// LCOV_EXCL_START
-			jwt_write_error(item, "Error importing RSA private key");
-			goto cleanup;
-			// LCOV_EXCL_STOP
-		}
-		item->is_private_key = key->is_private = 1;
-	} else {
-		/* Public key: import n,e only. We deliberately skip
-		 * mbedtls_rsa_complete()/check_pubkey() — they enforce minimum
-		 * sizes and reject structurally-odd keys that OpenSSL's loose
-		 * fromdata accepts; matching OpenSSL keeps cross-backend parsing
-		 * consistent (the RSA error-path tests rely on this). */
-		if (mbedtls_rsa_import_raw(&key->rsa, n, n_l, NULL, 0, NULL, 0,
-					   NULL, 0, e, e_l)) {
-			jwt_write_error(item, "Error importing RSA public key"); // LCOV_EXCL_LINE
+		key->priv = build_rsa_priv_der(n, n_l, e, e_l, d, d_l, p, p_l,
+					       q, q_l, dp, dp_l, dq, dq_l,
+					       qi, qi_l, &key->priv_len);
+		if (key->priv == NULL)
 			goto cleanup; // LCOV_EXCL_LINE
-		}
+		item->is_private_key = key->is_private = 1;
 	}
-
-	item->bits = mbedtls_rsa_get_bitlen(&key->rsa);
-
-	/* Wrap in a temporary pk_context only to export the convenience PEM. */
-	if (mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0 &&
-	    mbedtls_rsa_copy(mbedtls_pk_rsa(pk), &key->rsa) == 0)
-		have_pem = 1;
 
 	item->provider = JWT_CRYPTO_OPS_MBEDTLS;
 	item->provider_data = key;
+
+	set_pem_best_effort(item, key);
+
 	key = NULL;
 	ret = 0;
 
-	if (have_pem)
-		set_pem_from_pk(item, &pk, priv);
-
 cleanup: // LCOV_EXCL_LINE (gcov mis-counts the bare label)
-	mbedtls_pk_free(&pk);
 	if (key != NULL) {
-		mbedtls_rsa_free(&key->rsa);
+		// LCOV_EXCL_START
+		jwt_freemem(key->pub);
+		jwt_scrub_and_free(key->priv, key->priv_len);
 		jwt_freemem(key);
+		// LCOV_EXCL_STOP
 	}
 	jwt_freemem(n);
 	jwt_freemem(e);
@@ -218,21 +438,22 @@ cleanup: // LCOV_EXCL_LINE (gcov mis-counts the bare label)
 	return ret;
 }
 
-/* @rfc{7518,6.2} Build a native EC keypair from the JWK crv/x/y[/d]. */
+/* @rfc{7518,6.2} Build the importable EC material from the JWK crv/x/y[/d]. The
+ * public point (and private scalar, when present) is validated at parse via a
+ * throwaway PSA import, so structurally-bad points are rejected here exactly as
+ * the OpenSSL parser does. */
 JWT_NO_EXPORT
 int mbedtls_process_ec(jwt_json_t *jwk, jwk_item_t *item)
 {
-	unsigned char *x = NULL, *y = NULL, *d = NULL, *point = NULL;
+	unsigned char *x = NULL, *y = NULL, *d = NULL;
 	int x_l, y_l, d_l = 0;
 	jwt_json_t *jcrv, *jx, *jy, *jd;
 	const char *crv;
-	mbedtls_ecp_group_id gid;
+	psa_ecc_family_t fam;
+	size_t bits, fieldlen;
 	mbedtls_jwk_t *key = NULL;
-	mbedtls_pk_context pk;
-	size_t fieldlen, ptlen;
-	int priv = 0, have_pem = 0, ret = -1;
-
-	mbedtls_pk_init(&pk);
+	mbedtls_svc_key_id_t kid;
+	int priv = 0, ret = -1;
 
 	jcrv = jwt_json_obj_get(jwk, "crv");
 	jx = jwt_json_obj_get(jwk, "x");
@@ -253,8 +474,7 @@ int mbedtls_process_ec(jwt_json_t *jwk, jwk_item_t *item)
 
 	/* An unknown curve and bad x/y points are both pub-key construction
 	 * failures, sharing one message to mirror the OpenSSL parser. */
-	gid = ec_crv_to_group(crv);
-	if (gid == MBEDTLS_ECP_DP_NONE) {
+	if (crv_to_psa(crv, &fam, &bits, &fieldlen)) {
 		jwt_write_error(item,
 			"Error generating pub key from components");
 		goto cleanup;
@@ -263,18 +483,9 @@ int mbedtls_process_ec(jwt_json_t *jwk, jwk_item_t *item)
 	key = jwk_new(JWK_KEY_TYPE_EC);
 	if (key == NULL)
 		goto cleanup; // LCOV_EXCL_LINE
-	mbedtls_ecp_keypair_init(&key->ec);
-
-	if (mbedtls_ecp_group_load(&key->ec.MBEDTLS_PRIVATE(grp), gid)) {
-		jwt_write_error(item, "Error loading EC group"); // LCOV_EXCL_LINE
-		goto cleanup; // LCOV_EXCL_LINE
-	}
-
-	/* Field length from the loaded group. JWK coordinates are big-endian
-	 * and may have had leading zero bytes stripped (e.g. P-521 often
-	 * decodes to 65 bytes, not 66), so left-pad each into the fixed field
-	 * width that mbedtls_ecp_point_read_binary expects. */
-	fieldlen = (key->ec.MBEDTLS_PRIVATE(grp).nbits + 7) / 8;
+	key->ecc_family = fam;
+	key->bits = bits;
+	item->bits = bits;
 
 	x = decode_member(jwk, "x", &x_l);
 	y = decode_member(jwk, "y", &y_l);
@@ -286,85 +497,81 @@ int mbedtls_process_ec(jwt_json_t *jwk, jwk_item_t *item)
 	}
 
 	/* Uncompressed point: 0x04 || X || Y, each left-padded to fieldlen. */
-	ptlen = 1 + fieldlen * 2;
-	point = jwt_malloc(ptlen);
-	if (point == NULL)
+	key->pub_len = 1 + fieldlen * 2;
+	key->pub = jwt_malloc(key->pub_len);
+	if (key->pub == NULL)
 		goto cleanup; // LCOV_EXCL_LINE
-	memset(point, 0, ptlen);
-	point[0] = 0x04;
-	memcpy(point + 1 + (fieldlen - (size_t)x_l), x, (size_t)x_l);
-	memcpy(point + 1 + fieldlen + (fieldlen - (size_t)y_l), y, (size_t)y_l);
-
-	if (mbedtls_ecp_point_read_binary(&key->ec.MBEDTLS_PRIVATE(grp),
-					  &key->ec.MBEDTLS_PRIVATE(Q),
-					  point, ptlen) ||
-	    mbedtls_ecp_check_pubkey(&key->ec.MBEDTLS_PRIVATE(grp),
-				     &key->ec.MBEDTLS_PRIVATE(Q))) {
-		jwt_write_error(item,
-			"Error generating pub key from components");
-		goto cleanup;
-	}
+	memset(key->pub, 0, key->pub_len);
+	key->pub[0] = 0x04;
+	memcpy(key->pub + 1 + (fieldlen - (size_t)x_l), x, (size_t)x_l);
+	memcpy(key->pub + 1 + fieldlen + (fieldlen - (size_t)y_l), y, (size_t)y_l);
 
 	if (jd != NULL && jwt_json_is_string(jd)) {
 		d = decode_member(jwk, "d", &d_l);
-		if (d == NULL) {
-			jwt_write_error(item, "Error decoding EC d"); // LCOV_EXCL_LINE
-			goto cleanup; // LCOV_EXCL_LINE
-		}
-		if (mbedtls_mpi_read_binary(&key->ec.MBEDTLS_PRIVATE(d),
-					    d, (size_t)d_l) ||
-		    mbedtls_ecp_check_privkey(&key->ec.MBEDTLS_PRIVATE(grp),
-					      &key->ec.MBEDTLS_PRIVATE(d))) {
+		if (d == NULL || (size_t)d_l > fieldlen) {
 			// LCOV_EXCL_START
 			jwt_write_error(item, "Error importing EC private key");
 			goto cleanup;
 			// LCOV_EXCL_STOP
 		}
+		/* Scalar left-padded to the field length for PSA import. */
+		key->priv_len = fieldlen;
+		key->priv = jwt_malloc(key->priv_len);
+		if (key->priv == NULL)
+			goto cleanup; // LCOV_EXCL_LINE
+		memset(key->priv, 0, key->priv_len);
+		memcpy(key->priv + (fieldlen - (size_t)d_l), d, (size_t)d_l);
 		item->is_private_key = key->is_private = priv = 1;
 	}
 
-	item->bits = key->ec.MBEDTLS_PRIVATE(grp).nbits;
-
-	/* Wrap a copy of the native keypair in a pk_context for the PEM export.
-	 * mbedtls_pk_setup(ECKEY) gives an initialized-but-empty keypair, so we
-	 * load the group and copy Q (and d for private keys) into it. */
-	if (mbedtls_pk_setup(&pk, mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)) == 0) {
-		mbedtls_ecp_keypair *kp = mbedtls_pk_ec(pk);
-
-		if (mbedtls_ecp_group_load(&kp->MBEDTLS_PRIVATE(grp), gid) == 0 &&
-		    mbedtls_ecp_copy(&kp->MBEDTLS_PRIVATE(Q),
-				     &key->ec.MBEDTLS_PRIVATE(Q)) == 0 &&
-		    (!priv || mbedtls_mpi_copy(&kp->MBEDTLS_PRIVATE(d),
-					       &key->ec.MBEDTLS_PRIVATE(d)) == 0))
-			have_pem = 1;
+	/* Validate the public point (on-curve) via a throwaway PSA import. */
+	if (mbedtls_jwk_to_psa(key, 0, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH),
+			       PSA_KEY_USAGE_VERIFY_MESSAGE, &kid)) {
+		jwt_write_error(item,
+			"Error generating pub key from components");
+		goto cleanup;
 	}
+	psa_destroy_key(kid);
+
+	/* Validate the private scalar, when present, the same way. */
+	if (priv &&
+	    mbedtls_jwk_to_psa(key, 1, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH),
+			       PSA_KEY_USAGE_SIGN_MESSAGE, &kid)) {
+		// LCOV_EXCL_START
+		jwt_write_error(item, "Error importing EC private key");
+		goto cleanup;
+		// LCOV_EXCL_STOP
+	}
+	if (priv)
+		psa_destroy_key(kid);
 
 	item->provider = JWT_CRYPTO_OPS_MBEDTLS;
 	item->provider_data = key;
+
+	set_pem_best_effort(item, key);
+
 	key = NULL;
 	ret = 0;
 
-	if (have_pem)
-		set_pem_from_pk(item, &pk, priv);
-
 cleanup: // LCOV_EXCL_LINE (gcov mis-counts the bare label)
-	mbedtls_pk_free(&pk);
 	if (key != NULL) {
-		mbedtls_ecp_keypair_free(&key->ec);
+		jwt_freemem(key->pub);
+		jwt_scrub_and_free(key->priv, key->priv_len);
 		jwt_freemem(key);
 	}
 	jwt_freemem(x);
 	jwt_freemem(y);
-	jwt_freemem(point);
 	jwt_scrub_and_free(d, d ? (size_t)d_l : 0);
 
 	return ret;
 }
 
-/* @rfc{8037} OKP keys. MbedTLS supports the X-curves (X25519/X448) for ECDH but
- * has no EdDSA at all. We retain the native ECP keypair for X-curves and only
- * the raw material for Ed-curves; an Ed key parses cleanly so a keyring still
- * loads, but any sign/verify/JWE op on it fails with a clear error. */
+/* @rfc{8037} OKP keys. PSA (like MbedTLS classic) supports the X-curves
+ * (X25519/X448) for ECDH but has no EdDSA. We keep the raw material for both:
+ * X-curves as PSA-importable little-endian bytes, Ed-curves retained only so a
+ * keyring still loads (any sign/verify/JWE on an Ed key fails with a clear
+ * error). Montgomery keys need no on-curve check — any value of the right length
+ * is a valid u-coordinate — so length is the only validation. */
 JWT_NO_EXPORT
 int mbedtls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item)
 {
@@ -373,6 +580,7 @@ int mbedtls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item)
 	jwt_json_t *jcrv, *jx, *jd;
 	const char *crv;
 	mbedtls_jwk_t *key = NULL;
+	size_t keylen = 0;
 	int is_ed, ret = -1;
 
 	jcrv = jwt_json_obj_get(jwk, "crv");
@@ -413,37 +621,28 @@ int mbedtls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item)
 	if (key == NULL)
 		goto cleanup; // LCOV_EXCL_LINE
 	key->okp_is_ed = is_ed;
+	key->bits = item->bits;
 
 	if (jd != NULL)
 		item->is_private_key = key->is_private = 1;
 
 	if (is_ed) {
-		/* Ed-curves: store raw material only (mbedtls has no EdDSA). */
+		/* Ed-curves: store raw material only (no EdDSA support here). */
 		if (jx != NULL && jwt_json_is_string(jx)) {
-			key->okp_ed.pub = decode_member(jwk, "x", &x_l);
-			key->okp_ed.pub_len = key->okp_ed.pub ? (size_t)x_l : 0;
+			key->pub = decode_member(jwk, "x", &x_l);
+			key->pub_len = key->pub ? (size_t)x_l : 0;
 		}
 		if (jd != NULL && jwt_json_is_string(jd)) {
-			key->okp_ed.priv = decode_member(jwk, "d", &d_l);
-			key->okp_ed.priv_len = key->okp_ed.priv ? (size_t)d_l : 0;
+			key->priv = decode_member(jwk, "d", &d_l);
+			key->priv_len = key->priv ? (size_t)d_l : 0;
 		}
 	} else {
-		/* X-curves: a native ECP keypair usable for ECDH. The JWK "x"/
-		 * "d" are RFC 7748 little-endian; mbedtls Montgomery points read
-		 * little-endian via the *_le MPI helpers. */
-		mbedtls_ecp_group_id gid = ec_crv_to_group(crv);
-		/* Field width: X25519 = 32 bytes, X448 = 56 bytes. The decoded
-		 * "x"/"d" must be exactly this length. Without the check an
-		 * over/undersized attacker-supplied value would be accepted here
-		 * (mbedtls grows the MPI dynamically), where OpenSSL/GnuTLS and the
-		 * mbedtls "epk" reader reject it. */
-		size_t keylen = !strcmp(crv, "X25519") ? 32 : 56;
-
-		mbedtls_ecp_keypair_init(&key->ec);
-		if (mbedtls_ecp_group_load(&key->ec.MBEDTLS_PRIVATE(grp), gid)) {
-			jwt_write_error(item, "Error loading OKP group"); // LCOV_EXCL_LINE
-			goto cleanup; // LCOV_EXCL_LINE
-		}
+		/* X-curves: PSA-importable little-endian material. The decoded
+		 * "x"/"d" must be exactly the curve length (X25519 = 32, X448 =
+		 * 56); without the check an over/undersized attacker value would
+		 * be accepted where OpenSSL/GnuTLS reject it. */
+		key->ecc_family = PSA_ECC_FAMILY_MONTGOMERY;
+		keylen = !strcmp(crv, "X25519") ? 32 : 56;
 
 		if (jx != NULL && jwt_json_is_string(jx)) {
 			x = decode_member(jwk, "x", &x_l);
@@ -455,15 +654,9 @@ int mbedtls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item)
 				jwt_write_error(item, "Invalid OKP x length");
 				goto cleanup;
 			}
-			if (mbedtls_mpi_read_binary_le(
-				    &key->ec.MBEDTLS_PRIVATE(Q).MBEDTLS_PRIVATE(X),
-				    x, (size_t)x_l) ||
-			    mbedtls_mpi_lset(
-				    &key->ec.MBEDTLS_PRIVATE(Q).MBEDTLS_PRIVATE(Z),
-				    1)) {
-				jwt_write_error(item, "Error importing OKP x"); // LCOV_EXCL_LINE
-				goto cleanup; // LCOV_EXCL_LINE
-			}
+			key->pub = x;
+			key->pub_len = (size_t)x_l;
+			x = NULL;
 		}
 		if (jd != NULL && jwt_json_is_string(jd)) {
 			d = decode_member(jwk, "d", &d_l);
@@ -475,12 +668,9 @@ int mbedtls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item)
 				jwt_write_error(item, "Invalid OKP d length");
 				goto cleanup;
 			}
-			if (mbedtls_mpi_read_binary_le(
-				    &key->ec.MBEDTLS_PRIVATE(d), d,
-				    (size_t)d_l)) {
-				jwt_write_error(item, "Error importing OKP d"); // LCOV_EXCL_LINE
-				goto cleanup; // LCOV_EXCL_LINE
-			}
+			key->priv = d;
+			key->priv_len = (size_t)d_l;
+			d = NULL;
 		}
 	}
 
@@ -490,21 +680,11 @@ int mbedtls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item)
 	ret = 0;
 
 cleanup:
-	/* Only reached with key != NULL on a post-allocation error path, all of
-	 * which are defensive (decode/group-load failures). */
-	// LCOV_EXCL_START
 	if (key != NULL) {
-		/* okp_ed and ec overlap in a union; free only the one in use. */
-		if (is_ed) {
-			jwt_scrub_and_free(key->okp_ed.pub, key->okp_ed.pub_len);
-			jwt_scrub_and_free(key->okp_ed.priv,
-					   key->okp_ed.priv_len);
-		} else {
-			mbedtls_ecp_keypair_free(&key->ec);
-		}
+		jwt_freemem(key->pub);
+		jwt_scrub_and_free(key->priv, key->priv_len);
 		jwt_freemem(key);
 	}
-	// LCOV_EXCL_STOP
 	jwt_freemem(x);
 	jwt_scrub_and_free(d, d ? (size_t)d_l : 0);
 
@@ -521,30 +701,8 @@ void mbedtls_process_item_free(jwk_item_t *item)
 
 	key = item->provider_data;
 	if (key != NULL) {
-		switch (key->kty) {
-		case JWK_KEY_TYPE_RSA:
-			mbedtls_rsa_free(&key->rsa);
-			break;
-		case JWK_KEY_TYPE_EC:
-			mbedtls_ecp_keypair_free(&key->ec);
-			break;
-		case JWK_KEY_TYPE_OKP:
-			/* okp_ed and ec overlap in a union; free only the one in
-			 * use. Ed-curves kept raw buffers; X-curves an ecp pair. */
-			if (key->okp_is_ed) {
-				jwt_scrub_and_free(key->okp_ed.pub,
-						   key->okp_ed.pub_len);
-				jwt_scrub_and_free(key->okp_ed.priv,
-						   key->okp_ed.priv_len);
-			} else {
-				mbedtls_ecp_keypair_free(&key->ec);
-			}
-			break;
-		// LCOV_EXCL_START
-		default:
-			break;
-		// LCOV_EXCL_STOP
-		}
+		jwt_freemem(key->pub);
+		jwt_scrub_and_free(key->priv, key->priv_len);
 		jwt_freemem(key);
 	}
 

--- a/libjwt/mbedtls/jwt-mbedtls.h
+++ b/libjwt/mbedtls/jwt-mbedtls.h
@@ -9,37 +9,50 @@
 #ifndef JWT_MBEDTLS_H
 #define JWT_MBEDTLS_H
 
-#include <mbedtls/rsa.h>
-#include <mbedtls/ecp.h>
+#include <psa/crypto.h>
 
-/* A parsed JWK held as a native MbedTLS key object. This is what a MbedTLS
- * jwk_item_t.provider_data points to. MbedTLS 3.x has no single "any key"
- * container that covers every type we need (it lacks EdDSA entirely), so we
- * carry a small tagged union of the native objects.
+/* A parsed JWK held as PSA-importable key material. This is what a MbedTLS
+ * jwk_item_t.provider_data points to.
  *
- * - RSA / RSA-PSS: mbedtls_rsa_context (JWK alg "PS*" is still an RSA key here;
- *   the PSS padding is applied at sign/verify time, avoiding the id-RSASSA-PSS
- *   PEM that mbedtls_pk_parse_key rejects).
- * - EC (P-256/384/521) and OKP X-curves (X25519/X448): mbedtls_ecp_keypair.
- * - OKP Ed-curves (Ed25519/Ed448): MbedTLS has no EdDSA support, so we only
- *   retain the raw key material and curve name. The key parses cleanly (so a
- *   keyring containing one still loads), but any sign/verify/JWE operation on
- *   it fails with a clear "not supported" error. */
+ * MbedTLS 4.x (TF-PSA-Crypto) split the crypto core out, made the classic
+ * low-level API (mbedtls_rsa_*, mbedtls_ecp_*, ...) private, and removed the
+ * mbedtls_ecdh_* primitives entirely. The public, version-stable crypto API is
+ * now PSA Crypto (psa/crypto.h), which is also present in MbedTLS 3.6 LTS. So
+ * instead of holding a native key object, we keep the raw importable material
+ * and, for each operation, import a short-lived (volatile) PSA key with exactly
+ * the policy that operation needs, then destroy it. This keeps one code path
+ * for both 3.6 and 4.x and sidesteps PSA's single-policy-per-key model (an RSA
+ * JWK may be used for PS*, RS*, or RSA-OAEP).
+ *
+ * Material by key type (all heap-allocated; private material scrubbed on free):
+ *  - RSA:    pub  = DER PKCS#1 RSAPublicKey;  priv = DER PKCS#1 RSAPrivateKey.
+ *  - EC:     pub  = uncompressed point 0x04||X||Y (big-endian, field-padded);
+ *            priv = raw scalar, big-endian, left-padded to the field length.
+ *  - OKP X-curve (X25519/X448): pub = raw little-endian u-coordinate;
+ *            priv = raw little-endian scalar. Used for ECDH-ES only.
+ *  - OKP Ed-curve (Ed25519/Ed448): neither MbedTLS nor PSA here implement EdDSA;
+ *            we retain the raw pub/priv only so a keyring still loads, but any
+ *            sign/verify/JWE on such a key fails with a clear "not supported". */
 typedef struct {
 	jwk_key_type_t kty;	/* EC, RSA, or OKP				*/
-	int is_private;		/* 1 if private components are present		*/
-	int okp_is_ed;		/* For OKP: 1 = Ed-curve (raw), 0 = X-curve (ec) */
-	union {
-		mbedtls_rsa_context rsa;
-		mbedtls_ecp_keypair ec;	/* EC and OKP X-curves			*/
-		struct {		/* OKP Ed-curves (unsupported by mbedtls) */
-			unsigned char *pub;
-			size_t pub_len;
-			unsigned char *priv;
-			size_t priv_len;
-		} okp_ed;
-	};
+	int is_private;		/* 1 if private material is present		*/
+	int okp_is_ed;		/* For OKP: 1 = Ed-curve (raw), 0 = X-curve	*/
+	psa_ecc_family_t ecc_family;	/* EC/OKP-X: the PSA curve family	*/
+	size_t bits;		/* key size in bits (mirrors item->bits)	*/
+
+	unsigned char *pub;	/* public material (see above)			*/
+	size_t pub_len;
+	unsigned char *priv;	/* private material (NULL for a public key)	*/
+	size_t priv_len;
 } mbedtls_jwk_t;
+
+/* Import a short-lived (volatile) PSA key from the stored JWK material with the
+ * given algorithm/usage policy. @want_private selects the key-pair (private) vs
+ * the public key. On success *kid holds a key the caller must release with
+ * psa_destroy_key(). Returns 0 on success, non-zero on failure. */
+JWT_NO_EXPORT
+int mbedtls_jwk_to_psa(const mbedtls_jwk_t *key, int want_private,
+	psa_algorithm_t alg, psa_key_usage_t usage, mbedtls_svc_key_id_t *kid);
 
 JWT_NO_EXPORT
 int mbedtls_process_eddsa(jwt_json_t *jwk, jwk_item_t *item);

--- a/libjwt/mbedtls/sign-verify.c
+++ b/libjwt/mbedtls/sign-verify.c
@@ -6,15 +6,7 @@
    License, v. 2.0. If a copy of the MPL was not distributed with this
    file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include <mbedtls/md.h>
-#include <mbedtls/ssl.h>
-#include <mbedtls/rsa.h>
-#include <mbedtls/pk.h>
-#include <mbedtls/ecp.h>
-#include <mbedtls/ecdsa.h>
-#include <mbedtls/error.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
+#include <psa/crypto.h>
 #include <string.h>
 
 #include <jwt.h>
@@ -23,119 +15,113 @@
 
 #include "jwt-mbedtls.h"
 
+/* @rfc{7518,3.2} HMAC with SHA-2 via PSA. The oct key is imported as a volatile
+ * PSA HMAC key, used once, and destroyed. */
 static int mbedtls_sign_sha_hmac(jwt_t *jwt, char **out, unsigned int *len,
                                  const char *str, unsigned int str_len)
 {
-	mbedtls_md_context_t ctx;
-	const mbedtls_md_info_t *md_info;
-	void *key;
-	size_t key_len;
-	int ret = 1;
-
-	key = jwt->key->oct.key;
-	key_len = jwt->key->oct.len;
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	mbedtls_svc_key_id_t kid;
+	psa_algorithm_t alg;
+	size_t mac_size, mac_len = 0;
+	psa_status_t st;
 
 	*out = NULL;
 
-	/* Determine the HMAC algorithm based on jwt->alg */
 	switch (jwt->alg) {
 	case JWT_ALG_HS256:
-		md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-		break;
+		alg = PSA_ALG_HMAC(PSA_ALG_SHA_256); mac_size = 32; break;
 	case JWT_ALG_HS384:
-		md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
-		break;
+		alg = PSA_ALG_HMAC(PSA_ALG_SHA_384); mac_size = 48; break;
 	case JWT_ALG_HS512:
-		md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA512);
-		break;
+		alg = PSA_ALG_HMAC(PSA_ALG_SHA_512); mac_size = 64; break;
 	// LCOV_EXCL_START
 	default:
 		return 1;
 	// LCOV_EXCL_STOP
 	}
 
-	*out = jwt_malloc(mbedtls_md_get_size(md_info));
-	if (*out == NULL)
+	if (psa_crypto_init() != PSA_SUCCESS)
 		return 1; // LCOV_EXCL_LINE
 
-	mbedtls_md_init(&ctx);
+	psa_set_key_type(&attr, PSA_KEY_TYPE_HMAC);
+	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_SIGN_MESSAGE);
+	psa_set_key_algorithm(&attr, alg);
 
-	ret = mbedtls_md_setup(&ctx, md_info, 1);
-	if (ret) {
+	if (psa_import_key(&attr, jwt->key->oct.key, jwt->key->oct.len, &kid))
+		return 1; // LCOV_EXCL_LINE
+
+	*out = jwt_malloc(mac_size);
+	if (*out == NULL) {
 		// LCOV_EXCL_START
-		mbedtls_md_free(&ctx);
+		psa_destroy_key(kid);
+		return 1;
+		// LCOV_EXCL_STOP
+	}
+
+	st = psa_mac_compute(kid, alg, (const unsigned char *)str, str_len,
+			     (unsigned char *)*out, mac_size, &mac_len);
+	psa_destroy_key(kid);
+
+	if (st != PSA_SUCCESS) {
+		// LCOV_EXCL_START
 		jwt_freemem(*out);
 		return 1;
 		// LCOV_EXCL_STOP
 	}
 
-	/* Start HMAC calculation */
-	ret = mbedtls_md_hmac_starts(&ctx, key, key_len);
-	if (!ret)
-		ret = mbedtls_md_hmac_update(&ctx, (const unsigned char *)str,
-				       str_len);
-	if (!ret)
-		ret = mbedtls_md_hmac_finish(&ctx, (unsigned char *)*out);
-	if (ret) {
-		// LCOV_EXCL_START
-		mbedtls_md_free(&ctx);
-		jwt_freemem(*out);
-		return 1;
-		// LCOV_EXCL_STOP
-	}
-
-	/* Get the output size */
-	*len = mbedtls_md_get_size(md_info);
-
-	mbedtls_md_free(&ctx);
+	*len = (unsigned int)mac_len;
 
 	return 0;
 }
 
-#define SIGN_ERROR(_msg) { jwt_write_error(jwt, "JWT[MbedTLS]: " _msg); goto sign_clean_key; }
-
-/* Map a signing alg to its MbedTLS message digest. Returns NULL for algs that
- * do not use a PEM key here (HMAC) or are unsupported. */
-static const mbedtls_md_info_t *sign_md_info(jwt_alg_t alg)
+/* Map a JWS signing alg to its PSA signature algorithm (hash included). Returns
+ * 0 on success. EdDSA is handled by the caller (rejected); HMAC never reaches
+ * here. */
+static int sign_alg_to_psa(jwt_alg_t alg, psa_algorithm_t *psa_alg)
 {
 	switch (alg) {
-	case JWT_ALG_RS256:
-	case JWT_ALG_PS256:
 	case JWT_ALG_ES256:
 	case JWT_ALG_ES256K:
-		return mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-	case JWT_ALG_RS384:
-	case JWT_ALG_PS384:
+		*psa_alg = PSA_ALG_ECDSA(PSA_ALG_SHA_256); return 0;
 	case JWT_ALG_ES384:
-		return mbedtls_md_info_from_type(MBEDTLS_MD_SHA384);
-	case JWT_ALG_RS512:
-	case JWT_ALG_PS512:
+		*psa_alg = PSA_ALG_ECDSA(PSA_ALG_SHA_384); return 0;
 	case JWT_ALG_ES512:
-		return mbedtls_md_info_from_type(MBEDTLS_MD_SHA512);
+		*psa_alg = PSA_ALG_ECDSA(PSA_ALG_SHA_512); return 0;
+	case JWT_ALG_RS256:
+		*psa_alg = PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_SHA_256); return 0;
+	case JWT_ALG_RS384:
+		*psa_alg = PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_SHA_384); return 0;
+	case JWT_ALG_RS512:
+		*psa_alg = PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_SHA_512); return 0;
+	case JWT_ALG_PS256:
+		*psa_alg = PSA_ALG_RSA_PSS(PSA_ALG_SHA_256); return 0;
+	case JWT_ALG_PS384:
+		*psa_alg = PSA_ALG_RSA_PSS(PSA_ALG_SHA_384); return 0;
+	case JWT_ALG_PS512:
+		*psa_alg = PSA_ALG_RSA_PSS(PSA_ALG_SHA_512); return 0;
 	// LCOV_EXCL_START
 	default:
-		return NULL;
+		return 1;
 	// LCOV_EXCL_STOP
 	}
 }
 
-/* Sign using the native MbedTLS key object stored on the JWK (provider_data),
- * not a re-parsed PEM. This is required for RSA-PSS, whose OpenSSL-exported
- * id-RSASSA-PSS PEM mbedtls_pk_parse_key rejects, and keeps every alg native. */
+/* Sign using the native PSA key imported from the JWK material on the key
+ * object. For ECDSA, PSA emits the raw R||S signature, which is exactly the
+ * JOSE form; for RSA the PSS/PKCS#1v1.5 padding is selected by @alg. */
 static int mbedtls_sign_sha_pem(jwt_t *jwt, char **out, unsigned int *len,
 				const char *str, unsigned int str_len)
 {
-	size_t out_size;
-	const mbedtls_md_info_t *md_info;
 	const mbedtls_jwk_t *key;
-	unsigned char hash[MBEDTLS_MD_MAX_SIZE];
-	unsigned char sig[MBEDTLS_PK_SIGNATURE_MAX_SIZE];
-	mbedtls_entropy_context entropy;
-	mbedtls_ctr_drbg_context ctr_drbg;
+	mbedtls_svc_key_id_t kid;
+	psa_algorithm_t alg;
+	unsigned char sig[PSA_SIGNATURE_MAX_SIZE];
 	size_t sig_len = 0;
-	const char *pers = "libjwt_ecdsa_sign";
 
-	/* MbedTLS has no EdDSA; reject cleanly rather than mis-signing. */
+	*out = NULL;
+
+	/* PSA here has no EdDSA; reject cleanly rather than mis-signing. */
 	if (jwt->alg == JWT_ALG_EDDSA)
 		return jwt_write_error(jwt,
 			"JWT[MbedTLS]: MbedTLS does not support EdDSA");
@@ -147,150 +133,41 @@ static int mbedtls_sign_sha_pem(jwt_t *jwt, char **out, unsigned int *len,
 
 	key = jwt->key->provider_data;
 
-	md_info = sign_md_info(jwt->alg);
-	if (md_info == NULL)
+	if (sign_alg_to_psa(jwt->alg, &alg))
 		return jwt_write_error(jwt, "JWT[MbedTLS]: Unsupported algorithm"); // LCOV_EXCL_LINE
 
-	mbedtls_entropy_init(&entropy);
-	mbedtls_ctr_drbg_init(&ctr_drbg);
+	if (mbedtls_jwk_to_psa(key, 1, alg, PSA_KEY_USAGE_SIGN_MESSAGE, &kid))
+		return jwt_write_error(jwt, "JWT[MbedTLS]: Failed to load signing key"); // LCOV_EXCL_LINE
 
-	if (mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func,
-			&entropy, (const unsigned char *)pers, strlen(pers)))
-		SIGN_ERROR("Failed RNG setup"); // LCOV_EXCL_LINE
-
-	/* Compute the hash of the input string */
-	if (mbedtls_md(md_info, (unsigned char *)str, str_len, hash))
-		SIGN_ERROR("Error initializing md context"); // LCOV_EXCL_LINE
-
-	if (key->kty == JWK_KEY_TYPE_EC) {
-		/* EC: produce a raw R||S JOSE signature. */
-		mbedtls_ecp_keypair *kp = (mbedtls_ecp_keypair *)&key->ec;
-		mbedtls_mpi r, s;
-		int adj;
-
-		mbedtls_mpi_init(&r);
-		mbedtls_mpi_init(&s);
-
-		if (mbedtls_ecdsa_sign(&kp->MBEDTLS_PRIVATE(grp), &r, &s,
-				       &kp->MBEDTLS_PRIVATE(d), hash,
-				       mbedtls_md_get_size(md_info),
-				       mbedtls_ctr_drbg_random, &ctr_drbg)) {
-			// LCOV_EXCL_START
-			mbedtls_mpi_free(&r);
-			mbedtls_mpi_free(&s);
-			SIGN_ERROR("Error signing token");
-			// LCOV_EXCL_STOP
-		}
-
-		switch (jwt->alg) {
-		case JWT_ALG_ES256:
-		case JWT_ALG_ES256K:
-			adj = 32;
-			break;
-		case JWT_ALG_ES384:
-			adj = 48;
-			break;
-		case JWT_ALG_ES512:
-			adj = 66;
-			break;
+	if (psa_sign_message(kid, alg, (const unsigned char *)str, str_len,
+			     sig, sizeof(sig), &sig_len)) {
 		// LCOV_EXCL_START
-		default:
-			mbedtls_mpi_free(&r);
-			mbedtls_mpi_free(&s);
-			SIGN_ERROR("Unknown EC alg");
+		psa_destroy_key(kid);
+		return jwt_write_error(jwt, "JWT[MbedTLS]: Error signing token");
 		// LCOV_EXCL_STOP
-		}
-
-		out_size = adj * 2;
-		*out = jwt_malloc(out_size);
-		if (*out == NULL) {
-			// LCOV_EXCL_START
-			mbedtls_mpi_free(&r);
-			mbedtls_mpi_free(&s);
-			SIGN_ERROR("Out of memory");
-			// LCOV_EXCL_STOP
-		}
-		memset(*out, 0, out_size);
-
-		mbedtls_mpi_write_binary(&r, (unsigned char *)(*out), adj);
-		mbedtls_mpi_write_binary(&s, (unsigned char *)(*out) + adj, adj);
-
-		*len = out_size;
-
-		mbedtls_mpi_free(&r);
-		mbedtls_mpi_free(&s);
-	} else if (key->kty == JWK_KEY_TYPE_RSA) {
-		mbedtls_rsa_context *rsa = (mbedtls_rsa_context *)&key->rsa;
-
-		switch (jwt->alg) {
-		case JWT_ALG_PS256:
-		case JWT_ALG_PS384:
-		case JWT_ALG_PS512:
-			if (mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V21,
-					mbedtls_md_get_type(md_info)))
-				SIGN_ERROR("Failed setting RSASSA-PSS padding"); // LCOV_EXCL_LINE
-
-			if (mbedtls_rsa_rsassa_pss_sign(rsa,
-					mbedtls_ctr_drbg_random, &ctr_drbg,
-					mbedtls_md_get_type(md_info),
-					mbedtls_md_get_size(md_info), hash, sig))
-				SIGN_ERROR("Failed signing RSASSA-PSS"); // LCOV_EXCL_LINE
-			break;
-
-		case JWT_ALG_RS256:
-		case JWT_ALG_RS384:
-		case JWT_ALG_RS512:
-			/* Reset the shared context to PKCS1v1.5 padding: a prior
-			 * PSS or RSA-OAEP op on the same key object leaves it at
-			 * PKCS_V21, and the v1.5 signer rejects that state
-			 * (MBEDTLS_ERR_RSA_BAD_INPUT_DATA). */
-			if (mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V15,
-						    MBEDTLS_MD_NONE))
-				SIGN_ERROR("Failed setting PKCS1 padding"); // LCOV_EXCL_LINE
-			if (mbedtls_rsa_rsassa_pkcs1_v15_sign(rsa,
-					mbedtls_ctr_drbg_random, &ctr_drbg,
-					mbedtls_md_get_type(md_info),
-					mbedtls_md_get_size(md_info), hash, sig))
-				SIGN_ERROR("Error signing token"); // LCOV_EXCL_LINE
-			break;
-
-		// LCOV_EXCL_START
-		default:
-			SIGN_ERROR("Unexpected algorithm");
-		// LCOV_EXCL_STOP
-		}
-
-		sig_len = mbedtls_rsa_get_len(rsa);
-
-		*out = jwt_malloc(sig_len);
-		if (*out == NULL)
-			SIGN_ERROR("Out of memory"); // LCOV_EXCL_LINE
-		memcpy(*out, sig, sig_len);
-		*len = sig_len;
-	} else {
-		SIGN_ERROR("Key is not compatible"); // LCOV_EXCL_LINE
 	}
+	psa_destroy_key(kid);
 
-sign_clean_key:
-	mbedtls_ctr_drbg_free(&ctr_drbg);
-	mbedtls_entropy_free(&entropy);
+	*out = jwt_malloc(sig_len);
+	if (*out == NULL)
+		return jwt_write_error(jwt, "JWT[MbedTLS]: Out of memory"); // LCOV_EXCL_LINE
+	memcpy(*out, sig, sig_len);
+	*len = (unsigned int)sig_len;
 
-	return jwt->error;
+	return 0;
 }
 
-#define VERIFY_ERROR(_msg) { jwt_write_error(jwt, "JWT[MbedTLS]: " _msg); goto verify_clean_key; }
-
-/* Verify using the native MbedTLS key object on the JWK (provider_data). */
+/* Verify using the native PSA key imported from the JWK material. */
 static int mbedtls_verify_sha_pem(jwt_t *jwt, const char *head,
 				  unsigned int head_len,
 				  unsigned char *sig, int sig_len)
 {
-	unsigned char hash[MBEDTLS_MD_MAX_SIZE];
-	const mbedtls_md_info_t *md_info = NULL;
 	const mbedtls_jwk_t *key;
-	int ret = 1;
+	mbedtls_svc_key_id_t kid;
+	psa_algorithm_t alg;
+	int exp_len = 0;
 
-	/* MbedTLS has no EdDSA; reject cleanly. */
+	/* PSA here has no EdDSA; reject cleanly. */
 	if (jwt->alg == JWT_ALG_EDDSA)
 		return jwt_write_error(jwt,
 			"JWT[MbedTLS]: MbedTLS does not support EdDSA");
@@ -302,106 +179,47 @@ static int mbedtls_verify_sha_pem(jwt_t *jwt, const char *head,
 
 	key = jwt->key->provider_data;
 
-	md_info = sign_md_info(jwt->alg);
-	if (md_info == NULL)
-		VERIFY_ERROR("Unsupported algorithm"); // LCOV_EXCL_LINE
+	if (sign_alg_to_psa(jwt->alg, &alg))
+		return jwt_write_error(jwt, "JWT[MbedTLS]: Unsupported algorithm"); // LCOV_EXCL_LINE
 
-	/* Compute the hash of the input string */
-	if ((ret = mbedtls_md(md_info, (const unsigned char *)head, head_len,
-			      hash)))
-		VERIFY_ERROR("Failed to compute hash"); // LCOV_EXCL_LINE
-
+	/* Require the signature to be exactly the size dictated by the bound
+	 * algorithm: for EC the R||S length pinned to the curve (ES256/ES256K=64,
+	 * ES384=96, ES512=132); for RSA exactly the modulus length. This matches
+	 * the OpenSSL backend's stricter check. */
 	if (key->kty == JWK_KEY_TYPE_EC) {
-		mbedtls_ecp_keypair *kp = (mbedtls_ecp_keypair *)&key->ec;
-		mbedtls_mpi r, s;
-		int exp_len;
-
-		/* Require the signature to be exactly the size dictated by the
-		 * bound algorithm, not merely one of the three valid ECDSA sizes.
-		 * This pins R||S to the alg/curve (ES256/ES256K=64, ES384=96,
-		 * ES512=132), matching the OpenSSL backend's stricter check. */
 		switch (jwt->alg) {
 		case JWT_ALG_ES256:
-		case JWT_ALG_ES256K:
-			exp_len = 64;
-			break;
-		case JWT_ALG_ES384:
-			exp_len = 96;
-			break;
-		case JWT_ALG_ES512:
-			exp_len = 132;
-			break;
+		case JWT_ALG_ES256K: exp_len = 64; break;
+		case JWT_ALG_ES384: exp_len = 96; break;
+		case JWT_ALG_ES512: exp_len = 132; break;
 		// LCOV_EXCL_START
 		default:
-			VERIFY_ERROR("Unexpected EC algorithm");
+			return jwt_write_error(jwt,
+				"JWT[MbedTLS]: Unexpected EC algorithm");
 		// LCOV_EXCL_STOP
 		}
-
-		mbedtls_mpi_init(&r);
-		mbedtls_mpi_init(&s);
-
-		/* Split R/S from the JOSE signature. */
-		if (sig_len == exp_len) {
-			size_t r_size = sig_len / 2;
-			mbedtls_mpi_read_binary(&r, sig, r_size);
-			mbedtls_mpi_read_binary(&s, sig + r_size, r_size);
-		} else {
-			mbedtls_mpi_free(&r);
-			mbedtls_mpi_free(&s);
-			VERIFY_ERROR("Invalid ECDSA sig size");
-		}
-
-		if (mbedtls_ecdsa_verify(&kp->MBEDTLS_PRIVATE(grp), hash,
-				mbedtls_md_get_size(md_info),
-				&kp->MBEDTLS_PRIVATE(Q), &r, &s))
-			ret = 1;
-
-		mbedtls_mpi_free(&r);
-		mbedtls_mpi_free(&s);
-
-		if (ret)
-			VERIFY_ERROR("Failed to verify signature");
+		if (sig_len != exp_len)
+			return jwt_write_error(jwt,
+				"JWT[MbedTLS]: Invalid ECDSA sig size");
 	} else if (key->kty == JWK_KEY_TYPE_RSA) {
-		mbedtls_rsa_context *rsa = (mbedtls_rsa_context *)&key->rsa;
-
-		/* The MbedTLS RSA verify functions take no length argument and
-		 * unconditionally read mbedtls_rsa_get_len(rsa) bytes from sig.
-		 * Reject a signature that is not exactly the modulus length so a
-		 * short attacker-controlled segment cannot cause an out-of-bounds
-		 * read of the heap buffer (which is sized to the decoded length). */
-		if (sig_len < 0 || (size_t)sig_len != mbedtls_rsa_get_len(rsa))
-			VERIFY_ERROR("Invalid RSA signature size");
-
-		if (jwt->alg == JWT_ALG_PS256 || jwt->alg == JWT_ALG_PS384 ||
-		    jwt->alg == JWT_ALG_PS512) {
-			if (mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V21,
-					mbedtls_md_get_type(md_info)))
-				VERIFY_ERROR("Failed setting RSASSA-PSS padding"); // LCOV_EXCL_LINE
-			if (mbedtls_rsa_rsassa_pss_verify(rsa,
-					mbedtls_md_get_type(md_info),
-					mbedtls_md_get_size(md_info),
-					hash, sig))
-				VERIFY_ERROR("Failed to verify signature");
-		} else {
-			/* Reset to PKCS1v1.5 padding before verifying (see the
-			 * matching note in the sign path). */
-			if (mbedtls_rsa_set_padding(rsa, MBEDTLS_RSA_PKCS_V15,
-						    MBEDTLS_MD_NONE))
-				VERIFY_ERROR("Failed setting PKCS1 padding"); // LCOV_EXCL_LINE
-			if (mbedtls_rsa_rsassa_pkcs1_v15_verify(rsa,
-					mbedtls_md_get_type(md_info),
-					mbedtls_md_get_size(md_info),
-					hash, sig))
-				VERIFY_ERROR("Failed to verify signature");
-		}
+		if (sig_len < 0 || (size_t)sig_len != (key->bits + 7) / 8)
+			return jwt_write_error(jwt,
+				"JWT[MbedTLS]: Invalid RSA signature size");
 	} else {
-		VERIFY_ERROR("Unexpected key type"); // LCOV_EXCL_LINE
+		return jwt_write_error(jwt, "JWT[MbedTLS]: Unexpected key type"); // LCOV_EXCL_LINE
 	}
 
-	ret = 0;
+	if (mbedtls_jwk_to_psa(key, 0, alg, PSA_KEY_USAGE_VERIFY_MESSAGE, &kid))
+		return jwt_write_error(jwt, "JWT[MbedTLS]: Key is not compatible"); // LCOV_EXCL_LINE
 
-verify_clean_key:
-	return jwt->error;
+	if (psa_verify_message(kid, alg, (const unsigned char *)head, head_len,
+			       sig, (size_t)sig_len)) {
+		psa_destroy_key(kid);
+		return jwt_write_error(jwt, "JWT[MbedTLS]: Failed to verify signature");
+	}
+	psa_destroy_key(kid);
+
+	return 0;
 }
 
 /* Export our ops */

--- a/tests/jwt_flipflop.c
+++ b/tests/jwt_flipflop.c
@@ -117,7 +117,8 @@ static void __checker(const char *cops, const char *pub, jwt_alg_t alg,
 	free_key();
 }
 
-static void __flip_one(const char *priv, const char *pub, jwt_alg_t alg)
+static void __flip_one(const char *priv, const char *pub, jwt_alg_t alg,
+		       int mbedtls_skip)
 {
 	char *out = NULL;
 	size_t i;
@@ -126,9 +127,11 @@ static void __flip_one(const char *priv, const char *pub, jwt_alg_t alg)
 	for (i = 0; i < ARRAY_SIZE(jwt_test_ops); i++) {
 		size_t c;
 
-		/* MbedTLS has no EdDSA; it can neither produce nor verify an
-		 * EdDSA token, so skip it on both sides of the flip-flop. */
-		if (alg == JWT_ALG_EDDSA &&
+		/* MbedTLS has no EdDSA, and its PSA backend cannot handle RSA keys
+		 * above PSA_VENDOR_RSA_MAX_KEY_BITS (the 8192-bit key); in either
+		 * case it can neither produce nor verify, so skip it on both sides
+		 * of the flip-flop. */
+		if ((alg == JWT_ALG_EDDSA || mbedtls_skip) &&
 		    jwt_test_ops[i].type == JWT_CRYPTO_OPS_MBEDTLS)
 			continue;
 
@@ -140,7 +143,7 @@ static void __flip_one(const char *priv, const char *pub, jwt_alg_t alg)
 		for (c = 0; c < ARRAY_SIZE(jwt_test_ops); c++) {
 			/* Test everywhere */
 
-			if (alg == JWT_ALG_EDDSA &&
+			if ((alg == JWT_ALG_EDDSA || mbedtls_skip) &&
 			    jwt_test_ops[c].type == JWT_CRYPTO_OPS_MBEDTLS)
 				continue;
 
@@ -157,7 +160,17 @@ static void __flip_one(const char *priv, const char *pub, jwt_alg_t alg)
 START_TEST(__name)				\
 {						\
         __flip_one(#__name ".json",		\
-		   #__pub ".json", __alg);	\
+		   #__pub ".json", __alg, 0);	\
+}						\
+END_TEST
+
+/* As FLIPFLOP_KEY, but skip the MbedTLS backend (its PSA crypto cannot import
+ * RSA keys above PSA_VENDOR_RSA_MAX_KEY_BITS). */
+#define FLIPFLOP_KEY_NO_MBEDTLS(__name, __pub, __alg)	\
+START_TEST(__name)				\
+{						\
+        __flip_one(#__name ".json",		\
+		   #__pub ".json", __alg, 1);	\
 }						\
 END_TEST
 
@@ -165,7 +178,7 @@ END_TEST
 START_TEST(rsa_no_alg_ ## __alg)		\
 {						\
 	__flip_one(#__name ".json",		\
-		   #__pub ".json", __alg);	\
+		   #__pub ".json", __alg, 0);	\
 }						\
 END_TEST
 
@@ -192,7 +205,7 @@ FLIPFLOP_KEY(rsa_key_2048,
 FLIPFLOP_KEY(rsa_key_4096,
 	     rsa_key_4096,
 	     JWT_ALG_RS384);
-FLIPFLOP_KEY(rsa_key_8192,
+FLIPFLOP_KEY_NO_MBEDTLS(rsa_key_8192,
 	     rsa_key_8192_pub,
 	     JWT_ALG_RS512);
 

--- a/tests/jwt_jwks.c
+++ b/tests/jwt_jwks.c
@@ -53,6 +53,15 @@ START_TEST(test_jwks_keyring_load)
 		    gnutls_native_jwk(jwt_test_ops[_i].type))
 			continue;
 
+		/* MbedTLS (PSA) rejects RSA keys larger than the crypto build's
+		 * PSA_VENDOR_RSA_MAX_KEY_BITS (4096 by default) at parse, so the
+		 * two 8192-bit keys in this ring are flagged bad there. */
+		if (jwt_test_ops[_i].type == JWT_CRYPTO_OPS_MBEDTLS &&
+		    jwks_item_key_bits(item) > 4096) {
+			ck_assert_int_ne(jwks_item_error(item), 0);
+			continue;
+		}
+
 		if (jwks_item_error(item)) {
 			fprintf(stderr, "Err KID: %s\n",
 				jwks_item_kid(item));
@@ -117,6 +126,11 @@ START_TEST(test_jwks_keyring_load)
 	if (gnutls_native_jwk(jwt_test_ops[_i].type)) {
 		ck_assert_int_eq(i, 1);
 		ck_assert_int_eq(jwks_item_count(g_jwk_set), 25);
+	} else if (jwt_test_ops[_i].type == JWT_CRYPTO_OPS_MBEDTLS) {
+		/* The two 8192-bit RSA keys exceed the PSA RSA size limit and
+		 * were rejected at parse. */
+		ck_assert_int_eq(i, 2);
+		ck_assert_int_eq(jwks_item_count(g_jwk_set), 24);
 	} else {
 		ck_assert_int_eq(i, 0);
 		ck_assert_int_eq(jwks_item_count(g_jwk_set), 26);


### PR DESCRIPTION
Closes #267.

## What

Migrates the native MbedTLS backend (`libjwt/mbedtls/`) from the classic
low-level API to the public **PSA Crypto API** (`psa/crypto.h`), so it builds
and works against **MbedTLS 4.x** (TF-PSA-Crypto) while remaining compatible with
**3.6 LTS** — one code path, no version `#ifdef`s. CMake floor stays
`mbedcrypto >= 3.6.0`.

## Why

MbedTLS 4.x made the classic low-level crypto headers private under
`mbedtls/private/`, removed the low-level `mbedtls_ecdh_*` primitives, and
reshaped even some public APIs (`mbedtls_md` HMAC, `nist_kw`) toward PSA. Using
the private headers would just break again on the next release, so the backend
moves to the supported public API. PSA is stable in 3.6 too, which keeps a single
implementation for both lines.

## How

- **Key model:** a parsed JWK holds PSA-importable material (RSA PKCS#1 DER built
  via the public `asn1write.h`; EC/OKP-X family + raw point/scalar) instead of a
  native key object. Each op imports a short-lived **volatile** PSA key with
  exactly the policy it needs and destroys it — sidesteps PSA's
  single-policy-per-key model and preserves RSA parse-time leniency.
- **sign/verify:** `psa_sign_message`/`psa_verify_message` (RSA PSS/PKCS1v15,
  ECDSA); HMAC via PSA MAC. Strict signature-size checks kept.
- **JWE:** GCM via PSA AEAD, CBC via PSA cipher + truncated-MAC HMAC, RSA-OAEP via
  PSA, RNG via `psa_generate_random`, ECDH via `psa_raw_key_agreement`, and RFC
  3394 AES-KW hand-rolled on PSA AES-ECB. EdDSA stays unsupported.
- **Parse:** EC keys validated via a throwaway PSA import; `item->bits` computed
  at parse.

### PSA constraints handled
- `psa_generate_key` can't produce Montgomery pairs here → X25519/X448 ephemerals
  generate a random scalar and import it.
- secp256k1 rejected for ECDH-ES (PSA would otherwise allow a non-JOSE curve).
- **RSA size:** PSA caps RSA at `PSA_VENDOR_RSA_MAX_KEY_BITS` (4096 by default),
  which the classic API did not. Oversize keys are now **rejected at parse** with
  a clear message; the keyring and flip-flop tests skip the 8192-bit key on the
  MbedTLS backend, mirroring the existing EdDSA skip.

## Testing

Against MbedTLS 4.1, the full suite passes both mbedtls-only and in the
OpenSSL+GnuTLS+MbedTLS+libcurl combo, with no new uncovered lines in the three
backend files. 3.6 LTS and json-c parity are exercised by the
`build-linux-mbedtls` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)