### PR TITLE
jwks: RFC 7638 JWK Thumbprint and RFC 9278 Thumbprint URI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,7 +407,7 @@ if (CHECK_FOUND)
 
 	# JWKS Tests
 	list (APPEND UNIT_TESTS jwt_jwks jwt_jwks_errors
-		jwt_ec jwt_rsa jwt_hs jwt_jwks_pem)
+		jwt_ec jwt_rsa jwt_hs jwt_jwks_pem jwt_thumbprint)
 
 	# Checker and Builder
 	list (APPEND UNIT_TESTS jwt_builder jwt_checker jwt_flipflop)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Standard | RFC                                                                  
 ``JWK``  | :page_facing_up: [RFC-7517](https://datatracker.ietf.org/doc/html/rfc7517) | JSON Web Keys and Sets
 ``JWA``  | :page_facing_up: [RFC-7518](https://datatracker.ietf.org/doc/html/rfc7518) | JSON Web Algorithms
 ``JWT``  | :page_facing_up: [RFC-7519](https://datatracker.ietf.org/doc/html/rfc7519) | JSON Web Token
+``JWK Thumbprint`` | :page_facing_up: [RFC-7638](https://datatracker.ietf.org/doc/html/rfc7638) / [RFC-9278](https://datatracker.ietf.org/doc/html/rfc9278) | JWK Thumbprint and Thumbprint URI
 
 > [!NOTE]
 > Throughout this documentation you will see links such as the ones

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -2211,8 +2211,10 @@ jwk_set_t *jwks_create_fromurl(const char *url, int verify);
  */
 typedef enum {
 	JWK_KEY_NONE		= 0x0000,	/**< No options */
-	JWK_KEY_GEN_KID		= 0x0001,	/**< Generate a random (uuidv4)
-						     "kid" for each imported key */
+	JWK_KEY_GEN_KID		= 0x0001,	/**< Generate a deterministic
+						     "kid" (the @rfc{7638} JWK
+						     SHA-256 thumbprint) for each
+						     imported key */
 	JWK_KEY_TRY_HMAC	= 0x0002,	/**< If the input does not parse
 						     as a PEM/DER key, treat the
 						     raw bytes as an "oct" (HMAC)
@@ -2552,6 +2554,103 @@ char *jwks_item_export(const jwk_item_t *item, int priv);
  */
 JWT_EXPORT
 char *jwks_export(const jwk_set_t *jwk_set, int priv);
+
+/**
+ * @brief Hash algorithm for a JWK Thumbprint
+ *
+ * Selects the digest used by jwks_item_thumbprint() and
+ * jwks_item_thumbprint_uri(). SHA-256 is the value 0, so it is the default for
+ * a zero-initialized argument and is what virtually all deployments use.
+ *
+ * @since 3.6.0
+ */
+typedef enum {
+	JWK_THUMBPRINT_SHA256 = 0,	/**< SHA-256 (default) */
+	JWK_THUMBPRINT_SHA384,		/**< SHA-384 */
+	JWK_THUMBPRINT_SHA512,		/**< SHA-512 */
+} jwk_thumbprint_alg_t;
+
+/**
+ * @brief Compute the JWK Thumbprint of a key
+ *
+ * @rfc{7638,3}
+ *
+ * Produces the base64url-encoded SHA-2 digest of the key's canonical JWK form:
+ * a JSON object containing only the members required for the key type, with no
+ * whitespace and the member names in lexicographic order. The result is a
+ * stable, deterministic fingerprint of the (public) key parameters, commonly
+ * used as a key id (@c "kid") or as the @c "jkt" confirmation value.
+ *
+ * The thumbprint is computed over public parameters and is identical whether
+ * the item was loaded from a JWK or from a PEM/DER key.
+ *
+ * @param item A JWK Item
+ * @param alg The thumbprint hash algorithm (see @ref jwk_thumbprint_alg_t);
+ *   @ref JWK_THUMBPRINT_SHA256 is the default.
+ * @return A newly allocated, nil-terminated base64url string the caller must
+ *   free with free(), or NULL on error (an unusable key, a missing required
+ *   member, or an invalid @p alg).
+ * @since 3.6.0
+ */
+JWT_EXPORT
+char *jwks_item_thumbprint(const jwk_item_t *item, jwk_thumbprint_alg_t alg);
+
+/**
+ * @brief Compute the JWK Thumbprint URI of a key
+ *
+ * @rfc{9278}
+ *
+ * As jwks_item_thumbprint(), but returns the RFC 9278 URI form:
+ * @c "urn:ietf:params:oauth:jwk-thumbprint:sha-256:<thumbprint>" (or
+ * @c sha-384 / @c sha-512 to match @p alg).
+ *
+ * @param item A JWK Item
+ * @param alg The thumbprint hash algorithm (see @ref jwk_thumbprint_alg_t);
+ *   @ref JWK_THUMBPRINT_SHA256 is the default.
+ * @return A newly allocated, nil-terminated URI string the caller must free
+ *   with free(), or NULL on error.
+ * @since 3.6.0
+ */
+JWT_EXPORT
+char *jwks_item_thumbprint_uri(const jwk_item_t *item, jwk_thumbprint_alg_t alg);
+
+/**
+ * @brief Find a key in a set by its JWK Thumbprint
+ *
+ * @rfc{7638}
+ *
+ * Returns the first item in @p jwk_set whose thumbprint (for the given hash)
+ * equals @p thumbprint. Unlike jwks_find_bykid(), this matches on the key's
+ * canonical, deterministic identity rather than the advisory @c "kid", so it
+ * works even when keys carry no (or an inconsistent) @c "kid" — e.g. matching a
+ * proof-of-possession @c "cnf"/@c "jkt" value against a set of known keys.
+ *
+ * @param jwk_set An existing jwk_set_t
+ * @param alg The hash used to produce @p thumbprint (see @ref jwk_thumbprint_alg_t)
+ * @param thumbprint A base64url JWK thumbprint, as from jwks_item_thumbprint()
+ * @return The matching jwk_item_t, or NULL if none matches or on bad input
+ * @since 3.6.0
+ */
+JWT_EXPORT
+jwk_item_t *jwks_find_bythumbprint(jwk_set_t *jwk_set, jwk_thumbprint_alg_t alg,
+				   const char *thumbprint);
+
+/**
+ * @brief Find a key in a set by its JWK Thumbprint URI
+ *
+ * @rfc{9278}
+ *
+ * As jwks_find_bythumbprint(), but takes the RFC 9278 URI form
+ * (@c "urn:ietf:params:oauth:jwk-thumbprint:sha-256:<thumbprint>"); the hash
+ * is taken from the URI's @c sha-NNN label.
+ *
+ * @param jwk_set An existing jwk_set_t
+ * @param uri A JWK Thumbprint URI, as from jwks_item_thumbprint_uri()
+ * @return The matching jwk_item_t, or NULL if none matches or on bad input
+ * @since 3.6.0
+ */
+JWT_EXPORT
+jwk_item_t *jwks_find_bythumbprint_uri(jwk_set_t *jwk_set, const char *uri);
 
 /**
  * @brief Retrieve binary octet data of a key

--- a/libjwt/gnutls/sign-verify.c
+++ b/libjwt/gnutls/sign-verify.c
@@ -454,6 +454,34 @@ verify_clean_sig:
 	return jwt->error;
 }
 
+/* @rfc{7638} One-shot SHA-2 digest used by the JWK thumbprint. */
+static int gnutls_sha(int sha_bits, const unsigned char *in, size_t in_len,
+		      unsigned char *out, unsigned int *out_len)
+{
+	gnutls_digest_algorithm_t alg;
+
+	switch (sha_bits) {
+	case 256:
+		alg = GNUTLS_DIG_SHA256;
+		break;
+	case 384:
+		alg = GNUTLS_DIG_SHA384;
+		break;
+	case 512:
+		alg = GNUTLS_DIG_SHA512;
+		break;
+	default:
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	if (gnutls_hash_fast(alg, in, in_len, out))
+		return 1; // LCOV_EXCL_LINE
+
+	*out_len = gnutls_hash_get_len(alg);
+
+	return 0;
+}
+
 /* Export our ops */
 struct jwt_crypto_ops jwt_gnutls_ops = {
 	.name			= "gnutls",
@@ -474,6 +502,8 @@ struct jwt_crypto_ops jwt_gnutls_ops = {
 	.process_item_free	= gnutls_process_item_free,
 	/* Native-key -> JWK conversion, done natively by GnuTLS. */
 	.key2jwk_params		= gnutls_key2jwk_params,
+
+	.sha			= gnutls_sha,
 
 	.jwe_implemented	= 1,
 	.rng			= gnutls_rng,

--- a/libjwt/jwk-export.c
+++ b/libjwt/jwk-export.c
@@ -24,26 +24,20 @@
 #include <jwt.h>
 #include "jwt-private.h"
 
-/* Generate an RFC 4122 version 4 UUID string into the caller's buffer (which
- * must be at least 37 bytes), using the active backend's CSPRNG. Returns 0 on
- * success. */
-static int uuidv4(char out[37])
+/* Set a deterministic @rfc{7638} "kid" (the SHA-256 JWK thumbprint) on @jwk
+ * when JWK_KEY_GEN_KID is requested. @jwk must already carry the key's members
+ * (its kty plus the type's public parameters). A no-op if the thumbprint
+ * cannot be computed (e.g. a key missing a required public member). */
+static void gen_kid(jwt_json_t *jwk, jwk_key_type_t kty, unsigned int flags)
 {
-	uint8_t b[16];
+	char_auto *tp = NULL;
 
-	if (jwt_ops->rng == NULL || jwt_ops->rng(b, sizeof(b)))
-		return -1; // LCOV_EXCL_LINE
+	if (!(flags & JWK_KEY_GEN_KID))
+		return;
 
-	/* version 4 and RFC 4122 variant */
-	b[6] = (b[6] & 0x0F) | 0x40;
-	b[8] = (b[8] & 0x3F) | 0x80;
-
-	snprintf(out, 37,
-		"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-		b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
-		b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]);
-
-	return 0;
+	tp = jwt_jwk_thumbprint(jwk, kty, 256);
+	if (tp != NULL)
+		jwt_json_obj_set(jwk, "kid", jwt_json_create_str(tp));
 }
 
 /* For HMAC keys: treat the raw bytes as an "oct" key, guessing the alg from the
@@ -103,7 +97,6 @@ int jwt_key2jwk(const char *key, size_t len, unsigned int flags,
 	jwk_export_t kp;
 	jwt_json_t *jwk, *ops;
 	const char *kty;
-	char kid[37];
 	int r, i;
 
 	memset(&kp, 0, sizeof(kp));
@@ -135,13 +128,11 @@ int jwt_key2jwk(const char *key, size_t len, unsigned int flags,
 		jwt_json_obj_set(jwk, "key_ops", ops);
 	}
 
-	if ((flags & JWK_KEY_GEN_KID) && uuidv4(kid) == 0)
-		jwt_json_obj_set(jwk, "kid", jwt_json_create_str(kid));
-
 	/* HMAC fallback for unparseable input. */
 	if (r != 0) {
 		jwk_export_clear(&kp);
 		process_hmac_key(jwk, (const unsigned char *)key, len);
+		gen_kid(jwk, JWK_KEY_TYPE_OCT, flags);
 		jwt_json_arr_append(out_array, jwk);
 		return 0;
 	}
@@ -174,6 +165,8 @@ int jwt_key2jwk(const char *key, size_t len, unsigned int flags,
 			jwt_freemem(b64);
 		}
 	}
+
+	gen_kid(jwk, kp.kty, flags);
 
 	jwk_export_clear(&kp);
 	jwt_json_arr_append(out_array, jwk);

--- a/libjwt/jwks.c
+++ b/libjwt/jwks.c
@@ -798,3 +798,201 @@ char *jwks_export(const jwk_set_t *jwk_set, int priv)
 
 	return jwt_json_serialize(root, JWT_JSON_INDENT(2));
 }
+
+/* @rfc{7638,3} The required members for the JWK thumbprint, per key type. The
+ * thumbprint is the hash of a JSON object containing ONLY these members, with
+ * no whitespace and the member names in lexicographic order. The array is
+ * NULL-terminated; an unknown kty returns an empty list (a hard error). */
+static const char **jwk_thumbprint_members(jwk_key_type_t kty)
+{
+	static const char *ec[]  = { "crv", "kty", "x", "y", NULL };
+	static const char *rsa[] = { "e", "kty", "n", NULL };
+	static const char *okp[] = { "crv", "kty", "x", NULL };
+	static const char *oct[] = { "k", "kty", NULL };
+	static const char *none[] = { NULL };
+#ifdef LIBJWT_HAVE_ML_DSA
+	static const char *akp[] = { "alg", "kty", "pub", NULL };
+#endif
+
+	switch (kty) {
+	case JWK_KEY_TYPE_EC:
+		return ec;
+	case JWK_KEY_TYPE_RSA:
+		return rsa;
+	case JWK_KEY_TYPE_OKP:
+		return okp;
+	case JWK_KEY_TYPE_OCT:
+		return oct;
+#ifdef LIBJWT_HAVE_ML_DSA
+	case JWK_KEY_TYPE_AKP:
+		return akp;
+#endif
+	default:
+		return none; // LCOV_EXCL_LINE
+	}
+}
+
+char *jwt_jwk_thumbprint(const jwt_json_t *jwk, jwk_key_type_t kty, int bits)
+{
+	jwt_json_auto_t *canon = NULL;
+	char_auto *json = NULL;
+	const char **members;
+	unsigned char dig[64];
+	unsigned int dig_len = 0;
+	char *out = NULL;
+	size_t i;
+
+	if (jwk == NULL)
+		return NULL;
+
+	/* A valid key always has a supported kty, so the member list is never
+	 * empty here; guard defensively anyway. */
+	members = jwk_thumbprint_members(kty);
+	if (members[0] == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	/* Build a fresh object with ONLY the required members, cloned from the
+	 * key, then serialize it sorted + compact. This reuses the exact
+	 * canonicalization the library already trusts for signing (and is
+	 * identical across the Jansson and json-c backends), so we neither
+	 * hand-order keys nor hand-escape values. */
+	canon = jwt_json_create();
+	if (canon == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	for (i = 0; members[i] != NULL; i++) {
+		jwt_json_t *val = jwt_json_obj_get(jwk, members[i]);
+		jwt_json_t *cval;
+
+		if (val == NULL || !jwt_json_is_string(val))
+			return NULL;
+
+		cval = jwt_json_clone(val);
+		if (cval == NULL)
+			return NULL; // LCOV_EXCL_LINE
+
+		/* obj_set steals the reference to cval. */
+		jwt_json_obj_set(canon, members[i], cval);
+	}
+
+	json = jwt_json_serialize(canon, JWT_JSON_SORT_KEYS | JWT_JSON_COMPACT);
+	if (json == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	if (jwt_ops->sha == NULL ||
+	    jwt_ops->sha(bits, (const unsigned char *)json, strlen(json),
+			 dig, &dig_len))
+		return NULL; // LCOV_EXCL_LINE
+
+	if (jwt_base64uri_encode(&out, (const char *)dig, (int)dig_len) <= 0)
+		return NULL; // LCOV_EXCL_LINE
+
+	return out;
+}
+
+char *jwks_item_thumbprint(const jwk_item_t *item, jwk_thumbprint_alg_t alg)
+{
+	int bits;
+
+	if (item == NULL || item->error || item->json == NULL)
+		return NULL;
+
+	switch (alg) {
+	case JWK_THUMBPRINT_SHA256:
+		bits = 256;
+		break;
+	case JWK_THUMBPRINT_SHA384:
+		bits = 384;
+		break;
+	case JWK_THUMBPRINT_SHA512:
+		bits = 512;
+		break;
+	default:
+		return NULL;
+	}
+
+	return jwt_jwk_thumbprint(item->json, item->kty, bits);
+}
+
+char *jwks_item_thumbprint_uri(const jwk_item_t *item, jwk_thumbprint_alg_t alg)
+{
+	char_auto *tp = NULL;
+	const char *label;
+	char *out = NULL;
+	size_t len;
+
+	/* @rfc{9278} maps the hash to a "sha-NNN" name from the RFC 6920
+	 * Named Information Hash Algorithm registry. */
+	switch (alg) {
+	case JWK_THUMBPRINT_SHA256:
+		label = "sha-256";
+		break;
+	case JWK_THUMBPRINT_SHA384:
+		label = "sha-384";
+		break;
+	case JWK_THUMBPRINT_SHA512:
+		label = "sha-512";
+		break;
+	default:
+		return NULL;
+	}
+
+	tp = jwks_item_thumbprint(item, alg);
+	if (tp == NULL)
+		return NULL;
+
+	len = strlen("urn:ietf:params:oauth:jwk-thumbprint:") + strlen(label)
+	      + 1 + strlen(tp) + 1;
+	out = jwt_malloc(len);
+	if (out == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	snprintf(out, len, "urn:ietf:params:oauth:jwk-thumbprint:%s:%s",
+		 label, tp);
+
+	return out;
+}
+
+jwk_item_t *jwks_find_bythumbprint(jwk_set_t *jwk_set, jwk_thumbprint_alg_t alg,
+				   const char *thumbprint)
+{
+	jwk_item_t *item;
+
+	if (jwk_set == NULL || thumbprint == NULL)
+		return NULL;
+
+	list_for_each_entry(item, &jwk_set->head, node) {
+		char_auto *tp = jwks_item_thumbprint(item, alg);
+
+		if (tp != NULL && !strcmp(tp, thumbprint))
+			return item;
+	}
+
+	return NULL;
+}
+
+jwk_item_t *jwks_find_bythumbprint_uri(jwk_set_t *jwk_set, const char *uri)
+{
+	static const char prefix[] = "urn:ietf:params:oauth:jwk-thumbprint:";
+	jwk_thumbprint_alg_t alg;
+
+	if (jwk_set == NULL || uri == NULL)
+		return NULL;
+
+	/* @rfc{9278}: urn:ietf:params:oauth:jwk-thumbprint:sha-NNN:<thumbprint> */
+	if (strncmp(uri, prefix, strlen(prefix)))
+		return NULL;
+	uri += strlen(prefix);
+
+	if (!strncmp(uri, "sha-256:", 8))
+		alg = JWK_THUMBPRINT_SHA256;
+	else if (!strncmp(uri, "sha-384:", 8))
+		alg = JWK_THUMBPRINT_SHA384;
+	else if (!strncmp(uri, "sha-512:", 8))
+		alg = JWK_THUMBPRINT_SHA512;
+	else
+		return NULL;
+	uri += 8;
+
+	return jwks_find_bythumbprint(jwk_set, alg, uri);
+}

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -301,6 +301,14 @@ struct jwt_crypto_ops {
 	 * native keys at all. */
 	int (*key2jwk_params)(const char *key, size_t len, jwk_export_t *out);
 
+	/* One-shot SHA-2 digest. @sha_bits selects the hash (256/384/512).
+	 * Writes the raw digest into @out (the caller provides a buffer of at
+	 * least 64 bytes) and sets *@out_len. Returns 0 on success. Backed by
+	 * each backend's native digest. Used by the @rfc{7638} JWK thumbprint;
+	 * every backend provides it (it is not gated by jwe_implemented). */
+	int (*sha)(int sha_bits, const unsigned char *in, size_t in_len,
+		   unsigned char *out, unsigned int *out_len);
+
 	/* JWE (RFC 7516/7518). A backend may implement JWE crypto ops even if
 	 * it does not parse JWKs (JWK parsing always falls back to OpenSSL).
 	 * jwe_implemented is set once a backend provides the ops below; until
@@ -446,6 +454,13 @@ static inline void jwk_export_add(jwk_export_t *out, const char *name,
 JWT_NO_EXPORT
 int jwt_key2jwk(const char *key, size_t len, unsigned int flags,
 		jwt_json_t *out_array);
+
+/* Core @rfc{7638} JWK thumbprint: base64url(SHA-@bits) over the canonical JWK
+ * assembled from @jwk's required members for key type @kty. @bits is 256/384/512.
+ * Returns a malloc'd string (caller frees) or NULL. Shared by the public
+ * jwks_item_thumbprint() and the key2jwk "kid" generator. */
+JWT_NO_EXPORT
+char *jwt_jwk_thumbprint(const jwt_json_t *jwk, jwk_key_type_t kty, int bits);
 
 static inline void jwt_freememp(char **mem) {
 	jwt_freemem(*mem);

--- a/libjwt/mbedtls/sign-verify.c
+++ b/libjwt/mbedtls/sign-verify.c
@@ -222,6 +222,39 @@ static int mbedtls_verify_sha_pem(jwt_t *jwt, const char *head,
 	return 0;
 }
 
+/* @rfc{7638} One-shot SHA-2 digest used by the JWK thumbprint. */
+static int mbedtls_sha(int sha_bits, const unsigned char *in, size_t in_len,
+		       unsigned char *out, unsigned int *out_len)
+{
+	psa_algorithm_t alg;
+	size_t olen = 0;
+
+	switch (sha_bits) {
+	case 256:
+		alg = PSA_ALG_SHA_256;
+		break;
+	case 384:
+		alg = PSA_ALG_SHA_384;
+		break;
+	case 512:
+		alg = PSA_ALG_SHA_512;
+		break;
+	default:
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	if (psa_crypto_init() != PSA_SUCCESS)
+		return 1; // LCOV_EXCL_LINE
+
+	if (psa_hash_compute(alg, in, in_len, out, PSA_HASH_LENGTH(alg),
+			     &olen) != PSA_SUCCESS)
+		return 1; // LCOV_EXCL_LINE
+
+	*out_len = (unsigned int)olen;
+
+	return 0;
+}
+
 /* Export our ops */
 struct jwt_crypto_ops jwt_mbedtls_ops = {
 	.name			= "mbedtls",
@@ -238,6 +271,8 @@ struct jwt_crypto_ops jwt_mbedtls_ops = {
 	.process_item_free	= mbedtls_process_item_free,
 	/* Native-key -> JWK conversion, done natively by MbedTLS. */
 	.key2jwk_params		= mbedtls_key2jwk_params,
+
+	.sha			= mbedtls_sha,
 
 	.jwe_implemented	= 1,
 	.rng			= mbedtls_rng,

--- a/libjwt/openssl/jwk-export.c
+++ b/libjwt/openssl/jwk-export.c
@@ -196,13 +196,17 @@ static void export_ec(EVP_PKEY *pkey, int priv, jwk_export_t *out)
 		add_bn(pkey, OSSL_PKEY_PARAM_PRIV_KEY, out, "d");
 }
 
-/* For EdDSA keys (Ed25519, Ed448) */
+/* For OKP keys (Ed25519, Ed448, X25519, X448). Per RFC 8037 a private OKP JWK
+ * carries BOTH the public "x" and the private "d", so always export "x" (the
+ * GnuTLS backend already does) and add "d" only for a private key. Emitting "x"
+ * for private keys also lets every OKP key get a deterministic RFC 7638
+ * thumbprint / "kid", and keeps the re-imported JWK off the seed-only path that
+ * crashes GnuTLS < 3.8.13. */
 static void export_eddsa(EVP_PKEY *pkey, int priv, jwk_export_t *out)
 {
+	add_octet(pkey, OSSL_PKEY_PARAM_PUB_KEY, out, "x");
 	if (priv)
 		add_octet(pkey, OSSL_PKEY_PARAM_PRIV_KEY, out, "d");
-	else
-		add_octet(pkey, OSSL_PKEY_PARAM_PUB_KEY, out, "x");
 }
 
 /* For RSA keys (RS256, RS384, RS512). Also works for RSA-PSS (PS256, PS384,

--- a/libjwt/openssl/sign-verify.c
+++ b/libjwt/openssl/sign-verify.c
@@ -448,6 +448,32 @@ jwt_verify_sha_pem_done:
 	return jwt->error;
 }
 
+/* @rfc{7638} One-shot SHA-2 digest used by the JWK thumbprint. */
+static int openssl_sha(int sha_bits, const unsigned char *in, size_t in_len,
+		       unsigned char *out, unsigned int *out_len)
+{
+	const EVP_MD *md;
+
+	switch (sha_bits) {
+	case 256:
+		md = EVP_sha256();
+		break;
+	case 384:
+		md = EVP_sha384();
+		break;
+	case 512:
+		md = EVP_sha512();
+		break;
+	default:
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	if (EVP_Digest(in, in_len, out, out_len, md, NULL) != 1)
+		return 1; // LCOV_EXCL_LINE
+
+	return 0;
+}
+
 /* Export our ops */
 struct jwt_crypto_ops jwt_openssl_ops = {
 	.name			= "openssl",
@@ -466,6 +492,8 @@ struct jwt_crypto_ops jwt_openssl_ops = {
 	.process_ec		= openssl_process_ec,
 	.process_item_free	= openssl_process_item_free,
 	.key2jwk_params		= openssl_key2jwk_params,
+
+	.sha			= openssl_sha,
 
 	.jwe_implemented	= 1,
 	.rng			= openssl_rng,

--- a/tests/cli/all.json
+++ b/tests/cli/all.json
@@ -99,6 +99,7 @@
       "kty": "OKP",
       "crv": "Ed25519",
       "alg": "EdDSA",
+      "x": "HUj-14kN6N4i5qNVkfEhwKiCf-tSrvRHstQdtV8a5QM",
       "d": "XY5oUZqGWVZhX7J09hG-rRnAKXiw1g_aBh-Bc52KZ_Y"
     },
     {
@@ -115,6 +116,7 @@
       "kty": "OKP",
       "crv": "Ed448",
       "alg": "EdDSA",
+      "x": "J5dXafOvQWBrUabIHVqTbiDU4Jq7RtozL5jopRdiUGp-rs0Kz-f0-2r7scLjclKO9q8r3m9_YGAA",
       "d": "nsYcSyibFeqtBBmVUh3S_xGTNQJr0IGwVmU6gTd8Xn-gtb-PxxzPhJnUXZ_UdkPRsz2SY0d8On-t"
     },
     {

--- a/tests/jwt-cli.bats
+++ b/tests/jwt-cli.bats
@@ -111,9 +111,11 @@ EOF
 }
 
 @test "Convert JWK to PEM - OCT" {
-	rm -f oct_384.bin
+	rm -f oct_384*.bin
 	./tools/jwk2key -d . ${SRCDIR}/tests/keys/oct_key_384.json
-	cmp oct_384.bin ${SRCDIR}/tests/cli/oct_384.bin
+	# oct_key_384.json carries no "kid", so jwk2key names the file by the
+	# key's RFC 7638 thumbprint: oct_384_<thumbprint>.bin
+	cmp oct_384_*.bin ${SRCDIR}/tests/cli/oct_384.bin
 }
 
 # JWE tools
@@ -221,8 +223,9 @@ ECENC="../tests/keys/ec_key_prime256v1_enc.json"
 # A crash is not a reliable signal (the overflow lands in adjacent stack
 # memory and often doesn't fault), so instead assert the *observable*
 # outcome: with the fix, bits is safely truncated and a correctly named
-# oct_1050000.bin is written. Without the fix, the overflow corrupts the
-# output path and that file is never created.
+# oct_1050000_<thumbprint>.bin is written (the JWK has no "kid", so jwk2key
+# names it by thumbprint). Without the fix, the overflow corrupts the output
+# path and that file is never created.
 @test "jwk2key handles oversized oct key without buffer overflow (#264)" {
 	dir="${BATS_TMPDIR:-/tmp}/jwk2key264_$$"
 	mkdir -p "${dir}"
@@ -236,7 +239,7 @@ ECENC="../tests/keys/ec_key_prime256v1_enc.json"
 
 	status_was="${status}"
 	have_out=0
-	[ -f "${dir}/oct_1050000.bin" ] && have_out=1
+	ls "${dir}"/oct_1050000_*.bin >/dev/null 2>&1 && have_out=1
 	rm -rf "${dir}"
 
 	# Must not crash (128+signal) and must produce the correctly named file.

--- a/tests/jwt_jwks_pem.c
+++ b/tests/jwt_jwks_pem.c
@@ -297,8 +297,17 @@ START_TEST(test_gen_kid)
 	item = jwks_item_get(with, 0);
 	kid = jwks_item_kid(item);
 	ck_assert_ptr_nonnull(kid);
-	/* uuidv4 string form: 8-4-4-4-12 = 36 chars. */
-	ck_assert_int_eq((int)strlen(kid), 36);
+
+	/* The generated kid is the deterministic RFC 7638 SHA-256 thumbprint:
+	 * base64url of a 32-byte digest, i.e. 43 chars, and equal to what
+	 * jwks_item_thumbprint() computes for the same key. */
+	{
+		char_auto *tp = jwks_item_thumbprint(item, JWK_THUMBPRINT_SHA256);
+
+		ck_assert_int_eq((int)strlen(kid), 43);
+		ck_assert_ptr_nonnull(tp);
+		ck_assert_str_eq(kid, tp);
+	}
 }
 END_TEST
 

--- a/tests/jwt_thumbprint.c
+++ b/tests/jwt_thumbprint.c
@@ -1,0 +1,386 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* Tests for the RFC 7638 JWK Thumbprint and RFC 9278 Thumbprint URI:
+ * jwks_item_thumbprint() and jwks_item_thumbprint_uri(). The expected values
+ * are deterministic across every crypto and JSON backend, so each test runs
+ * under the full jwt_test_ops[] loop. */
+
+/* RFC 7638 Section 3.1 example JWK and its published thumbprint. The extra
+ * members ("alg", "kid") are NOT part of the thumbprint and must be ignored. */
+static const char rfc7638_jwk[] =
+	"{\"kty\":\"RSA\","
+	"\"n\":\"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86z"
+	"wu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9y"
+	"BXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7"
+	"d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2N"
+	"cRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw\","
+	"\"e\":\"AQAB\",\"alg\":\"RS256\",\"kid\":\"2011-04-29\"}";
+
+static const char rfc7638_thumb[] =
+	"NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs";
+
+static const char *URN_PREFIX = "urn:ietf:params:oauth:jwk-thumbprint:";
+
+static jwk_set_t *load_set(const char *file)
+{
+	char *path;
+	jwk_set_t *set;
+	int ret;
+
+	ret = asprintf(&path, KEYDIR "/%s", file);
+	ck_assert_int_gt(ret, 0);
+
+	set = jwks_create_fromfile(path);
+	free(path);
+	ck_assert_ptr_nonnull(set);
+
+	return set;
+}
+
+START_TEST(test_rfc7638_vector)
+{
+	jwk_set_t *set;
+	const jwk_item_t *item;
+	char_auto *tp = NULL;
+	char_auto *tp0 = NULL;
+	char_auto *uri = NULL;
+
+	SET_OPS();
+
+	set = jwks_create(rfc7638_jwk);
+	ck_assert_ptr_nonnull(set);
+	ck_assert(!jwks_error(set));
+
+	item = jwks_item_get(set, 0);
+	ck_assert_ptr_nonnull(item);
+
+	/* Explicit SHA-256 and the zero (default) selector must both equal the
+	 * RFC value (JWK_THUMBPRINT_SHA256 is 0). */
+	tp = jwks_item_thumbprint(item, JWK_THUMBPRINT_SHA256);
+	ck_assert_ptr_nonnull(tp);
+	ck_assert_str_eq(tp, rfc7638_thumb);
+
+	tp0 = jwks_item_thumbprint(item, 0);
+	ck_assert_ptr_nonnull(tp0);
+	ck_assert_str_eq(tp0, rfc7638_thumb);
+
+	uri = jwks_item_thumbprint_uri(item, JWK_THUMBPRINT_SHA256);
+	ck_assert_ptr_nonnull(uri);
+	ck_assert_str_eq(uri,
+		"urn:ietf:params:oauth:jwk-thumbprint:sha-256:"
+		"NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs");
+
+	jwks_free(set);
+}
+END_TEST
+
+/* Known SHA-256 thumbprints for the standard fixtures, one per key type. */
+static const struct {
+	const char *file;
+	const char *thumb;
+} known[] = {
+	{ "ec_key_prime256v1.json",  "dcqGJi_pttovbuO9Lefa_iDKSnhrviqfEWPhjKkzTgs" },
+	{ "rsa_key_2048.json",       "Fqs2Gji6uQfnAew4-CpkIQVlUVqLMRCmecl5ddMwVaA" },
+	{ "oct_key_256.json",        "CqF3NtBIm-AK4Ik0wgHcKk5vLKjxQMrLFuiF4BvHcho" },
+	{ "eddsa_key_ed25519.json",  "yP8YONwTmFovdfeOfp9y5u_lxzP7Y3JAmpUgeNnXFS8" },
+};
+
+START_TEST(test_known_values)
+{
+	size_t i;
+
+	SET_OPS();
+
+	for (i = 0; i < ARRAY_SIZE(known); i++) {
+		jwk_set_t *set = load_set(known[i].file);
+		const jwk_item_t *item = jwks_item_get(set, 0);
+		char_auto *tp = NULL;
+
+		ck_assert_ptr_nonnull(item);
+		ck_assert(!jwks_item_error(item));
+
+		tp = jwks_item_thumbprint(item, JWK_THUMBPRINT_SHA256);
+		ck_assert_ptr_nonnull(tp);
+		ck_assert_str_eq(tp, known[i].thumb);
+
+		jwks_free(set);
+	}
+}
+END_TEST
+
+/* The thumbprint covers only public members, so a private key and its public
+ * counterpart must produce the identical thumbprint. */
+static const struct {
+	const char *priv;
+	const char *pub;
+} pairs[] = {
+	{ "ec_key_prime256v1.json", "ec_key_prime256v1_pub.json" },
+	{ "eddsa_key_ed25519.json", "eddsa_key_ed25519_pub.json" },
+};
+
+START_TEST(test_public_equals_private)
+{
+	size_t i;
+
+	SET_OPS();
+
+	for (i = 0; i < ARRAY_SIZE(pairs); i++) {
+		jwk_set_t *sp = load_set(pairs[i].priv);
+		jwk_set_t *su = load_set(pairs[i].pub);
+		char_auto *tp = jwks_item_thumbprint(jwks_item_get(sp, 0),
+						     JWK_THUMBPRINT_SHA256);
+		char_auto *tu = jwks_item_thumbprint(jwks_item_get(su, 0),
+						     JWK_THUMBPRINT_SHA256);
+
+		ck_assert_ptr_nonnull(tp);
+		ck_assert_ptr_nonnull(tu);
+		ck_assert_str_eq(tp, tu);
+
+		jwks_free(sp);
+		jwks_free(su);
+	}
+}
+END_TEST
+
+START_TEST(test_seed_only_okp_null)
+{
+	jwk_set_t *set;
+	const jwk_item_t *item;
+
+	SET_OPS();
+
+	/* The Ed448 fixture is a seed-only private OKP key (it has "d" but no
+	 * "x"). The thumbprint requires the public "x" member, so it must fail
+	 * cleanly (return NULL, never crash). */
+	set = load_set("eddsa_key_ed448.json");
+	item = jwks_item_get(set, 0);
+	ck_assert_ptr_nonnull(item);
+
+	ck_assert_ptr_null(jwks_item_thumbprint(item, JWK_THUMBPRINT_SHA256));
+	ck_assert_ptr_null(jwks_item_thumbprint_uri(item, JWK_THUMBPRINT_SHA256));
+
+	jwks_free(set);
+}
+END_TEST
+
+START_TEST(test_hash_sizes)
+{
+	jwk_set_t *set;
+	const jwk_item_t *item;
+	char_auto *t256 = NULL;
+	char_auto *t384 = NULL;
+	char_auto *t512 = NULL;
+	char_auto *u384 = NULL;
+	char_auto *u512 = NULL;
+	size_t plen = strlen(URN_PREFIX);
+
+	SET_OPS();
+
+	set = load_set("ec_key_prime256v1.json");
+	item = jwks_item_get(set, 0);
+	ck_assert_ptr_nonnull(item);
+
+	t256 = jwks_item_thumbprint(item, JWK_THUMBPRINT_SHA256);
+	t384 = jwks_item_thumbprint(item, JWK_THUMBPRINT_SHA384);
+	t512 = jwks_item_thumbprint(item, JWK_THUMBPRINT_SHA512);
+	ck_assert_ptr_nonnull(t256);
+	ck_assert_ptr_nonnull(t384);
+	ck_assert_ptr_nonnull(t512);
+
+	/* base64url without padding: 32 -> 43, 48 -> 64, 64 -> 86 chars. */
+	ck_assert_uint_eq(strlen(t256), 43);
+	ck_assert_uint_eq(strlen(t384), 64);
+	ck_assert_uint_eq(strlen(t512), 86);
+
+	/* A different hash size yields a different value. */
+	ck_assert(strcmp(t256, t384) != 0);
+
+	u384 = jwks_item_thumbprint_uri(item, JWK_THUMBPRINT_SHA384);
+	u512 = jwks_item_thumbprint_uri(item, JWK_THUMBPRINT_SHA512);
+	ck_assert_ptr_nonnull(u384);
+	ck_assert_ptr_nonnull(u512);
+	ck_assert(!strncmp(u384, URN_PREFIX, plen));
+	ck_assert(!strncmp(u384 + plen, "sha-384:", 8));
+	ck_assert(!strncmp(u512 + plen, "sha-512:", 8));
+	/* The URI must carry the bare thumbprint after the "sha-NNN:" label. */
+	ck_assert_str_eq(u384 + plen + 8, t384);
+
+	jwks_free(set);
+}
+END_TEST
+
+START_TEST(test_errors)
+{
+	jwk_set_t *set;
+	const jwk_item_t *item;
+	char_auto *tp = NULL;
+
+	SET_OPS();
+
+	/* NULL item */
+	ck_assert_ptr_null(jwks_item_thumbprint(NULL, JWK_THUMBPRINT_SHA256));
+	ck_assert_ptr_null(jwks_item_thumbprint_uri(NULL, JWK_THUMBPRINT_SHA256));
+
+	set = load_set("ec_key_prime256v1.json");
+	item = jwks_item_get(set, 0);
+	ck_assert_ptr_nonnull(item);
+
+	/* Out-of-range hash selector. */
+	ck_assert_ptr_null(jwks_item_thumbprint(item, (jwk_thumbprint_alg_t)100));
+	ck_assert_ptr_null(jwks_item_thumbprint_uri(item,
+						    (jwk_thumbprint_alg_t)100));
+
+	/* A valid call still works after the rejected ones. */
+	tp = jwks_item_thumbprint(item, JWK_THUMBPRINT_SHA256);
+	ck_assert_ptr_nonnull(tp);
+
+	jwks_free(set);
+}
+END_TEST
+
+START_TEST(test_find_bythumbprint)
+{
+	jwk_set_t *set;
+	char *p_ec, *p_ed;
+	const jwk_item_t *found, *ec_item, *ed_item;
+	char_auto *tp_ec = NULL;
+	char_auto *uri_ed = NULL;
+	int r;
+
+	SET_OPS();
+
+	/* Build a two-key set: EC P-256 + Ed25519 (loaded into one set). */
+	r = asprintf(&p_ec, KEYDIR "/ec_key_prime256v1.json");
+	ck_assert_int_gt(r, 0);
+	r = asprintf(&p_ed, KEYDIR "/eddsa_key_ed25519.json");
+	ck_assert_int_gt(r, 0);
+
+	set = jwks_load_fromfile(NULL, p_ec);
+	ck_assert_ptr_nonnull(set);
+	ck_assert_ptr_nonnull(jwks_load_fromfile(set, p_ed));
+	free(p_ec);
+	free(p_ed);
+	ck_assert(!jwks_error(set));
+	ck_assert_uint_eq(jwks_item_count(set), 2);
+
+	ec_item = jwks_item_get(set, 0);
+	ed_item = jwks_item_get(set, 1);
+
+	/* Find the EC key by its bare SHA-256 thumbprint. */
+	tp_ec = jwks_item_thumbprint(ec_item, JWK_THUMBPRINT_SHA256);
+	ck_assert_ptr_nonnull(tp_ec);
+	found = jwks_find_bythumbprint(set, JWK_THUMBPRINT_SHA256, tp_ec);
+	ck_assert_ptr_eq(found, ec_item);
+
+	/* Find the Ed25519 key by its (SHA-384) thumbprint URI. */
+	uri_ed = jwks_item_thumbprint_uri(ed_item, JWK_THUMBPRINT_SHA384);
+	ck_assert_ptr_nonnull(uri_ed);
+	found = jwks_find_bythumbprint_uri(set, uri_ed);
+	ck_assert_ptr_eq(found, ed_item);
+
+	/* Right value, wrong hash -> no match. */
+	ck_assert_ptr_null(jwks_find_bythumbprint(set, JWK_THUMBPRINT_SHA512,
+						  tp_ec));
+
+	/* Negative and bad-input paths. */
+	ck_assert_ptr_null(jwks_find_bythumbprint(set, JWK_THUMBPRINT_SHA256,
+						  "nomatch"));
+	ck_assert_ptr_null(jwks_find_bythumbprint(NULL, JWK_THUMBPRINT_SHA256,
+						  tp_ec));
+	ck_assert_ptr_null(jwks_find_bythumbprint(set, JWK_THUMBPRINT_SHA256,
+						  NULL));
+	ck_assert_ptr_null(jwks_find_bythumbprint_uri(NULL, uri_ed));
+	ck_assert_ptr_null(jwks_find_bythumbprint_uri(set, NULL));
+	/* Wrong URN prefix, unknown hash label, and valid-but-unmatched. */
+	ck_assert_ptr_null(jwks_find_bythumbprint_uri(set, "not-a-uri"));
+	ck_assert_ptr_null(jwks_find_bythumbprint_uri(set,
+		"urn:ietf:params:oauth:jwk-thumbprint:sha-999:abc"));
+	ck_assert_ptr_null(jwks_find_bythumbprint_uri(set,
+		"urn:ietf:params:oauth:jwk-thumbprint:sha-256:nomatch"));
+
+	jwks_free(set);
+}
+END_TEST
+
+#ifdef LIBJWT_HAVE_ML_DSA
+/* Known SHA-256 thumbprints for the ML-DSA (AKP) fixtures. The digest is over
+ * the public members ("alg","kty","pub") and is backend independent. */
+static const struct {
+	const char *file;
+	const char *thumb;
+} akp_known[] = {
+	{ "mldsa_key_44.json",     "xxGwBakMZvovG1w3N7H6HRyppdaD7RkeKhsjtRZsyeA" },
+	{ "mldsa_key_44_pub.json", "xxGwBakMZvovG1w3N7H6HRyppdaD7RkeKhsjtRZsyeA" },
+	{ "mldsa_key_65.json",     "ZlqlfBlPyndAYX9Bav1t7QPDoguca-O5n5FW5Kv9HXs" },
+	{ "mldsa_key_87.json",     "9ljbLP6hu3Z-N3QsolhMGSUwctjOuM4graYlTXgB_xQ" },
+};
+
+START_TEST(test_akp_values)
+{
+	size_t i;
+
+	SET_OPS();
+
+	for (i = 0; i < ARRAY_SIZE(akp_known); i++) {
+		jwk_set_t *set = load_set(akp_known[i].file);
+		const jwk_item_t *item = jwks_item_get(set, 0);
+		char_auto *tp = NULL;
+
+		ck_assert_ptr_nonnull(item);
+
+		/* A backend that cannot import ML-DSA at runtime (e.g. a GnuTLS
+		 * without leancrypto) flags the item; skip it. Any backend that
+		 * does import the key yields the same backend-independent value. */
+		if (jwks_item_error(item)) {
+			jwks_free(set);
+			continue;
+		}
+
+		tp = jwks_item_thumbprint(item, JWK_THUMBPRINT_SHA256);
+		ck_assert_ptr_nonnull(tp);
+		ck_assert_str_eq(tp, akp_known[i].thumb);
+
+		jwks_free(set);
+	}
+}
+END_TEST
+#endif
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+
+	tc_core = tcase_create("jwt_thumbprint");
+
+	tcase_add_loop_test(tc_core, test_rfc7638_vector, 0, i);
+	tcase_add_loop_test(tc_core, test_known_values, 0, i);
+	tcase_add_loop_test(tc_core, test_public_equals_private, 0, i);
+	tcase_add_loop_test(tc_core, test_seed_only_okp_null, 0, i);
+	tcase_add_loop_test(tc_core, test_hash_sizes, 0, i);
+	tcase_add_loop_test(tc_core, test_errors, 0, i);
+	tcase_add_loop_test(tc_core, test_find_bythumbprint, 0, i);
+#ifdef LIBJWT_HAVE_ML_DSA
+	tcase_add_loop_test(tc_core, test_akp_values, 0, i);
+#endif
+
+	tcase_set_timeout(tc_core, 30);
+
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT JWK Thumbprint (RFC 7638 / RFC 9278)");
+}

--- a/tools/jwk2key.1
+++ b/tools/jwk2key.1
@@ -44,8 +44,10 @@ E.g.
 Public keys will have \f[B]_pub\f[R] added to the end of the filename
 (before the extension).
 .IP \[bu] 2
-Most importantly, the \f[B]kid\f[R] attribute, which is supposed to be
-unique.
+Most importantly, a stable per\-key identifier: the \f[B]kid\f[R] attribute
+if the key has one, otherwise its RFC 7638 JWK thumbprint.
+This keeps multiple keys of the same type that carry no \f[B]kid\f[R] from
+colliding on one file name.
 .SS Options
 .TP
 \f[B]\-h\f[R], \f[B]\-\-help\f[R]

--- a/tools/jwk2key.1.md
+++ b/tools/jwk2key.1.md
@@ -36,7 +36,9 @@ Output file naming is based on (hopefully) unique characteristics, including:
 - **Bits** in the key. E.g. 2048 for an _RSA_ key, or 384 for an _EC_ key.
 - **Private** vs **Public**. Public keys will have **\_pub** added to the end
   of the filename (before the extension).
-- Most importantly, the **kid** attribute, which is supposed to be unique.
+- Most importantly, a stable per-key identifier: the **kid** attribute if the
+  key has one, otherwise its RFC 7638 JWK thumbprint. This keeps multiple keys
+  of the same type that carry no **kid** from colliding on one file name.
 
 ## Options
 

--- a/tools/jwk2key.c
+++ b/tools/jwk2key.c
@@ -103,17 +103,34 @@ static void write_key_file(const jwk_item_t *item)
 		return;
 	}
 
-	if (jwks_item_kid(item) == NULL) {
-		snprintf(file_name, sizeof(file_name), "%s/%s_%s%s%s",
-			 out_dir, pre, name, priv ? "" : "_pub", ext);
-	} else if (!is_safe_filename_part(jwks_item_kid(item))) {
-		fprintf(stderr, "Skipping key with unsafe kid: %s\n",
-			jwks_item_kid(item));
-		return;
-	} else {
-		snprintf(file_name, sizeof(file_name), "%s/%s_%s_%s%s%s",
-			 out_dir, pre, name, jwks_item_kid(item),
-			 priv ? "" : "_pub", ext);
+	{
+		const char *kid = jwks_item_kid(item);
+		char *tp = NULL;
+		const char *id = kid;
+
+		/* Name files by a stable per-key id: the "kid" if present, else
+		 * the deterministic RFC 7638 thumbprint. This disambiguates
+		 * multiple keys of the same type that carry no "kid" (which would
+		 * otherwise collide on the same file name). */
+		if (id == NULL) {
+			tp = jwks_item_thumbprint(item, JWK_THUMBPRINT_SHA256);
+			id = tp;
+		}
+
+		if (id != NULL && !is_safe_filename_part(id)) {
+			fprintf(stderr, "Skipping key with unsafe id: %s\n", id);
+			free(tp);
+			return;
+		}
+
+		if (id == NULL)
+			snprintf(file_name, sizeof(file_name), "%s/%s_%s%s%s",
+				 out_dir, pre, name, priv ? "" : "_pub", ext);
+		else
+			snprintf(file_name, sizeof(file_name), "%s/%s_%s_%s%s%s",
+				 out_dir, pre, name, id, priv ? "" : "_pub", ext);
+
+		free(tp);
 	}
 
 	for (i = 0; i < 10; i++) {

--- a/tools/key2jwk.1
+++ b/tools/key2jwk.1
@@ -43,8 +43,9 @@ Private keys will have \f[B]sign\f[R] added to the \f[B]key_ops\f[R]
 array while public keys will have the \f[B]use\f[R] attribute set to
 \f[B]sig\f[R].
 .PP
-All keys will get a generated randomized uuidv4 \f[B]kid\f[R] attribute
-unless you use the \f[B]\-k\f[R] option.
+All keys will get a generated \f[B]kid\f[R] attribute (the RFC 7638 JWK
+SHA\-256 thumbprint, which is deterministic) unless you use the
+\f[B]\-k\f[R] option.
 .PP
 Example output:
 .IP
@@ -59,11 +60,12 @@ $ key2jwk \-q \-o \- eddsa_key_ed25519.pem
       \[dq]key_ops\[dq]: [
         \[dq]sign\[dq]
       ],
-      \[dq]kid\[dq]: \[dq]d74a55b0\-631a\-4dfb\-8842\-cecfcb50e728\[dq],
       \[dq]kty\[dq]: \[dq]OKP\[dq],
       \[dq]crv\[dq]: \[dq]Ed25519\[dq],
       \[dq]alg\[dq]: \[dq]EdDSA\[dq],
-      \[dq]d\[dq]: \[dq]XY5oUZqGWVZhX7J09hG\-rRnAKXiw1g_aBh\-Bc52KZ_Y\[dq]
+      \[dq]x\[dq]: \[dq]HUj\-14kN6N4i5qNVkfEhwKiCf\-tSrvRHstQdtV8a5QM\[dq],
+      \[dq]d\[dq]: \[dq]XY5oUZqGWVZhX7J09hG\-rRnAKXiw1g_aBh\-Bc52KZ_Y\[dq],
+      \[dq]kid\[dq]: \[dq]yP8YONwTmFovdfeOfp9y5u_lxzP7Y3JAmpUgeNnXFS8\[dq]
     }
   ]
 }

--- a/tools/key2jwk.1.md
+++ b/tools/key2jwk.1.md
@@ -38,8 +38,8 @@ will look no different than an RSA key. RSA keys must be at least 1024 bits.
 Private keys will have **sign** added to the **key_ops** array while public
 keys will have the **use** attribute set to **sig**.
 
-All keys will get a generated randomized uuidv4 **kid** attribute unless you
-use the **-k** option.
+All keys will get a generated **kid** attribute (the RFC 7638 JWK SHA-256
+thumbprint, which is deterministic) unless you use the **-k** option.
 
 Example output:
 
@@ -53,11 +53,12 @@ Example output:
           "key_ops": [
             "sign"
           ],
-          "kid": "d74a55b0-631a-4dfb-8842-cecfcb50e728",
           "kty": "OKP",
           "crv": "Ed25519",
           "alg": "EdDSA",
-          "d": "XY5oUZqGWVZhX7J09hG-rRnAKXiw1g_aBh-Bc52KZ_Y"
+          "x": "HUj-14kN6N4i5qNVkfEhwKiCf-tSrvRHstQdtV8a5QM",
+          "d": "XY5oUZqGWVZhX7J09hG-rRnAKXiw1g_aBh-Bc52KZ_Y",
+          "kid": "yP8YONwTmFovdfeOfp9y5u_lxzP7Y3JAmpUgeNnXFS8"
         }
       ]
     }

--- a/tools/key2jwk.c
+++ b/tools/key2jwk.c
@@ -54,8 +54,9 @@ and RS512. RSA keys must be at least 1024 bits.\n\
 RSA-PSS keys will be set to PS256, otherwise they will look no different\n\
 than an RSA key.\n\
 \n\
-All keys will get a generated randomized uuidv4 \"kid\" attribute unless you\n\
-use the -k option..\n", get_progname());
+All keys will get a generated \"kid\" attribute (the RFC 7638 JWK SHA-256\n\
+thumbprint, which is deterministic) unless you use the -k option.\n",
+		get_progname());
 
 	exit(exit_state);
 }


### PR DESCRIPTION
Implements #307 (RFC 7638 JWK Thumbprint) and applies it across the JWK APIs and CLI tools.

Three commits:

### 1. `jwks:` RFC 7638 JWK Thumbprint + RFC 9278 Thumbprint URI

New public API:
- `jwks_item_thumbprint(item, alg)` — `base64url(SHA-2(canonical JWK))`
- `jwks_item_thumbprint_uri(item, alg)` — RFC 9278 `urn:ietf:params:oauth:jwk-thumbprint:sha-256:<tp>`
- `jwks_find_bythumbprint(set, alg, tp)` / `jwks_find_bythumbprint_uri(set, uri)` — look a key up by its **canonical identity** rather than the advisory `kid` (e.g. matching a DPoP/PoP `cnf`/`jkt`)
- `jwk_thumbprint_alg_t` enum selects the hash (SHA-256 default, 384/512)

The canonical JWK is built from only the required members per key type and serialized `SORT_KEYS | COMPACT`, reusing the library's existing signing canonicalization — so the digest is identical across the Jansson and json-c backends. A new internal `sha` digest op backs it in all three crypto backends.

### 2. `tools:` deterministic thumbprint `kid` + jwk2key disambiguation

- **key2jwk**: `JWK_KEY_GEN_KID` now generates the RFC 7638 thumbprint instead of a random uuidv4 — deterministic, reproducible kids.
- **jwk2key**: names output files by a stable per-key id (the `kid`, else the thumbprint), so multiple keyless keys of the same type no longer collide on one filename.

### 3. `openssl:` export public `x` for private OKP keys (RFC 8037)

The OpenSSL backend emitted only `d` for private OKP keys, unlike GnuTLS (which emits both) and contrary to RFC 8037. Now always emits `x` (+`d` for private). This makes private OKP JWKs standards-compliant and identical across backends, lets every OKP key get a thumbprint/kid, and keeps a re-imported JWK off the seed-only path that crashes GnuTLS < 3.8.13. Golden `tests/cli/all.json` updated.

### Tests

`tests/jwt_thumbprint.c` runs the full crypto-ops loop under both JSON backends: the **RFC 7638 §3.1 vector** (exact match), per-key-type known values (EC/RSA/oct/Ed25519/ML-DSA-AKP), public==private invariant, seed-only Ed448 → clean NULL, hash sizes, URI forms, find-by-thumbprint (bare + URI), and error paths. Plus updated `test_gen_kid` and the CLI BATS suite. All 26 suites pass under jansson and json-c; only genuinely-defensive lines are `LCOV_EXCL`.

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)