### PR TITLE
Release v3.5.0

### DIFF
--- a/cmake/LibJWTVersions.cmake
+++ b/cmake/LibJWTVersions.cmake
@@ -4,9 +4,9 @@ set(LIBJWT_PROJECT		"LibJWT")
 set(LIBJWT_DESCRIPTION		"The C JSON Web Token Library +JWK +JWKS")
 set(LIBJWT_HOMEPAGE_URL		"https://libjwt.io")
 
-set(LIBJWT_VERSION_SET		3 4 0)
+set(LIBJWT_VERSION_SET		3 5 0)
 
-set(LIBJWT_SO_CRA		17 0 3)
+set(LIBJWT_SO_CRA		17 1 3)
 # SONAME History
 # v1.12.1      0 => 1
 # v1.15.0      1 => 2


### PR DESCRIPTION
Prepares the **v3.5.0** release.

## Version / ABI
- Bumps the project version `3.4.0` → `3.5.0`.
- Bumps the SONAME triple (libtool `c:r:a`) `17:0:3` → `17:1:3`. Per the [libtool rules](http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html), the source changed but **no interfaces (exported symbols) were added, removed, or changed** this cycle (`nm`: **118 → 118** public symbols), so only **revision** is incremented — `current` and `age` are untouched. The **SONAME stays `libjwt.so.14`** and existing binaries remain compatible (libtool "case 1": the new library is a drop-in for the old, and a program built against 3.5.0 still resolves cleanly against the 3.4.0 library).
- The experimental **ML-DSA** support added this cycle is exposed through new `jwt_alg_t` / `jwk_key_type_t` enumerators (`JWT_ALG_ML_DSA_44/65/87`, `JWK_KEY_TYPE_AKP`) and the `LIBJWT_HAVE_ML_DSA` feature macro — not new functions — so it contributes no linker symbols and does not move `current`/`age`.

## What's in 3.5.0 (since v3.4.0)

**Major feature — experimental ML-DSA (FIPS 204 / RFC 9964):** post-quantum signatures `ML-DSA-44/65/87` with JWK `kty="AKP"`, off by default behind `-DWITH_ML_DSA=ON`.
- OpenSSL backend (OpenSSL ≥ 3.5) and GnuTLS backend (GnuTLS ≥ 3.8.10 built with a PQC provider such as leancrypto).
- New public `LIBJWT_HAVE_ML_DSA` macro (emitted into `jwt_export.h`) so downstream code can detect support; the alg/kty enum values exist unconditionally for ABI stability.
- AKP keys follow the RFC 9964 seed contract (`priv` = the 32-byte FIPS-204 seed), with algorithm-confusion protection pinning the variant to the key at sign time.

**Crypto-backend portability:**
- **OpenSSL is now an optional backend** (closes #297) — a GnuTLS-only or MbedTLS-only build is supported.
- **MbedTLS native backend migrated to the PSA Crypto API** (closes #267), targeting the MbedTLS 3.6.x LTS.
- `key2jwk` build fixes on MbedTLS 3.x and GnuTLS < 3.8.4.

**GnuTLS hardening / version floors:**
- Require GnuTLS ≥ 3.8.4 (drop pre-3.8.4 compatibility) and ≥ 3.8.8 for issue-free EdDSA Ed448.
- Runtime-gate two GnuTLS < 3.8.13 OKP defects (seed-only OKP import segfault; X25519/X448 ECDH-ES) so the library errors instead of crashing.
- Drop the RSA-OAEP (SHA-1) OpenSSL fallback in the GnuTLS path; just fail.

**CI / build infrastructure:**
- New `debian:forky` base image with GnuTLS `--with-leancrypto` + the latest MbedTLS 3.6.x LTS; backend combinations now run in that image, with coverage + memcheck consolidated onto the `all` row.
- Vendor-compat matrix builds both JSON backends per distro; json-c excluded on Ubuntu 22.04 (json-c 0.15 < 0.16 floor).
- Move workflow actions off the deprecated Node.js 20 runtime.

**Docs / housekeeping:**
- Document that OpenSSL and the JSON library are optional/interchangeable (closes #299).
- Doxygen now reads sources as UTF-8 (fixes em-dash mojibake); copyright notices bumped to 2026; updated README logo and GitHub social-preview card.

## Testing
- All 25 tests pass locally (`make check`) with OpenSSL + Jansson; the produced library is `libjwt.14.3.1.dylib` (SONAME major 14, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
