### PR TITLE
jwt: tie key operations to the backend that parsed the key

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,7 @@ if (CHECK_FOUND)
 		jwt_ec jwt_rsa jwt_hs jwt_jwks_pem jwt_thumbprint)
 
 	# Checker and Builder
-	list (APPEND UNIT_TESTS jwt_builder jwt_checker jwt_flipflop)
+	list (APPEND UNIT_TESTS jwt_builder jwt_checker jwt_flipflop jwt_xbackend)
 
 	# ML-DSA (FIPS 204 / RFC 9964). The test is a no-op unless the build
 	# enabled WITH_ML_DSA against a capable backend.

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -2912,6 +2912,12 @@ jwt_crypto_provider_t jwt_get_crypto_ops_t(void);
  * The opname is one of the available operators in the compiled version
  * of LibJWT. Most times, this is either "openssl" or "gnutls".
  *
+ * @note A key (@ref jwk_item_t) remains bound to the backend that parsed it:
+ *  signing, verifying, and JWE operations on that key always route to its
+ *  origin backend, regardless of the backend selected here. So changing the
+ *  active backend after loading keys is safe — each key keeps working. (Keys
+ *  with no backend-specific material, i.e. @c "oct", use the active backend.)
+ *
  * @param opname the name of the crypto operation to set
  * @return 0 on success, 1 for error
  * @since 3.0.0

