### PR TITLE
jwt: typ media-type helper + algorithm allowlist (RFC 8725)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,9 @@ if (CHECK_FOUND)
 	# RFC 7797 unencoded / detached payload
 	list (APPEND UNIT_TESTS jws_b64)
 
+	# RFC 8725 typ helper + algorithm allowlist
+	list (APPEND UNIT_TESTS jwt_typ_alg)
+
 	# ML-DSA (FIPS 204 / RFC 9964). The test is a no-op unless the build
 	# enabled WITH_ML_DSA against a capable backend.
 	list (APPEND UNIT_TESTS jwt_mldsa)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Standard | RFC                                                                  
 ``JWT``  | :page_facing_up: [RFC-7519](https://datatracker.ietf.org/doc/html/rfc7519) | JSON Web Token
 ``JWK Thumbprint`` | :page_facing_up: [RFC-7638](https://datatracker.ietf.org/doc/html/rfc7638) / [RFC-9278](https://datatracker.ietf.org/doc/html/rfc9278) | JWK Thumbprint and Thumbprint URI
 ``cnf``  | :page_facing_up: [RFC-7800](https://datatracker.ietf.org/doc/html/rfc7800) | Proof-of-Possession (confirmation) claim helpers
+``Unencoded Payload`` | :page_facing_up: [RFC-7797](https://datatracker.ietf.org/doc/html/rfc7797) | JWS unencoded (``b64=false``) and detached payloads
+``BCP 225`` | :page_facing_up: [RFC-8725](https://datatracker.ietf.org/doc/html/rfc8725) | JWT Best Current Practices (``typ`` check, algorithm allowlist)
 
 > [!NOTE]
 > Throughout this documentation you will see links such as the ones

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -659,6 +659,22 @@ JWT_EXPORT
 int jwt_builder_set_detached(jwt_builder_t *builder, int detached);
 
 /**
+ * @brief Set the token media type ("typ" header)
+ *
+ * A convenience setter for the ``"typ"`` header parameter, naming the token's
+ * media type — e.g. ``"at+jwt"`` (RFC 9068), ``"dpop+jwt"``, ``"secevent+jwt"``.
+ * Equivalent to setting the ``"typ"`` header directly. Pair it with
+ * jwt_checker_expect_typ() on the verifying side.
+ *
+ * @param builder Pointer to a builder object
+ * @param typ The media type string, or NULL to clear it
+ * @return 0 on success, non-zero otherwise with error set in the builder
+ * @since 3.6.0
+ */
+JWT_EXPORT
+int jwt_builder_settyp(jwt_builder_t *builder, const char *typ);
+
+/**
  * @brief Set IssuedAt usage on builder
  *
  * By default, the builder will set the ``iat`` claim to all tokens. You can
@@ -984,6 +1000,42 @@ typedef enum {
 JWT_EXPORT
 int jwt_checker_setkeyring(jwt_checker_t *checker, const jwk_set_t *keyring,
 			   jwt_verify_policy_t policy);
+
+/**
+ * @brief Require a specific token media type ("typ" header)
+ *
+ * When set, jwt_checker_verify() rejects a token whose ``"typ"`` header does not
+ * match @p typ. The comparison is case-insensitive and tolerates the optional
+ * ``application/`` prefix (RFC 6838), so ``expect_typ(c, "at+jwt")`` accepts both
+ * ``"at+jwt"`` and ``"application/at+jwt"``. This is the standardized
+ * cross-JWT-confusion defense (@rfc{8725} §3.11).
+ *
+ * @param checker Pointer to a checker object
+ * @param typ The required media type, or NULL to clear the requirement
+ * @return 0 on success, non-zero otherwise with error set in the checker
+ * @since 3.6.0
+ */
+JWT_EXPORT
+int jwt_checker_expect_typ(jwt_checker_t *checker, const char *typ);
+
+/**
+ * @brief Set an allowlist of acceptable algorithms
+ *
+ * Restricts the algorithms jwt_checker_verify() will accept to the given set,
+ * checked before any signature work (@rfc{8725}). Useful when verifying against
+ * a keyring (jwt_checker_setkeyring()) where several algorithms are acceptable,
+ * e.g. ``{JWT_ALG_RS256, JWT_ALG_ES256}``. A token whose ``"alg"`` is not in the
+ * set is rejected, which also blocks an ``alg:none`` downgrade. Passing @p n as
+ * 0 (or @p algs as NULL) clears the allowlist.
+ *
+ * @param checker Pointer to a checker object
+ * @param algs An array of acceptable ::jwt_alg_t values (copied)
+ * @param n The number of entries in @p algs
+ * @return 0 on success, non-zero otherwise with error set in the checker
+ * @since 3.6.0
+ */
+JWT_EXPORT
+int jwt_checker_setalgs(jwt_checker_t *checker, const jwt_alg_t *algs, size_t n);
 
 /**
  * @brief Set a callback for generating tokens

--- a/libjwt/jwt-common.c
+++ b/libjwt/jwt-common.c
@@ -55,6 +55,10 @@ void FUNC(free)(jwt_common_t *__cmd)
 	/* @rfc{7797} Free any raw payload (jwt_builder_setpayload()). */
 	jwt_scrub_and_free(__cmd->c.payload_raw, __cmd->c.payload_raw_len);
 
+	/* @rfc{8725} Free the checker's typ expectation / algorithm allowlist. */
+	jwt_freemem(__cmd->c.expected_typ);
+	jwt_freemem(__cmd->c.alg_allowlist);
+
 	memset(__cmd, 0, sizeof(*__cmd));
 
 	jwt_freemem(__cmd);
@@ -663,6 +667,61 @@ int jwt_checker_setkeyring(jwt_checker_t *checker, const jwk_set_t *keyring,
 	return 0;
 }
 
+int jwt_checker_expect_typ(jwt_checker_t *checker, const char *typ)
+{
+	char *copy = NULL;
+
+	if (checker == NULL)
+		return 1;
+
+	if (typ != NULL) {
+		size_t n = strlen(typ) + 1;
+
+		copy = jwt_malloc(n);
+		if (copy == NULL) {
+			jwt_write_error(checker, "Error allocating memory"); // LCOV_EXCL_LINE
+			return 1; // LCOV_EXCL_LINE
+		}
+		memcpy(copy, typ, n);
+	}
+
+	jwt_freemem(checker->c.expected_typ);
+	checker->c.expected_typ = copy;
+
+	return 0;
+}
+
+int jwt_checker_setalgs(jwt_checker_t *checker, const jwt_alg_t *algs, size_t n)
+{
+	jwt_alg_t *copy = NULL;
+	size_t i;
+
+	if (checker == NULL)
+		return 1;
+
+	if (algs != NULL && n > 0) {
+		for (i = 0; i < n; i++) {
+			if (algs[i] >= JWT_ALG_INVAL) {
+				jwt_write_error(checker,
+					"Invalid algorithm in allowlist");
+				return 1;
+			}
+		}
+		copy = jwt_malloc(n * sizeof(jwt_alg_t));
+		if (copy == NULL) {
+			jwt_write_error(checker, "Error allocating memory"); // LCOV_EXCL_LINE
+			return 1; // LCOV_EXCL_LINE
+		}
+		memcpy(copy, algs, n * sizeof(jwt_alg_t));
+	}
+
+	jwt_freemem(checker->c.alg_allowlist);
+	checker->c.alg_allowlist = copy;
+	checker->c.n_alg_allowlist = copy ? n : 0;
+
+	return 0;
+}
+
 static const struct jwt_signature *checker_sig_at(const jwt_checker_t *checker,
 						  unsigned int index)
 {
@@ -762,6 +821,27 @@ int jwt_builder_set_detached(jwt_builder_t *builder, int detached)
 		return 1;
 
 	builder->c.detached = detached ? 1 : 0;
+
+	return 0;
+}
+
+int jwt_builder_settyp(jwt_builder_t *builder, const char *typ)
+{
+	jwt_json_t *v;
+
+	if (builder == NULL)
+		return 1;
+
+	if (typ == NULL) {
+		jwt_json_obj_del(builder->c.headers, "typ");
+		return 0;
+	}
+
+	v = jwt_json_create_str(typ);
+	if (v == NULL || jwt_json_obj_set(builder->c.headers, "typ", v)) {
+		jwt_write_error(builder, "Error setting \"typ\" header"); // LCOV_EXCL_LINE
+		return 1; // LCOV_EXCL_LINE
+	}
 
 	return 0;
 }

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -122,6 +122,14 @@ struct jwt_common {
 	size_t payload_raw_len;
 	int b64;
 	int detached;
+
+	/* --- @rfc{8725} Checker ergonomics ---
+	 * @expected_typ: if set, the token's "typ" must match it (case-insensitive,
+	 * optional "application/" prefix). @alg_allowlist: if non-empty, the token's
+	 * "alg" must be one of these (checked before the signature). */
+	char *expected_typ;
+	jwt_alg_t *alg_allowlist;
+	size_t n_alg_allowlist;
 };
 
 struct jwt_builder {

--- a/libjwt/jwt-verify.c
+++ b/libjwt/jwt-verify.c
@@ -8,6 +8,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <stdio.h>
 
 #include <jwt.h>
@@ -420,9 +421,58 @@ static jwt_claims_t __verify_jti(jwt_t *jwt)
 }
 
 /* This is after parsing and possibly a user callback. */
+/* @rfc{8725,3.11} Compare a media type ignoring case and an optional
+ * "application/" prefix (RFC 6838), so "at+jwt" matches "application/at+jwt". */
+static int jwt_typ_matches(const char *want, const char *got)
+{
+	if (!strncasecmp(want, "application/", 12))
+		want += 12;
+	if (!strncasecmp(got, "application/", 12))
+		got += 12;
+
+	return !strcasecmp(want, got);
+}
+
+/* @rfc{8725} Does the parsed header (@jwt->headers) and algorithm (@jwt->alg)
+ * satisfy the checker's "typ" expectation and algorithm allowlist? Returns 1 if
+ * acceptable (or nothing is configured), 0 if it should be rejected. */
+static int jwt_typ_alg_ok(jwt_t *jwt)
+{
+	jwt_checker_t *checker = jwt->checker;
+	size_t i;
+
+	if (checker == NULL)
+		return 1; // LCOV_EXCL_LINE
+
+	if (checker->c.expected_typ != NULL) {
+		jwt_json_t *t = jwt_json_obj_get(jwt->headers, "typ");
+		const char *got = (t && jwt_json_is_string(t))
+			? jwt_json_str_val(t) : NULL;
+
+		if (got == NULL || !jwt_typ_matches(checker->c.expected_typ, got))
+			return 0;
+	}
+
+	if (checker->c.n_alg_allowlist > 0) {
+		for (i = 0; i < checker->c.n_alg_allowlist; i++)
+			if (checker->c.alg_allowlist[i] == jwt->alg)
+				return 1;
+		return 0;
+	}
+
+	return 1;
+}
+
 static int __verify_config_post(jwt_t *jwt, const jwt_config_t *config,
 				unsigned int sig_len)
 {
+	/* @rfc{8725} Enforce the typ expectation / algorithm allowlist first. */
+	if (!jwt_typ_alg_ok(jwt)) {
+		jwt_write_error(jwt,
+			"Token rejected by \"typ\" or algorithm policy");
+		return 1;
+	}
+
 	/* Yes, we do this before checking a signature. @rfc{7797} An unencoded
 	 * (b64=false) payload is opaque, not JSON claims, so skip claim checks. */
 	if (jwt->b64 && __verify_claims(jwt)) {
@@ -693,6 +743,13 @@ static int verify_entry(jwt_checker_t *checker, jwt_t *jwt,
 			jwt->headers = NULL;
 			return 1;
 		}
+	}
+
+	/* @rfc{8725} A signature whose "typ"/alg does not meet the checker's
+	 * expectation is simply not accepted (skipped), so the policy decides. */
+	if (!jwt_typ_alg_ok(jwt)) {
+		jwt->headers = NULL;
+		return 0;
 	}
 
 	/* Seed the candidate: a kid-named keyring key (a binding assertion, no

--- a/tests/jwt_typ_alg.c
+++ b/tests/jwt_typ_alg.c
@@ -1,0 +1,168 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* @rfc{8725} typ media-type helper + algorithm allowlist (issue #312). Runs
+ * under each crypto backend (SET_OPS) and both JSON backends. */
+
+static jwk_set_t *load_ec(void)
+{
+	char *path;
+	jwk_set_t *set;
+	int ret;
+
+	ret = asprintf(&path, KEYDIR "/ec_key_prime256v1.json");
+	ck_assert_int_gt(ret, 0);
+	set = jwks_create_fromfile(path);
+	free(path);
+	ck_assert_ptr_nonnull(set);
+
+	return set;
+}
+
+/* Build an ES256 token with the given "typ" (NULL for none) and format. */
+static char *gen(const jwk_item_t *ec, const char *typ, jwt_serialization_t fmt)
+{
+	jwt_builder_auto_t *b = jwt_builder_new();
+
+	ck_assert_int_eq(jwt_builder_setkey(b, JWT_ALG_ES256, ec), 0);
+	if (typ != NULL)
+		ck_assert_int_eq(jwt_builder_settyp(b, typ), 0);
+	ck_assert_int_eq(jwt_builder_set_format(b, fmt), 0);
+
+	return jwt_builder_generate(b);
+}
+
+START_TEST(test_typ)
+{
+	jwk_set_t *ks;
+	const jwk_item_t *ec;
+	char_auto *tok = NULL;
+	jwt_serialization_t fmts[] = { JWT_FORMAT_COMPACT, JWT_FORMAT_JSON_FLAT };
+	size_t i;
+
+	SET_OPS();
+	ks = load_ec();
+	ec = jwks_item_get(ks, 0);
+
+	/* Cover both the Compact and JSON verify paths. */
+	for (i = 0; i < ARRAY_SIZE(fmts); i++) {
+		jwt_checker_auto_t *c1 = NULL, *c2 = NULL, *c3 = NULL, *c4 = NULL;
+
+		tok = gen(ec, "at+jwt", fmts[i]);
+		ck_assert_ptr_nonnull(tok);
+
+		/* Exact, case-insensitive, and application/-prefixed all accept. */
+		c1 = jwt_checker_new();
+		ck_assert_int_eq(jwt_checker_setkey(c1, JWT_ALG_ES256, ec), 0);
+		ck_assert_int_eq(jwt_checker_expect_typ(c1, "at+jwt"), 0);
+		ck_assert_int_eq(jwt_checker_verify(c1, tok), 0);
+
+		c2 = jwt_checker_new();
+		ck_assert_int_eq(jwt_checker_setkey(c2, JWT_ALG_ES256, ec), 0);
+		ck_assert_int_eq(jwt_checker_expect_typ(c2, "AT+JWT"), 0);
+		ck_assert_int_eq(jwt_checker_verify(c2, tok), 0);
+
+		c3 = jwt_checker_new();
+		ck_assert_int_eq(jwt_checker_setkey(c3, JWT_ALG_ES256, ec), 0);
+		ck_assert_int_eq(jwt_checker_expect_typ(c3, "application/at+jwt"), 0);
+		ck_assert_int_eq(jwt_checker_verify(c3, tok), 0);
+
+		/* A different typ is rejected. */
+		c4 = jwt_checker_new();
+		ck_assert_int_eq(jwt_checker_setkey(c4, JWT_ALG_ES256, ec), 0);
+		ck_assert_int_eq(jwt_checker_expect_typ(c4, "dpop+jwt"), 0);
+		ck_assert_int_ne(jwt_checker_verify(c4, tok), 0);
+
+		jwt_freemem(tok);
+		tok = NULL;
+	}
+
+	/* expect_typ when the token has no "typ" at all is rejected. */
+	{
+		jwt_checker_auto_t *c = jwt_checker_new();
+		char_auto *t = gen(ec, NULL, JWT_FORMAT_COMPACT);
+
+		/* JWT default typ is "JWT"; expecting "at+jwt" must fail. */
+		ck_assert_int_eq(jwt_checker_setkey(c, JWT_ALG_ES256, ec), 0);
+		ck_assert_int_eq(jwt_checker_expect_typ(c, "at+jwt"), 0);
+		ck_assert_int_ne(jwt_checker_verify(c, t), 0);
+		/* Clearing the expectation accepts again. */
+		ck_assert_int_eq(jwt_checker_expect_typ(c, NULL), 0);
+		ck_assert_int_eq(jwt_checker_verify(c, t), 0);
+	}
+
+	jwks_free(ks);
+}
+END_TEST
+
+START_TEST(test_allowlist)
+{
+	jwk_set_t *ks;
+	const jwk_item_t *ec;
+	char_auto *tok = NULL, *none_tok = NULL;
+	jwt_alg_t ok_set[] = { JWT_ALG_RS256, JWT_ALG_ES256 };
+	jwt_alg_t no_set[] = { JWT_ALG_RS256, JWT_ALG_RS512 };
+	jwt_builder_auto_t *nb = NULL;
+	jwt_checker_auto_t *c1 = NULL, *c2 = NULL, *c3 = NULL;
+
+	SET_OPS();
+	ks = load_ec();
+	ec = jwks_item_get(ks, 0);
+
+	tok = gen(ec, NULL, JWT_FORMAT_COMPACT);
+	ck_assert_ptr_nonnull(tok);
+
+	/* ES256 is in the permitted set. */
+	c1 = jwt_checker_new();
+	ck_assert_int_eq(jwt_checker_setkey(c1, JWT_ALG_ES256, ec), 0);
+	ck_assert_int_eq(jwt_checker_setalgs(c1, ok_set, 2), 0);
+	ck_assert_int_eq(jwt_checker_verify(c1, tok), 0);
+
+	/* ES256 is NOT in this set -> rejected. */
+	c2 = jwt_checker_new();
+	ck_assert_int_eq(jwt_checker_setkey(c2, JWT_ALG_ES256, ec), 0);
+	ck_assert_int_eq(jwt_checker_setalgs(c2, no_set, 2), 0);
+	ck_assert_int_ne(jwt_checker_verify(c2, tok), 0);
+	/* Clearing the allowlist accepts again. */
+	ck_assert_int_eq(jwt_checker_setalgs(c2, NULL, 0), 0);
+	ck_assert_int_eq(jwt_checker_verify(c2, tok), 0);
+
+	/* An alg:none token is rejected by an allowlist that lacks none. */
+	nb = jwt_builder_new();
+	none_tok = jwt_builder_generate(nb);
+	ck_assert_ptr_nonnull(none_tok);
+	c3 = jwt_checker_new();
+	ck_assert_int_eq(jwt_checker_setalgs(c3, ok_set, 2), 0);
+	ck_assert_int_ne(jwt_checker_verify(c3, none_tok), 0);
+
+	jwks_free(ks);
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+	tc_core = tcase_create("jwt_typ_alg");
+
+	tcase_add_loop_test(tc_core, test_typ, 0, i);
+	tcase_add_loop_test(tc_core, test_allowlist, 0, i);
+
+	tcase_set_timeout(tc_core, 30);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT typ helper + algorithm allowlist (#312)");
+}


### PR DESCRIPTION
Closes #312.

Two small, no-crypto **RFC 8725 / BCP 225** checker ergonomics that turn registered JWT profiles (`at+jwt` RFC 9068, `dpop+jwt`, `secevent+jwt`, …) into one-call setups.

- **`jwt_builder_settyp()`** sets the `"typ"` header; **`jwt_checker_expect_typ()`** requires it on verify — case-insensitive, tolerating the optional `application/` prefix (RFC 6838). This is the standardized cross-JWT-confusion defense (RFC 8725 §3.11), so `expect_typ(c, "at+jwt")` accepts both `at+jwt` and `application/at+jwt`.
- **`jwt_checker_setalgs()`** restricts accepted algorithms to a set, checked **before** any signature work — which also blocks an `alg:none` downgrade. Useful with a keyring (`jwt_checker_setkeyring`) where several algs are acceptable, e.g. `{RS256, ES256}`.

Enforced in the Compact path (`__verify_config_post`) and per signature in the JSON path (`verify_entry`); a JSON signature failing the typ/alg policy is simply not accepted, so the verify policy still decides.

### Tests — `tests/jwt_typ_alg.c` (both JSON backends, all crypto backends)
`typ` accepted exact / case-folded / `application/`-prefixed; rejected on mismatch or when absent; allowlist accepts a permitted alg, rejects a non-permitted one and an `alg:none` downgrade; clearing either restores acceptance. **31/31** suites pass locally (MbedTLS 4.1) and in the CI image (MbedTLS 3.6.6); valgrind-clean. `@since 3.6.0`; README standards table updated.

This unblocks **#317** (application profiles) — the last primitive it needs alongside `cnf` (#316), thumbprints (#307), and X.509 (#314).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
