### PR TITLE
jwt: RFC 7800 cnf (confirmation) claim helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,7 +422,7 @@ if (CHECK_FOUND)
 		jwe_json_neg)
 
 	# Claims
-	list (APPEND UNIT_TESTS jwt_claims)
+	list (APPEND UNIT_TESTS jwt_claims jwt_cnf)
 
 	# Security
 	list (APPEND UNIT_TESTS jwt_security)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Standard | RFC                                                                  
 ``JWA``  | :page_facing_up: [RFC-7518](https://datatracker.ietf.org/doc/html/rfc7518) | JSON Web Algorithms
 ``JWT``  | :page_facing_up: [RFC-7519](https://datatracker.ietf.org/doc/html/rfc7519) | JSON Web Token
 ``JWK Thumbprint`` | :page_facing_up: [RFC-7638](https://datatracker.ietf.org/doc/html/rfc7638) / [RFC-9278](https://datatracker.ietf.org/doc/html/rfc9278) | JWK Thumbprint and Thumbprint URI
+``cnf``  | :page_facing_up: [RFC-7800](https://datatracker.ietf.org/doc/html/rfc7800) | Proof-of-Possession (confirmation) claim helpers
 
 > [!NOTE]
 > Throughout this documentation you will see links such as the ones

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -1415,6 +1415,78 @@ JWT_EXPORT
 jwt_value_error_t jwt_claim_del(jwt_t *jwt, const char *claim);
 
 /**
+ * @brief Set the "cnf" (confirmation) claim to a key thumbprint
+ *
+ * @rfc{7800} @rfc{9449,6}
+ *
+ * Sets @c "cnf" to a single @c "jkt" member holding the RFC 7638 SHA-256 JWK
+ * thumbprint of @p key (the DPoP confirmation method). Any existing @c "cnf"
+ * is replaced, so the object always carries exactly one confirmation member.
+ *
+ * @param builder Pointer to a builder object
+ * @param key The proof-of-possession public key to bind the token to
+ * @return 0 on success, non-zero on error
+ * @since 3.6.0
+ */
+JWT_EXPORT
+int jwt_builder_setcnf_jkt(jwt_builder_t *builder, const jwk_item_t *key);
+
+/**
+ * @brief Set the "cnf" (confirmation) claim to an embedded JWK
+ *
+ * @rfc{7800,3.2}
+ *
+ * Sets @c "cnf" to a single @c "jwk" member holding the public JWK of @p key.
+ * Only public parameters are embedded. Any existing @c "cnf" is replaced.
+ *
+ * @param builder Pointer to a builder object
+ * @param key The proof-of-possession public key to embed
+ * @return 0 on success, non-zero on error
+ * @since 3.6.0
+ */
+JWT_EXPORT
+int jwt_builder_setcnf_jwk(jwt_builder_t *builder, const jwk_item_t *key);
+
+/**
+ * @brief Set the "cnf" (confirmation) claim to a single string member
+ *
+ * @rfc{7800}
+ *
+ * Sets @c "cnf" to a single member named @p member with string value @p value
+ * -- e.g. @c "kid" (RFC 7800), @c "x5t#S256" (RFC 8705 mTLS), or @c "jku". Any
+ * existing @c "cnf" is replaced, so the object always carries exactly one
+ * confirmation member.
+ *
+ * @param builder Pointer to a builder object
+ * @param member The confirmation member name (e.g. @c "kid", @c "x5t#S256")
+ * @param value The member's string value
+ * @return 0 on success, non-zero on error
+ * @since 3.6.0
+ */
+JWT_EXPORT
+int jwt_builder_setcnf(jwt_builder_t *builder, const char *member,
+		       const char *value);
+
+/**
+ * @brief Read a string-valued "cnf" (confirmation) member from a token
+ *
+ * @rfc{7800}
+ *
+ * Returns the value of @c cnf.@p member (e.g. @c "jkt", @c "kid",
+ * @c "x5t#S256") for a verified token. Because a verifier obtains the @ref
+ * jwt_t inside its jwt_checker_setcb() callback, this is where you call it to
+ * confirm a presented proof-of-possession key.
+ *
+ * @param jwt Pointer to a jwt_t token
+ * @param member The confirmation member name to read
+ * @return A newly allocated, nil-terminated string the caller must free with
+ *   free(), or NULL if @c cnf or the member is absent or not a string
+ * @since 3.6.0
+ */
+JWT_EXPORT
+char *jwt_get_cnf(const jwt_t *jwt, const char *member);
+
+/**
  * @}
  * @noop jwt_object_grp
  */

--- a/libjwt/jwt-setget.c
+++ b/libjwt/jwt-setget.c
@@ -320,3 +320,121 @@ jwt_value_error_t jwt_claim_del(jwt_t *jwt, const char *claim)
                 return JWT_VALUE_ERR_INVALID;
 	return __deleter(jwt->claims, claim);
 }
+
+/* @rfc{7800} "cnf" (confirmation) claim helpers.
+ *
+ * cnf is a JSON object carrying a single proof-of-possession confirmation. The
+ * issuer sets it on a builder; a verifier reads a member from the jwt_t handed
+ * to its jwt_checker_setcb() callback (see jwt_get_cnf()). Each setter REPLACES
+ * any existing cnf, so the object always holds exactly one member. */
+
+/* Serialize the single-member object @cnf and set it as the builder's "cnf". */
+static int builder_set_cnf(jwt_builder_t *builder, jwt_json_t *cnf)
+{
+	char_auto *json = NULL;
+	jwt_value_t jval;
+
+	json = jwt_json_serialize(cnf, JWT_JSON_COMPACT);
+	if (json == NULL)
+		return 1; // LCOV_EXCL_LINE
+
+	jwt_set_SET_JSON(&jval, "cnf", json);
+	jval.replace = 1;
+
+	return jwt_builder_claim_set(builder, &jval) != JWT_VALUE_ERR_NONE;
+}
+
+int jwt_builder_setcnf(jwt_builder_t *builder, const char *member,
+		       const char *value)
+{
+	jwt_json_auto_t *cnf = NULL;
+
+	if (builder == NULL || member == NULL || !strlen(member) ||
+	    value == NULL)
+		return 1;
+
+	cnf = jwt_json_create();
+	if (cnf == NULL)
+		return 1; // LCOV_EXCL_LINE
+
+	if (jwt_json_obj_set(cnf, member, jwt_json_create_str(value)))
+		return 1; // LCOV_EXCL_LINE
+
+	return builder_set_cnf(builder, cnf);
+}
+
+int jwt_builder_setcnf_jkt(jwt_builder_t *builder, const jwk_item_t *key)
+{
+	char_auto *tp = NULL;
+
+	if (builder == NULL || key == NULL)
+		return 1;
+
+	tp = jwks_item_thumbprint(key, JWK_THUMBPRINT_SHA256);
+	if (tp == NULL)
+		return 1;
+
+	return jwt_builder_setcnf(builder, "jkt", tp);
+}
+
+int jwt_builder_setcnf_jwk(jwt_builder_t *builder, const jwk_item_t *key)
+{
+	jwt_json_auto_t *cnf = NULL;
+	char_auto *jwk_json = NULL;
+	jwt_json_t *jwk;
+
+	if (builder == NULL || key == NULL)
+		return 1;
+
+	cnf = jwt_json_create();
+	if (cnf == NULL)
+		return 1; // LCOV_EXCL_LINE
+
+	/* Embed the PUBLIC JWK only (@rfc{7800,3.2}). */
+	jwk_json = jwks_item_export(key, 0);
+	if (jwk_json == NULL)
+		return 1; // LCOV_EXCL_LINE
+
+	jwk = jwt_json_parse(jwk_json, 0, NULL);
+	if (jwk == NULL)
+		return 1; // LCOV_EXCL_LINE
+
+	/* obj_set steals the jwk reference into cnf. */
+	if (jwt_json_obj_set(cnf, "jwk", jwk))
+		return 1; // LCOV_EXCL_LINE
+
+	return builder_set_cnf(builder, cnf);
+}
+
+char *jwt_get_cnf(const jwt_t *jwt, const char *member)
+{
+	jwt_json_t *cnf, *val;
+	const char *str;
+	char *out;
+	size_t len;
+
+	if (jwt == NULL || jwt->claims == NULL || member == NULL)
+		return NULL;
+
+	cnf = jwt_json_obj_get(jwt->claims, "cnf");
+	if (cnf == NULL || !jwt_json_is_object(cnf))
+		return NULL;
+
+	val = jwt_json_obj_get(cnf, member);
+	if (val == NULL || !jwt_json_is_string(val))
+		return NULL;
+
+	str = jwt_json_str_val(val);
+	if (str == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	/* Return a copy: the borrowed value would dangle once the jwt_t (e.g. a
+	 * verify callback's token) is freed. */
+	len = strlen(str) + 1;
+	out = jwt_malloc(len);
+	if (out == NULL)
+		return NULL; // LCOV_EXCL_LINE
+	memcpy(out, str, len);
+
+	return out;
+}

--- a/tests/jwt_cnf.c
+++ b/tests/jwt_cnf.c
@@ -1,0 +1,359 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* Tests for the RFC 7800 "cnf" (confirmation) claim helpers:
+ * jwt_builder_setcnf_jkt() / _jwk() / jwt_builder_setcnf() and jwt_get_cnf().
+ * The token is signed and verified with one EC P-256 key (ES256 works on every
+ * backend); the same key's public thumbprint is the proof-of-possession value. */
+
+static jwk_set_t *load_named(const char *file)
+{
+	char *path;
+	jwk_set_t *set;
+	int ret;
+
+	ret = asprintf(&path, KEYDIR "/%s", file);
+	ck_assert_int_gt(ret, 0);
+
+	set = jwks_create_fromfile(path);
+	free(path);
+	ck_assert_ptr_nonnull(set);
+
+	return set;
+}
+
+/* The proof-of-possession key bound via cnf (its thumbprint/export are used). */
+static jwk_set_t *load_key(void)
+{
+	return load_named("ec_key_prime256v1.json");
+}
+
+/* A symmetric key used only to sign the test tokens. HS256 works on every
+ * backend, so the cnf round-trip tests don't depend on a particular signing
+ * algorithm (the cnf helpers are signature-agnostic). */
+static jwk_set_t *load_signer(void)
+{
+	return load_named("oct_key_256.json");
+}
+
+/* Get the builder's current "cnf" claim as a serialized JSON string. */
+static char *get_builder_cnf(jwt_builder_t *builder)
+{
+	jwt_value_t jval;
+
+	jwt_set_GET_JSON(&jval, "cnf");
+	if (jwt_builder_claim_get(builder, &jval) != JWT_VALUE_ERR_NONE)
+		return NULL;
+
+	return jval.json_val;
+}
+
+START_TEST(test_setcnf_jkt)
+{
+	jwk_set_t *set = load_key();
+	const jwk_item_t *key = jwks_item_get(set, 0);
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *tp = NULL;
+	char_auto *cnf = NULL;
+	char expected[128];
+
+	SET_OPS();
+
+	tp = jwks_item_thumbprint(key, JWK_THUMBPRINT_SHA256);
+	ck_assert_ptr_nonnull(tp);
+	snprintf(expected, sizeof(expected), "{\"jkt\":\"%s\"}", tp);
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	ck_assert_int_eq(jwt_builder_setcnf_jkt(builder, key), 0);
+
+	cnf = get_builder_cnf(builder);
+	ck_assert_ptr_nonnull(cnf);
+	ck_assert_str_eq(cnf, expected);
+
+	jwks_free(set);
+}
+END_TEST
+
+START_TEST(test_setcnf_generic_and_single_member)
+{
+	jwk_set_t *set = load_key();
+	const jwk_item_t *key = jwks_item_get(set, 0);
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *c1 = NULL, *c2 = NULL, *c3 = NULL;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	/* A string member (e.g. the RFC 8705 mTLS confirmation). */
+	ck_assert_int_eq(jwt_builder_setcnf(builder, "x5t#S256", "abc123"), 0);
+	c1 = get_builder_cnf(builder);
+	ck_assert_str_eq(c1, "{\"x5t#S256\":\"abc123\"}");
+
+	/* A second setter REPLACES cnf: it must still carry exactly one member. */
+	ck_assert_int_eq(jwt_builder_setcnf(builder, "kid", "key-1"), 0);
+	c2 = get_builder_cnf(builder);
+	ck_assert_str_eq(c2, "{\"kid\":\"key-1\"}");
+
+	/* jkt likewise replaces. */
+	ck_assert_int_eq(jwt_builder_setcnf_jkt(builder, key), 0);
+	c3 = get_builder_cnf(builder);
+	ck_assert(!strncmp(c3, "{\"jkt\":\"", 8));
+	/* exactly one member: one ':' and no ',' */
+	ck_assert_ptr_null(strchr(c3, ','));
+
+	jwks_free(set);
+}
+END_TEST
+
+START_TEST(test_setcnf_jwk)
+{
+	jwk_set_t *set = load_key();
+	const jwk_item_t *key = jwks_item_get(set, 0);
+	jwt_builder_auto_t *builder = NULL;
+	char_auto *cnf = NULL;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	ck_assert_int_eq(jwt_builder_setcnf_jwk(builder, key), 0);
+
+	cnf = get_builder_cnf(builder);
+	ck_assert_ptr_nonnull(cnf);
+
+	/* cnf = {"jwk": <public EC JWK>} : has the public members, not "d". */
+	ck_assert(strstr(cnf, "\"jwk\":{") != NULL);
+	ck_assert(strstr(cnf, "\"kty\":\"EC\"") != NULL);
+	ck_assert(strstr(cnf, "\"crv\":\"P-256\"") != NULL);
+	ck_assert(strstr(cnf, "\"x\":") != NULL);
+	ck_assert(strstr(cnf, "\"d\":") == NULL);
+
+	jwks_free(set);
+}
+END_TEST
+
+/* Captures what the verify callback reads from the token's cnf. */
+struct cnf_seen {
+	char *jkt;		/* cnf.jkt value (must match)	*/
+	int missing_is_null;	/* jwt_get_cnf(absent) == NULL	*/
+	int object_is_null;	/* jwt_get_cnf("jwk" object) == NULL when present */
+	int ran;
+};
+
+static int verify_jkt_cb(jwt_t *jwt, jwt_config_t *config)
+{
+	struct cnf_seen *s = config->ctx;
+
+	s->ran = 1;
+	s->jkt = jwt_get_cnf(jwt, "jkt");
+	s->missing_is_null = (jwt_get_cnf(jwt, "nope") == NULL);
+	return 0;
+}
+
+static int verify_jwk_cb(jwt_t *jwt, jwt_config_t *config)
+{
+	struct cnf_seen *s = config->ctx;
+
+	s->ran = 1;
+	/* "jwk" is an object, not a string -> the string getter returns NULL. */
+	s->object_is_null = (jwt_get_cnf(jwt, "jwk") == NULL);
+	return 0;
+}
+
+static int verify_nocnf_cb(jwt_t *jwt, jwt_config_t *config)
+{
+	struct cnf_seen *s = config->ctx;
+
+	s->ran = 1;
+	/* No "cnf" claim at all -> NULL. */
+	s->missing_is_null = (jwt_get_cnf(jwt, "jkt") == NULL);
+	return 0;
+}
+
+START_TEST(test_get_cnf_roundtrip)
+{
+	jwk_set_t *set = load_key();
+	jwk_set_t *sset = load_signer();
+	const jwk_item_t *key = jwks_item_get(set, 0);
+	const jwk_item_t *skey = jwks_item_get(sset, 0);
+	jwt_builder_auto_t *builder = NULL;
+	jwt_checker_auto_t *checker = NULL;
+	char_auto *tp = NULL;
+	char_auto *token = NULL;
+	struct cnf_seen seen;
+
+	SET_OPS();
+
+	tp = jwks_item_thumbprint(key, JWK_THUMBPRINT_SHA256);
+	ck_assert_ptr_nonnull(tp);
+
+	/* Issue an HS256 token bound to the EC key via cnf.jkt. */
+	builder = jwt_builder_new();
+	ck_assert_int_eq(jwt_builder_setkey(builder, JWT_ALG_HS256, skey), 0);
+	ck_assert_int_eq(jwt_builder_setcnf_jkt(builder, key), 0);
+	token = jwt_builder_generate(builder);
+	ck_assert_ptr_nonnull(token);
+
+	/* Verify and read cnf.jkt from the callback's jwt_t. */
+	memset(&seen, 0, sizeof(seen));
+	checker = jwt_checker_new();
+	ck_assert_int_eq(jwt_checker_setkey(checker, JWT_ALG_HS256, skey), 0);
+	ck_assert_int_eq(jwt_checker_setcb(checker, verify_jkt_cb, &seen), 0);
+	ck_assert_int_eq(jwt_checker_verify(checker, token), 0);
+
+	ck_assert_int_eq(seen.ran, 1);
+	ck_assert_ptr_nonnull(seen.jkt);
+	ck_assert_str_eq(seen.jkt, tp);
+	ck_assert_int_eq(seen.missing_is_null, 1);
+	free(seen.jkt);
+
+	jwks_free(sset);
+	jwks_free(set);
+}
+END_TEST
+
+START_TEST(test_get_cnf_object_member)
+{
+	jwk_set_t *set = load_key();
+	jwk_set_t *sset = load_signer();
+	const jwk_item_t *key = jwks_item_get(set, 0);
+	const jwk_item_t *skey = jwks_item_get(sset, 0);
+	jwt_builder_auto_t *builder = NULL;
+	jwt_checker_auto_t *checker = NULL;
+	char_auto *token = NULL;
+	struct cnf_seen seen;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_int_eq(jwt_builder_setkey(builder, JWT_ALG_HS256, skey), 0);
+	ck_assert_int_eq(jwt_builder_setcnf_jwk(builder, key), 0);
+	token = jwt_builder_generate(builder);
+	ck_assert_ptr_nonnull(token);
+
+	memset(&seen, 0, sizeof(seen));
+	checker = jwt_checker_new();
+	ck_assert_int_eq(jwt_checker_setkey(checker, JWT_ALG_HS256, skey), 0);
+	ck_assert_int_eq(jwt_checker_setcb(checker, verify_jwk_cb, &seen), 0);
+	ck_assert_int_eq(jwt_checker_verify(checker, token), 0);
+
+	ck_assert_int_eq(seen.ran, 1);
+	ck_assert_int_eq(seen.object_is_null, 1);
+
+	jwks_free(sset);
+	jwks_free(set);
+}
+END_TEST
+
+START_TEST(test_get_cnf_absent)
+{
+	jwk_set_t *sset = load_signer();
+	const jwk_item_t *skey = jwks_item_get(sset, 0);
+	jwt_builder_auto_t *builder = NULL;
+	jwt_checker_auto_t *checker = NULL;
+	char_auto *token = NULL;
+	struct cnf_seen seen;
+
+	SET_OPS();
+
+	/* A token with no "cnf" at all. */
+	builder = jwt_builder_new();
+	ck_assert_int_eq(jwt_builder_setkey(builder, JWT_ALG_HS256, skey), 0);
+	token = jwt_builder_generate(builder);
+	ck_assert_ptr_nonnull(token);
+
+	memset(&seen, 0, sizeof(seen));
+	checker = jwt_checker_new();
+	ck_assert_int_eq(jwt_checker_setkey(checker, JWT_ALG_HS256, skey), 0);
+	ck_assert_int_eq(jwt_checker_setcb(checker, verify_nocnf_cb, &seen), 0);
+	ck_assert_int_eq(jwt_checker_verify(checker, token), 0);
+
+	ck_assert_int_eq(seen.ran, 1);
+	ck_assert_int_eq(seen.missing_is_null, 1);
+
+	jwks_free(sset);
+}
+END_TEST
+
+START_TEST(test_errors)
+{
+	jwk_set_t *set = load_key();
+	const jwk_item_t *key = jwks_item_get(set, 0);
+	jwt_builder_auto_t *builder = NULL;
+	jwk_set_t *seed_set;
+	const jwk_item_t *seed_key;
+	char *p;
+	int ret;
+
+	SET_OPS();
+
+	builder = jwt_builder_new();
+	ck_assert_ptr_nonnull(builder);
+
+	/* NULL / empty arguments. */
+	ck_assert_int_ne(jwt_builder_setcnf_jkt(NULL, key), 0);
+	ck_assert_int_ne(jwt_builder_setcnf_jkt(builder, NULL), 0);
+	ck_assert_int_ne(jwt_builder_setcnf_jwk(NULL, key), 0);
+	ck_assert_int_ne(jwt_builder_setcnf_jwk(builder, NULL), 0);
+	ck_assert_int_ne(jwt_builder_setcnf(NULL, "kid", "v"), 0);
+	ck_assert_int_ne(jwt_builder_setcnf(builder, NULL, "v"), 0);
+	ck_assert_int_ne(jwt_builder_setcnf(builder, "", "v"), 0);
+	ck_assert_int_ne(jwt_builder_setcnf(builder, "kid", NULL), 0);
+
+	ck_assert_ptr_null(jwt_get_cnf(NULL, "jkt"));
+
+	/* A seed-only OKP key (Ed448, "d" with no "x") can't be thumbprinted,
+	 * so jkt binding fails cleanly. */
+	ret = asprintf(&p, KEYDIR "/eddsa_key_ed448.json");
+	ck_assert_int_gt(ret, 0);
+	seed_set = jwks_create_fromfile(p);
+	free(p);
+	ck_assert_ptr_nonnull(seed_set);
+	seed_key = jwks_item_get(seed_set, 0);
+	ck_assert_ptr_nonnull(seed_key);
+	ck_assert_int_ne(jwt_builder_setcnf_jkt(builder, seed_key), 0);
+
+	jwks_free(seed_set);
+	jwks_free(set);
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+
+	tc_core = tcase_create("jwt_cnf");
+
+	tcase_add_loop_test(tc_core, test_setcnf_jkt, 0, i);
+	tcase_add_loop_test(tc_core, test_setcnf_generic_and_single_member, 0, i);
+	tcase_add_loop_test(tc_core, test_setcnf_jwk, 0, i);
+	tcase_add_loop_test(tc_core, test_get_cnf_roundtrip, 0, i);
+	tcase_add_loop_test(tc_core, test_get_cnf_object_member, 0, i);
+	tcase_add_loop_test(tc_core, test_get_cnf_absent, 0, i);
+	tcase_add_loop_test(tc_core, test_errors, 0, i);
+
+	tcase_set_timeout(tc_core, 30);
+
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT cnf (RFC 7800) Confirmation Claim");
+}


### PR DESCRIPTION
Implements #316. Adds proof-of-possession `cnf` claim helpers — the substrate for DPoP (RFC 9449), OAuth mTLS (RFC 8705), and OpenID PoP. Builds directly on the RFC 7638 thumbprint primitive from #307.

### API

```c
/* Issuer side (builder). Each REPLACES any prior cnf -> always one member. */
int jwt_builder_setcnf_jkt(jwt_builder_t *b, const jwk_item_t *key); /* {"jkt": thumbprint} */
int jwt_builder_setcnf_jwk(jwt_builder_t *b, const jwk_item_t *key); /* {"jwk": public JWK} */
int jwt_builder_setcnf(jwt_builder_t *b, const char *member, const char *value); /* kid, x5t#S256, jku */

/* Verifier side: read a string cnf member from the jwt_t (in a verify callback). */
char *jwt_get_cnf(const jwt_t *jwt, const char *member);
```

### Notes

- `jkt` reuses `jwks_item_thumbprint()` (#307); the setters wrap the existing typed claim API. `replace = 1` is what enforces RFC 7800's single-member rule — each call rebuilds the whole `cnf`.
- A verifier obtains the `jwt_t` inside its `jwt_checker_setcb()` callback (the checker exposes only registered claims directly), so the getter is a `jwt_t` accessor — not the `jwt_checker_get_cnf_jkt()` the issue sketched (which the architecture doesn't support). Explained in the commit.
- `x5t#S256` is settable today via `setcnf("x5t#S256", value)`; computing it from a DER cert is the X.509 work in #314. Extracting an embedded `jwk` object is the embedded-JWK-verify primitive in the #317 umbrella.

### Tests (`tests/jwt_cnf.c`, both JSON backends, full crypto-ops loop)

jkt/jwk/generic set round-trips (exact-string assertions, identical across backends), single-member enforcement (a second setter replaces), callback-based `jwt_get_cnf` against a real verified token, and the absent / non-string-member / seed-only-OKP (no thumbprint) error paths. All 27 suites pass under jansson and json-c; new defensive lines are `LCOV_EXCL`.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)