--- a/libjwt/jwe.c
+++ b/libjwt/jwe.c
@@ -150,9 +150,11 @@ int jwe_ecdh_derive(jwe_key_alg_t alg, jwe_enc_t enc, const jwk_item_t *key,
 		    int for_encrypt, jwt_json_t *hdr,
 		    unsigned char **dk, size_t *dk_len)
 {
-	if (jwt_ops->ecdh_derive == NULL)
+	struct jwt_crypto_ops *ops = jwt_item_ops(key);
+
+	if (ops == NULL || ops->ecdh_derive == NULL)
 		return 1; // LCOV_EXCL_LINE
-	return jwt_ops->ecdh_derive(alg, enc, key, for_encrypt, hdr, dk, dk_len);
+	return ops->ecdh_derive(alg, enc, key, for_encrypt, hdr, dk, dk_len);
 }
 
 /* @rfc{7518,4.4} AES Key Wrap / Unwrap with a raw KEK (the ECDH-ES agreed
@@ -185,10 +187,12 @@ int jwe_encrypt_cek(jwe_key_alg_t alg, const jwk_item_t *key,
 		return jwe_wrap_cek(alg, key, cek, cek_len, out, out_len);
 
 	if (alg_is_rsa(alg)) {
-		if (jwt_ops->encrypt_cek_rsa == NULL)
+		struct jwt_crypto_ops *ops = jwt_item_ops(key);
+
+		if (ops == NULL || ops->encrypt_cek_rsa == NULL)
 			return 1; // LCOV_EXCL_LINE
-		return jwt_ops->encrypt_cek_rsa(alg, key, cek, cek_len,
-						out, out_len);
+		return ops->encrypt_cek_rsa(alg, key, cek, cek_len,
+					    out, out_len);
 	}
 
 	return 1; // LCOV_EXCL_LINE
@@ -205,10 +209,12 @@ int jwe_decrypt_cek(jwe_key_alg_t alg, const jwk_item_t *key,
 		return jwe_unwrap_cek(alg, key, in, in_len, cek, cek_len);
 
 	if (alg_is_rsa(alg)) {
-		if (jwt_ops->decrypt_cek_rsa == NULL)
+		struct jwt_crypto_ops *ops = jwt_item_ops(key);
+
+		if (ops == NULL || ops->decrypt_cek_rsa == NULL)
 			return 1; // LCOV_EXCL_LINE
-		return jwt_ops->decrypt_cek_rsa(alg, key, in, in_len,
-						cek, cek_len);
+		return ops->decrypt_cek_rsa(alg, key, in, in_len,
+					    cek, cek_len);
 	}
 
 	return 1; // LCOV_EXCL_LINE

--- a/libjwt/jwt-crypto-ops.c
+++ b/libjwt/jwt-crypto-ops.c
@@ -71,6 +71,27 @@ int jwt_set_crypto_ops_t(jwt_crypto_provider_t opname)
 	return 1;
 }
 
+struct jwt_crypto_ops *jwt_item_ops(const jwk_item_t *item)
+{
+	int i;
+
+	/* Cross-compatible keys (oct) and NULL/error keys use the active ops. */
+	if (item == NULL || item->provider == JWT_CRYPTO_OPS_ANY ||
+	    item->provider == JWT_CRYPTO_OPS_NONE)
+		return jwt_ops;
+
+	/* Otherwise route to the backend that parsed the key, regardless of the
+	 * currently selected ops. */
+	for (i = 0; jwt_ops_available[i] != NULL; i++) {
+		if (jwt_ops_available[i]->provider == item->provider)
+			return jwt_ops_available[i];
+	}
+
+	/* A successfully-parsed asymmetric key's backend is always compiled in,
+	 * so this is unreachable in practice. */
+	return NULL; // LCOV_EXCL_LINE
+}
+
 int jwt_set_crypto_ops(const char *opname)
 {
 	int i;

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -44,6 +44,14 @@
 JWT_NO_EXPORT
 extern struct jwt_crypto_ops *jwt_ops;
 
+/* The crypto ops to use for operations on @item. A jwk_item is bound to the
+ * backend that parsed it (item->provider); route key operations through that
+ * backend regardless of the active jwt_ops. Cross-compatible keys (oct, i.e.
+ * JWT_CRYPTO_OPS_ANY) and a NULL/error item use the active ops. Returns NULL
+ * only if the origin backend is not compiled into this build. */
+JWT_NO_EXPORT
+struct jwt_crypto_ops *jwt_item_ops(const jwk_item_t *item);
+
 /* This can be used on anything with an error and error_msg field */
 #define jwt_write_error(__obj, __fmt, __args...)	\
 ({							\

--- a/libjwt/jwt.c
+++ b/libjwt/jwt.c
@@ -329,6 +329,8 @@ fallback_ops:
 int jwt_sign(jwt_t *jwt, char **out, unsigned int *len, const char *str,
 	     unsigned int str_len)
 {
+	struct jwt_crypto_ops *ops;
+
 	switch (jwt->alg) {
 	/* HMAC */
 	case JWT_ALG_HS256:
@@ -376,7 +378,15 @@ int jwt_sign(jwt_t *jwt, char **out, unsigned int *len, const char *str,
 #endif
 		if (__check_key_bits(jwt))
 			return 1;
-		if (jwt_ops->sign_sha_pem(jwt, out, len, str, str_len)) {
+		/* Route to the backend that parsed the key, not the active ops. */
+		ops = jwt_item_ops(jwt->key);
+		if (ops == NULL) {
+			// LCOV_EXCL_START
+			jwt_write_error(jwt, "Key's crypto backend is not available");
+			return 1;
+			// LCOV_EXCL_STOP
+		}
+		if (ops->sign_sha_pem(jwt, out, len, str, str_len)) {
 			jwt_write_error(jwt, "Token failed signing");
 			return 1;
 		} else {
@@ -444,6 +454,7 @@ static int _verify_sha_hmac(jwt_t *jwt, const char *head,
 jwt_t *jwt_verify_sig(jwt_t *jwt, const char *head, unsigned int head_len,
 		      const char *sig_b64)
 {
+	struct jwt_crypto_ops *ops;
 	int sig_len;
 	char_auto *sig = NULL;
 
@@ -490,8 +501,15 @@ jwt_t *jwt_verify_sig(jwt_t *jwt, const char *head, unsigned int head_len,
 			break;
 		}
 
-		if (jwt_ops->verify_sha_pem(jwt, head, head_len,
-					    (unsigned char *)sig, sig_len))
+		/* Route to the backend that parsed the key, not the active ops. */
+		ops = jwt_item_ops(jwt->key);
+		if (ops == NULL) {
+			jwt_write_error(jwt, "Key's crypto backend is not available"); // LCOV_EXCL_LINE
+			break; // LCOV_EXCL_LINE
+		}
+
+		if (ops->verify_sha_pem(jwt, head, head_len,
+					(unsigned char *)sig, sig_len))
 			jwt_write_error(jwt, "Token failed verification");
 		break;
 

--- a/tests/jwt_xbackend.c
+++ b/tests/jwt_xbackend.c
@@ -1,0 +1,168 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* Backend affinity (issue #320): a jwk_item is bound to the crypto backend that
+ * parsed it, and key operations route to that backend regardless of the active
+ * jwt_ops. Each test sets the active backend with SET_OPS() (the "use" backend),
+ * then parses a key under EVERY backend (the "parse" backend) and exercises it
+ * under the active one. Before affinity, a cross-backend asymmetric key failed
+ * ("Key is not compatible"); now every (parse, use) pair must succeed. */
+
+static const char PT[] = "cross-backend proof-of-possession plaintext";
+
+static jwk_set_t *load_under(size_t ops_idx, const char *file)
+{
+	char *path;
+	jwk_set_t *set;
+	int ret;
+
+	/* Parse the JWK under jwt_test_ops[ops_idx]; this binds item->provider. */
+	ret = jwt_set_crypto_ops(jwt_test_ops[ops_idx].name);
+	ck_assert_int_eq(ret, 0);
+
+	ret = asprintf(&path, KEYDIR "/%s", file);
+	ck_assert_int_gt(ret, 0);
+	set = jwks_create_fromfile(path);
+	free(path);
+	ck_assert_ptr_nonnull(set);
+
+	return set;
+}
+
+static const struct {
+	const char *file;
+	jwt_alg_t alg;
+} sig_keys[] = {
+	{ "ec_key_prime256v1.json", JWT_ALG_ES256 },	/* backend-specific */
+	{ "rsa_key_2048.json",      JWT_ALG_RS256 },	/* backend-specific */
+	{ "oct_key_256.json",       JWT_ALG_HS256 },	/* cross-compatible (ANY) */
+};
+
+START_TEST(test_xbackend_sign_verify)
+{
+	size_t k, p;
+
+	SET_OPS(); /* active ("use") backend = jwt_test_ops[_i] */
+
+	for (k = 0; k < ARRAY_SIZE(sig_keys); k++) {
+		for (p = 0; p < ARRAY_SIZE(jwt_test_ops); p++) {
+			jwt_builder_auto_t *builder = NULL;
+			jwt_checker_auto_t *checker = NULL;
+			char_auto *token = NULL;
+			jwk_set_t *set;
+			const jwk_item_t *key;
+
+			/* Parse under backend p ... */
+			set = load_under(p, sig_keys[k].file);
+			key = jwks_item_get(set, 0);
+			ck_assert_ptr_nonnull(key);
+
+			/* ... then switch the active backend to the use one. */
+			ck_assert_int_eq(jwt_set_crypto_ops(
+				jwt_test_ops[_i].name), 0);
+
+			builder = jwt_builder_new();
+			ck_assert_int_eq(jwt_builder_setkey(builder,
+				sig_keys[k].alg, key), 0);
+			token = jwt_builder_generate(builder);
+			ck_assert_ptr_nonnull(token);
+
+			checker = jwt_checker_new();
+			ck_assert_int_eq(jwt_checker_setkey(checker,
+				sig_keys[k].alg, key), 0);
+			ck_assert_int_eq(jwt_checker_verify(checker, token), 0);
+
+			jwks_free(set);
+		}
+	}
+}
+END_TEST
+
+static void jwe_roundtrip_xbackend(size_t use_i, jwe_key_alg_t alg,
+				   jwe_enc_t enc, const char *file)
+{
+	size_t p;
+
+	for (p = 0; p < ARRAY_SIZE(jwt_test_ops); p++) {
+		jwe_builder_auto_t *builder = NULL;
+		jwe_checker_auto_t *checker = NULL;
+		char_auto *token = NULL;
+		unsigned char *pt = NULL;
+		size_t pt_len = 0;
+		jwk_set_t *set;
+		const jwk_item_t *key;
+
+		set = load_under(p, file);
+		key = jwks_item_get(set, 0);
+		ck_assert_ptr_nonnull(key);
+
+		ck_assert_int_eq(jwt_set_crypto_ops(jwt_test_ops[use_i].name), 0);
+
+		builder = jwe_builder_new();
+		ck_assert_int_eq(jwe_builder_setkey(builder, alg, enc, key), 0);
+		token = jwe_builder_generate(builder, (const unsigned char *)PT,
+					     strlen(PT));
+		ck_assert_ptr_nonnull(token);
+
+		checker = jwe_checker_new();
+		ck_assert_int_eq(jwe_checker_setkey(checker, alg, enc, key), 0);
+		pt = jwe_checker_decrypt(checker, token, &pt_len);
+		ck_assert_ptr_nonnull(pt);
+		ck_assert_uint_eq(pt_len, strlen(PT));
+		ck_assert_mem_eq(pt, PT, pt_len);
+		free(pt);
+
+		jwks_free(set);
+	}
+}
+
+START_TEST(test_xbackend_jwe_rsa)
+{
+	SET_OPS();
+	/* RSA-OAEP-256 wraps the CEK with the recipient RSA key (decrypt_cek_rsa
+	 * / encrypt_cek_rsa route to the key's backend). */
+	jwe_roundtrip_xbackend(_i, JWE_ALG_RSA_OAEP_256, JWE_ENC_A256GCM,
+			       "rsa_key_2048_enc.json");
+}
+END_TEST
+
+START_TEST(test_xbackend_jwe_ecdh)
+{
+	SET_OPS();
+	/* ECDH-ES derives the agreed key from the recipient EC key (ecdh_derive
+	 * routes to the key's backend). */
+	jwe_roundtrip_xbackend(_i, JWE_ALG_ECDH_ES_A256KW, JWE_ENC_A256GCM,
+			       "ec_key_prime256v1_enc.json");
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+
+	tc_core = tcase_create("jwt_xbackend");
+
+	tcase_add_loop_test(tc_core, test_xbackend_sign_verify, 0, i);
+	tcase_add_loop_test(tc_core, test_xbackend_jwe_rsa, 0, i);
+	tcase_add_loop_test(tc_core, test_xbackend_jwe_ecdh, 0, i);
+
+	tcase_set_timeout(tc_core, 60);
+
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT cross-backend key affinity (#320)");
+}


### PR DESCRIPTION
Closes #320.

A `jwk_item` is bound to the crypto backend active when its JWK was parsed (`item->provider`). Before this, signing/verifying or JWE-encrypting with that key under a **different** active backend failed (*"Key is not compatible"* on OpenSSL/MbedTLS; GnuTLS silently re-imported). This was the footgun behind the #319/#321 ordering bug.

### Change

- New internal `jwt_item_ops(item)` resolves a key's **origin backend** from the ops registry.
- Asymmetric key operations dispatch through it:
  - **sign / verify** (`jwt.c`: `sign_sha_pem`, `verify_sha_pem`)
  - **JWE key management** (`jwe.c`: `ecdh_derive`, RSA `encrypt_cek_rsa` / `decrypt_cek_rsa`)
- Left on the **active** backend (no key, or cross-compatible): `oct` keys (`JWT_CRYPTO_OPS_ANY`), content encryption (raw CEK), raw AES-KW of the ECDH-derived KEK, the CSPRNG, the RFC 7638 thumbprint digest (keyless), and `jwks_item_export` (pure JSON).

No public API change; documented the behavior on `jwt_set_crypto_ops`. Mixed-backend usage now "just works" and the "set ops before loading keys" discipline is no longer required.

### Tests — `tests/jwt_xbackend.c`

The full **(parse-backend × use-backend)** matrix: for every pair, a key parsed under one backend signs+verifies (EC ES256, RSA RS256, oct HS256) and round-trips JWE (RSA-OAEP-256, ECDH-ES) under another. All 28 suites pass under **both** JSON backends:
- locally against brew OpenSSL / GnuTLS / **MbedTLS 4.1**
- in the CI image against **MbedTLS 3.6.6** + leancrypto (ML-DSA on)

Only the unreachable "origin backend not compiled" return is `LCOV_EXCL`.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)
