### PR TITLE
jwks: jwks_generate() key-generation API (all backends + AKP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,6 +421,9 @@ if (CHECK_FOUND)
 	# RFC 8725 typ helper + algorithm allowlist
 	list (APPEND UNIT_TESTS jwt_typ_alg)
 
+	# Key generation (jwks_generate)
+	list (APPEND UNIT_TESTS jwt_generate)
+
 	# ML-DSA (FIPS 204 / RFC 9964). The test is a no-op unless the build
 	# enabled WITH_ML_DSA against a capable backend.
 	list (APPEND UNIT_TESTS jwt_mldsa)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ A detached token is verified with `jwt_checker_verify_detached()`, supplying the
 payload out-of-band. As mandated by RFC 7797 §6, the checker rejects a
 `"b64":false` token unless `"b64"` appears in `"crit"`.
 
+#### Key generation
+
+`jwks_generate()` produces a fresh key as a JWK, ready to sign/verify with:
+
+```c
+jwk_set_t *set = jwks_create_generate(JWK_KEY_TYPE_EC, "P-256",
+                                      JWT_ALG_ES256, JWK_KEY_GEN_KID);
+const jwk_item_t *key = jwks_item_get(set, 0);
+```
+
+It covers EC (incl. `secp256k1`), RSA / RSA-PSS, OKP (Ed25519/Ed448/X25519/X448),
+`oct`, and AKP (ML-DSA), bound to the active crypto backend. `JWK_KEY_GEN_KID`
+stamps the RFC 7638 thumbprint as the `kid`. Each backend generates what it
+supports (OpenSSL: all; GnuTLS: all but `secp256k1`/X-curves; MbedTLS: EC/RSA;
+`oct` everywhere); an unsupported request returns a clean error rather than a
+weak or partial key.
+
 #### JWE
 
 LibJWT supports JWE (RFC 7516) in both the Compact Serialization and the JSON

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -2662,6 +2662,54 @@ JWT_EXPORT
 jwk_set_t *jwks_create_fromkey_file(const char *file_name, unsigned int flags);
 
 /**
+ * @brief Generate a new key and add it to a keyring as a JWK
+ *
+ * Generates a fresh key of type @p kty and appends it to @p jwk_set as a new
+ * ::jwk_item_t (a private JWK), returning the set. Pass NULL for @p jwk_set to
+ * create a new keyring. The generated key is bound to the active crypto backend,
+ * so it can be used directly for signing/verifying or JWE.
+ *
+ * @p param selects the key geometry, interpreted by @p kty (NULL or "" picks a
+ * sensible default):
+ *  - EC: the curve — ``"P-256"`` (default), ``"P-384"``, ``"P-521"``, ``"secp256k1"``
+ *  - OKP: the curve — ``"Ed25519"`` (default), ``"Ed448"``, ``"X25519"``, ``"X448"``
+ *  - RSA: the modulus size in bits — ``"2048"`` (default), ``"3072"``, ``"4096"``
+ *  - oct: the key size in bits — ``"256"`` (default), ``"384"``, ``"512"``
+ *  - AKP (ML-DSA): ignored (the variant comes from @p alg)
+ *
+ * @p alg is the JWA discriminator. It is optional for EC/OKP/oct (it stamps the
+ * JWK ``"alg"``), distinguishes RSA (``RS*``) from RSA-PSS (``PS*``) for
+ * ``kty=RSA``, and is REQUIRED for AKP to pin the ML-DSA variant
+ * (``JWT_ALG_ML_DSA_44/65/87``). Pass ::JWT_ALG_NONE for none. It must be
+ * compatible with @p kty.
+ *
+ * @p flags is a bitwise OR of ::jwk_key_flags_t; ::JWK_KEY_GEN_KID stamps the
+ * RFC 7638 thumbprint as the ``"kid"``.
+ *
+ * A backend that cannot generate the requested key (e.g. MbedTLS has no EdDSA)
+ * does not crash: the appended item carries an error (jwks_item_error()).
+ *
+ * @param jwk_set A keyring to append to, or NULL to create a new one
+ * @param kty The key type to generate
+ * @param param The key geometry selector (see above), or NULL for the default
+ * @param alg The JWA algorithm discriminator, or ::JWT_ALG_NONE
+ * @param flags A bitwise OR of ::jwk_key_flags_t values (or ::JWK_KEY_NONE)
+ * @return The keyring with the new key appended, or NULL on allocation failure
+ * @since 3.6.0
+ */
+JWT_EXPORT
+jwk_set_t *jwks_generate(jwk_set_t *jwk_set, jwk_key_type_t kty,
+			 const char *param, jwt_alg_t alg, unsigned int flags);
+
+/**
+ * @brief Wrapper around jwks_generate() that explicitly creates a new keyring
+ * @since 3.6.0
+ */
+JWT_EXPORT
+jwk_set_t *jwks_create_generate(jwk_key_type_t kty, const char *param,
+				jwt_alg_t alg, unsigned int flags);
+
+/**
  * @brief Check if there is an error with a jwk_set
  *
  * An Error in a jwk_set is usually passive and generally means there was an

--- a/libjwt/gnutls/jwk-parse.c
+++ b/libjwt/gnutls/jwk-parse.c
@@ -737,3 +737,98 @@ void gnutls_process_item_free(jwk_item_t *item)
 	item->provider_data = NULL;
 	item->provider = JWT_CRYPTO_OPS_NONE;
 }
+
+/* Generate a fresh asymmetric key and emit it as a PKCS#8 private-key PEM.
+ * EC (NIST), RSA/RSA-PSS, OKP, and AKP (ML-DSA) are supported subject to the
+ * GnuTLS version; secp256k1 is not supported by GnuTLS. */
+int gnutls_generate_pem(jwk_key_type_t kty, const char *param, jwt_alg_t alg,
+			char **pem_out, size_t *pem_len)
+{
+	gnutls_x509_privkey_t key = NULL;
+	gnutls_datum_t out = { NULL, 0 };
+	gnutls_pk_algorithm_t pk;
+	unsigned int bits = 0;
+	int ret = 1;
+
+	switch (kty) {
+	case JWK_KEY_TYPE_EC: {
+		gnutls_ecc_curve_t curve =
+			ec_crv_to_curve((param && param[0]) ? param : "P-256");
+
+		if (curve != GNUTLS_ECC_CURVE_SECP256R1 &&
+		    curve != GNUTLS_ECC_CURVE_SECP384R1 &&
+		    curve != GNUTLS_ECC_CURVE_SECP521R1)
+			return 1;	/* incl. secp256k1: unsupported by GnuTLS */
+		pk = GNUTLS_PK_ECDSA;
+		bits = GNUTLS_CURVE_TO_BITS(curve);
+		break;
+	}
+	case JWK_KEY_TYPE_OKP: {
+		const char *crv = (param && param[0]) ? param : "Ed25519";
+
+		/* GnuTLS < 3.8.13 has OKP generation/import defects (see #320). */
+		if (gnutls_check_version("3.8.13") == NULL)
+			return 1;
+		if (!strcmp(crv, "Ed25519"))
+			pk = GNUTLS_PK_EDDSA_ED25519;
+		else if (!strcmp(crv, "Ed448"))
+			pk = GNUTLS_PK_EDDSA_ED448;
+		else if (!strcmp(crv, "X25519"))
+			pk = GNUTLS_PK_ECDH_X25519;
+		else if (!strcmp(crv, "X448"))
+			pk = GNUTLS_PK_ECDH_X448;
+		else
+			return 1;
+		bits = GNUTLS_CURVE_TO_BITS(ec_crv_to_curve(crv));
+		break;
+	}
+	case JWK_KEY_TYPE_RSA: {
+		long b = (param && param[0]) ? strtol(param, NULL, 10) : 2048;
+
+		if (b < 2048)
+			return 1;
+		pk = (alg == JWT_ALG_PS256 || alg == JWT_ALG_PS384 ||
+		      alg == JWT_ALG_PS512) ? GNUTLS_PK_RSA_PSS : GNUTLS_PK_RSA;
+		bits = (unsigned int)b;
+		break;
+	}
+#if defined(LIBJWT_HAVE_ML_DSA) && GNUTLS_VERSION_NUMBER >= 0x03080a
+	case JWK_KEY_TYPE_AKP:
+		if (gnutls_check_version("3.8.10") == NULL)
+			return 1;
+		pk = (alg == JWT_ALG_ML_DSA_44) ? GNUTLS_PK_MLDSA44 :
+		     (alg == JWT_ALG_ML_DSA_65) ? GNUTLS_PK_MLDSA65 :
+		     (alg == JWT_ALG_ML_DSA_87) ? GNUTLS_PK_MLDSA87 :
+		     GNUTLS_PK_UNKNOWN;
+		if (pk == GNUTLS_PK_UNKNOWN)
+			return 1;
+		break;
+#endif
+	default:
+		return 1;
+	}
+
+	if (gnutls_x509_privkey_init(&key))
+		return 1; // LCOV_EXCL_LINE
+	if (gnutls_x509_privkey_generate(key, pk, bits, 0))
+		goto out;
+	if (gnutls_x509_privkey_export2_pkcs8(key, GNUTLS_X509_FMT_PEM, NULL,
+					      0, &out))
+		goto out; // LCOV_EXCL_LINE
+
+	*pem_out = jwt_malloc((size_t)out.size + 1);
+	if (*pem_out == NULL)
+		goto out; // LCOV_EXCL_LINE
+	memcpy(*pem_out, out.data, out.size);
+	(*pem_out)[out.size] = '\0';
+	*pem_len = out.size;
+	ret = 0;
+
+out:
+	if (out.data != NULL)
+		gnutls_free(out.data);
+	if (key != NULL)
+		gnutls_x509_privkey_deinit(key);
+
+	return ret;
+}

--- a/libjwt/gnutls/jwt-gnutls.h
+++ b/libjwt/gnutls/jwt-gnutls.h
@@ -39,6 +39,8 @@ void gnutls_process_item_free(jwk_item_t *item);
 /* Native-key -> JWK conversion (the key2jwk_params op); see jwk-export.c. */
 JWT_NO_EXPORT
 int gnutls_key2jwk_params(const char *key, size_t len, jwk_export_t *out);
+JWT_NO_EXPORT
+int gnutls_generate_pem(jwk_key_type_t kty, const char *param, jwt_alg_t alg, char **pem_out, size_t *pem_len);
 
 /* JWE (RFC 7516/7518) — native GnuTLS implementations. Backend internals
  * reached only through the jwt_crypto_ops table; keep out of ABI. */

--- a/libjwt/gnutls/sign-verify.c
+++ b/libjwt/gnutls/sign-verify.c
@@ -502,6 +502,7 @@ struct jwt_crypto_ops jwt_gnutls_ops = {
 	.process_item_free	= gnutls_process_item_free,
 	/* Native-key -> JWK conversion, done natively by GnuTLS. */
 	.key2jwk_params		= gnutls_key2jwk_params,
+	.generate_pem		= gnutls_generate_pem,
 
 	.sha			= gnutls_sha,
 

--- a/libjwt/jwk-export.c
+++ b/libjwt/jwk-export.c
@@ -28,7 +28,7 @@
  * when JWK_KEY_GEN_KID is requested. @jwk must already carry the key's members
  * (its kty plus the type's public parameters). A no-op if the thumbprint
  * cannot be computed (e.g. a key missing a required public member). */
-static void gen_kid(jwt_json_t *jwk, jwk_key_type_t kty, unsigned int flags)
+void jwt_gen_kid(jwt_json_t *jwk, jwk_key_type_t kty, unsigned int flags)
 {
 	char_auto *tp = NULL;
 
@@ -132,7 +132,7 @@ int jwt_key2jwk(const char *key, size_t len, unsigned int flags,
 	if (r != 0) {
 		jwk_export_clear(&kp);
 		process_hmac_key(jwk, (const unsigned char *)key, len);
-		gen_kid(jwk, JWK_KEY_TYPE_OCT, flags);
+		jwt_gen_kid(jwk, JWK_KEY_TYPE_OCT, flags);
 		jwt_json_arr_append(out_array, jwk);
 		return 0;
 	}
@@ -166,7 +166,7 @@ int jwt_key2jwk(const char *key, size_t len, unsigned int flags,
 		}
 	}
 
-	gen_kid(jwk, kp.kty, flags);
+	jwt_gen_kid(jwk, kp.kty, flags);
 
 	jwk_export_clear(&kp);
 	jwt_json_arr_append(out_array, jwk);

--- a/libjwt/jwks.c
+++ b/libjwt/jwks.c
@@ -712,6 +712,150 @@ jwk_set_t *jwks_create_fromkey_file(const char *file_name, unsigned int flags)
 	return jwks_load_fromkey_file(NULL, file_name, flags);
 }
 
+/* Set a string member (helper for the generated-oct JWK). 0 on success. */
+static int jwk_set_str(jwt_json_t *obj, const char *key, const char *val)
+{
+	jwt_json_t *v = jwt_json_create_str(val);
+
+	if (v == NULL || jwt_json_obj_set(obj, key, v))
+		return 1; // LCOV_EXCL_LINE
+
+	return 0;
+}
+
+/* Generate a symmetric "oct" key: CSPRNG bytes -> {kty:oct, k, [alg]} -> the
+ * normal load path (process_octet, provider=ANY). Bits from @param or @alg. */
+static void jwks_generate_oct(jwk_set_t *jwk_set, const char *param,
+			      jwt_alg_t alg, unsigned int flags)
+{
+	jwt_json_auto_t *arr = NULL;
+	jwt_json_t *jwk;
+	unsigned char *buf = NULL;
+	char_auto *b64 = NULL;
+	long bits;
+	int blen;
+
+	if (param != NULL && param[0] != '\0') {
+		char *end;
+
+		bits = strtol(param, &end, 10);
+		if (*end != '\0') {
+			jwt_write_error(jwk_set, "Invalid oct key size [%s]", param);
+			return;
+		}
+	} else {
+		bits = (alg == JWT_ALG_HS384) ? 384 :
+		       (alg == JWT_ALG_HS512) ? 512 : 256;
+	}
+
+	if (bits < 112 || bits % 8) {
+		jwt_write_error(jwk_set,
+			"oct key size must be a multiple of 8 and >= 112");
+		return;
+	}
+
+	buf = jwt_malloc((size_t)bits / 8);
+	if (buf == NULL)
+		return; // LCOV_EXCL_LINE
+	if (jwt_ops->rng == NULL || jwt_ops->rng(buf, (size_t)bits / 8)) {
+		// LCOV_EXCL_START
+		jwt_scrub_and_free(buf, (size_t)bits / 8);
+		jwt_write_error(jwk_set, "Random generation failed");
+		return;
+		// LCOV_EXCL_STOP
+	}
+
+	blen = jwt_base64uri_encode(&b64, (char *)buf, (int)(bits / 8));
+	jwt_scrub_and_free(buf, (size_t)bits / 8);
+	if (blen <= 0)
+		return; // LCOV_EXCL_LINE
+
+	arr = jwt_json_create_arr();
+	jwk = jwt_json_create();
+	if (arr == NULL || jwk == NULL || jwt_json_arr_append(arr, jwk))
+		return; // LCOV_EXCL_LINE
+
+	if (jwk_set_str(jwk, "kty", "oct") || jwk_set_str(jwk, "k", b64) ||
+	    (alg != JWT_ALG_NONE && jwk_set_str(jwk, "alg", jwt_alg_str(alg))))
+		return; // LCOV_EXCL_LINE
+
+	jwt_gen_kid(jwk, JWK_KEY_TYPE_OCT, flags);
+	jwks_process_array(jwk_set, arr);
+}
+
+jwk_set_t *jwks_generate(jwk_set_t *jwk_set, jwk_key_type_t kty,
+			 const char *param, jwt_alg_t alg, unsigned int flags)
+{
+	jwt_json_auto_t *arr = NULL;
+	char *pem = NULL;
+	size_t pem_len = 0;
+
+	if (jwk_set == NULL)
+		jwk_set = jwks_new();
+	if (jwk_set == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	/* Anti-confusion: a stated alg must match the key type (GHSA-q843...). */
+	if (alg != JWT_ALG_NONE && jwt_alg_required_kty(alg) != kty) {
+		jwt_write_error(jwk_set,
+			"Algorithm does not match the requested key type");
+		return jwk_set;
+	}
+
+	if (kty == JWK_KEY_TYPE_OCT) {
+		jwks_generate_oct(jwk_set, param, alg, flags);
+		return jwk_set;
+	}
+
+	/* Asymmetric: generate a native key (PEM) via the active backend, then
+	 * run the existing key2jwk -> load pipeline (binds provider_data). */
+	if (jwt_ops->generate_pem == NULL) {
+		jwt_write_error(jwk_set,
+			"Key generation is not supported by the %s backend",
+			jwt_ops->name);
+		return jwk_set;
+	}
+
+	if (jwt_ops->generate_pem(kty, param, alg, &pem, &pem_len) || pem == NULL) {
+		jwt_write_error(jwk_set,
+			"Could not generate a key for the requested type");
+		jwt_scrub_and_free(pem, pem_len);
+		return jwk_set;
+	}
+
+	arr = jwt_json_create_arr();
+	if (arr == NULL) {
+		jwt_scrub_and_free(pem, pem_len); // LCOV_EXCL_LINE
+		return jwk_set; // LCOV_EXCL_LINE
+	}
+
+	if (jwt_key2jwk(pem, pem_len, flags, arr)) {
+		jwt_write_error(jwk_set, "Could not export the generated key");
+		jwt_scrub_and_free(pem, pem_len);
+		return jwk_set;
+	}
+	jwt_scrub_and_free(pem, pem_len);
+
+	/* Record the caller's alg (the in-key PEM cannot encode PS384/PS512 vs
+	 * PS256, and pins the ML-DSA variant) before parsing it into an item. */
+	if (alg != JWT_ALG_NONE) {
+		jwt_json_t *jwk0 = jwt_json_arr_get(arr, 0);
+
+		if (jwk0 != NULL && jwk_set_str(jwk0, "alg", jwt_alg_str(alg)))
+			return jwk_set; // LCOV_EXCL_LINE
+	}
+
+	jwks_process_array(jwk_set, arr);
+
+	return jwk_set;
+}
+
+jwk_set_t *jwks_create_generate(jwk_key_type_t kty, const char *param,
+				jwt_alg_t alg, unsigned int flags)
+{
+	return jwks_generate(NULL, kty, param, alg, flags);
+}
+
 /* The private members for each key type, used to strip a JWK down to its
  * public form. The returned array is NULL-terminated. */
 static const char **jwk_priv_members(jwk_key_type_t kty)

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -369,6 +369,16 @@ struct jwt_crypto_ops {
 	 * native keys at all. */
 	int (*key2jwk_params)(const char *key, size_t len, jwk_export_t *out);
 
+	/* Generate a fresh ASYMMETRIC key (EC/RSA/RSA-PSS/OKP/AKP) of type @kty
+	 * with the geometry in @param and the discriminator @alg, emitting an
+	 * unencrypted PKCS#8 private-key PEM into *@pem_out (jwt_malloc'd; the
+	 * common jwks_generate() scrubs+frees it and runs it through jwt_key2jwk).
+	 * Returns 0 on success, non-zero on an unsupported type/param/curve or a
+	 * runtime-incapable backend. NULL if the backend cannot generate keys.
+	 * "oct" is generated in common code (jwt_ops->rng), not here. */
+	int (*generate_pem)(jwk_key_type_t kty, const char *param, jwt_alg_t alg,
+			    char **pem_out, size_t *pem_len);
+
 	/* One-shot SHA-2 digest. @sha_bits selects the hash (256/384/512).
 	 * Writes the raw digest into @out (the caller provides a buffer of at
 	 * least 64 bytes) and sets *@out_len. Returns 0 on success. Backed by
@@ -522,6 +532,11 @@ static inline void jwk_export_add(jwk_export_t *out, const char *name,
 JWT_NO_EXPORT
 int jwt_key2jwk(const char *key, size_t len, unsigned int flags,
 		jwt_json_t *out_array);
+
+/* @rfc{7638} Stamp the thumbprint "kid" on @jwk when JWK_KEY_GEN_KID is in
+ * @flags (used by jwt_key2jwk and the oct path of jwks_generate). */
+JWT_NO_EXPORT
+void jwt_gen_kid(jwt_json_t *jwk, jwk_key_type_t kty, unsigned int flags);
 
 /* Core @rfc{7638} JWK thumbprint: base64url(SHA-@bits) over the canonical JWK
  * assembled from @jwk's required members for key type @kty. @bits is 256/384/512.

--- a/libjwt/mbedtls/jwk-parse.c
+++ b/libjwt/mbedtls/jwk-parse.c
@@ -789,6 +789,9 @@ int mbedtls_generate_pem(jwk_key_type_t kty, const char *param, jwt_alg_t alg,
 		}
 	}
 
+	/* The buffer held an unencrypted private key; scrub it (see the same
+	 * convention in set_pem_best_effort()). */
+	mbedtls_platform_zeroize(buf, sizeof(buf));
 	mbedtls_pk_free(&pk);
 	psa_destroy_key(kid);
 

--- a/libjwt/mbedtls/jwk-parse.c
+++ b/libjwt/mbedtls/jwk-parse.c
@@ -715,3 +715,82 @@ void mbedtls_process_item_free(jwk_item_t *item)
 	item->provider_data = NULL;
 	item->provider = JWT_CRYPTO_OPS_NONE;
 }
+
+/* Generate a fresh EC or RSA key via PSA and emit it as a PKCS#8 private-key
+ * PEM (via mbedtls_pk). MbedTLS has no EdDSA (OKP) or ML-DSA (AKP), so those
+ * return non-zero -> a clean "not supported" error. */
+int mbedtls_generate_pem(jwk_key_type_t kty, const char *param, jwt_alg_t alg,
+			 char **pem_out, size_t *pem_len)
+{
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	mbedtls_svc_key_id_t kid = MBEDTLS_SVC_KEY_ID_INIT;
+	mbedtls_pk_context pk;
+	unsigned char buf[8192];
+	psa_status_t st;
+	int ret = 1;
+
+	(void)alg;
+
+	if (psa_crypto_init() != PSA_SUCCESS)
+		return 1; // LCOV_EXCL_LINE
+
+	switch (kty) {
+	case JWK_KEY_TYPE_EC: {
+		const char *crv = (param && param[0]) ? param : "P-256";
+		psa_ecc_family_t fam = PSA_ECC_FAMILY_SECP_R1;
+		size_t bits;
+
+		if (!strcmp(crv, "P-256"))		bits = 256;
+		else if (!strcmp(crv, "P-384"))		bits = 384;
+		else if (!strcmp(crv, "P-521"))		bits = 521;
+		else if (!strcmp(crv, "secp256k1")) {
+			fam = PSA_ECC_FAMILY_SECP_K1;
+			bits = 256;
+		} else
+			return 1;
+
+		psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR(fam));
+		psa_set_key_bits(&attr, bits);
+		psa_set_key_algorithm(&attr, PSA_ALG_ECDSA(PSA_ALG_ANY_HASH));
+		break;
+	}
+	case JWK_KEY_TYPE_RSA: {
+		long bits = (param && param[0]) ? strtol(param, NULL, 10) : 2048;
+
+		if (bits < 2048)
+			return 1;
+		psa_set_key_type(&attr, PSA_KEY_TYPE_RSA_KEY_PAIR);
+		psa_set_key_bits(&attr, (size_t)bits);
+		psa_set_key_algorithm(&attr, PSA_ALG_RSA_PSS(PSA_ALG_ANY_HASH));
+		break;
+	}
+	default:
+		return 1;
+	}
+
+	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_EXPORT |
+				PSA_KEY_USAGE_SIGN_HASH | PSA_KEY_USAGE_VERIFY_HASH);
+
+	st = psa_generate_key(&attr, &kid);
+	psa_reset_key_attributes(&attr);
+	if (st != PSA_SUCCESS)
+		return 1;
+
+	mbedtls_pk_init(&pk);
+	if (mbedtls_pk_copy_from_psa(kid, &pk) == 0 &&
+	    mbedtls_pk_write_key_pem(&pk, buf, sizeof(buf)) == 0) {
+		size_t len = strlen((char *)buf);
+
+		*pem_out = jwt_malloc(len + 1);
+		if (*pem_out != NULL) {
+			memcpy(*pem_out, buf, len + 1);
+			*pem_len = len;
+			ret = 0;
+		}
+	}
+
+	mbedtls_pk_free(&pk);
+	psa_destroy_key(kid);
+
+	return ret;
+}

--- a/libjwt/mbedtls/jwt-mbedtls.h
+++ b/libjwt/mbedtls/jwt-mbedtls.h
@@ -67,6 +67,8 @@ void mbedtls_process_item_free(jwk_item_t *item);
  * MbedTLS via mbedtls_pk + PSA. Backend internal; keep out of ABI. */
 JWT_NO_EXPORT
 int mbedtls_key2jwk_params(const char *key, size_t len, jwk_export_t *out);
+JWT_NO_EXPORT
+int mbedtls_generate_pem(jwk_key_type_t kty, const char *param, jwt_alg_t alg, char **pem_out, size_t *pem_len);
 
 /* JWE (RFC 7516/7518) — native MbedTLS implementations. */
 JWT_NO_EXPORT

--- a/libjwt/mbedtls/sign-verify.c
+++ b/libjwt/mbedtls/sign-verify.c
@@ -271,6 +271,7 @@ struct jwt_crypto_ops jwt_mbedtls_ops = {
 	.process_item_free	= mbedtls_process_item_free,
 	/* Native-key -> JWK conversion, done natively by MbedTLS. */
 	.key2jwk_params		= mbedtls_key2jwk_params,
+	.generate_pem		= mbedtls_generate_pem,
 
 	.sha			= mbedtls_sha,
 

--- a/libjwt/openssl/jwk-parse.c
+++ b/libjwt/openssl/jwk-parse.c
@@ -669,3 +669,110 @@ void openssl_process_item_free(jwk_item_t *item)
 	item->provider_data = NULL;
 	item->provider = JWT_CRYPTO_OPS_NONE;
 }
+
+/* @rfc — Generate a fresh asymmetric key of @kty/@param/@alg and emit it as an
+ * unencrypted PKCS#8 private-key PEM. EC/RSA/RSA-PSS/OKP supported; AKP (ML-DSA)
+ * generation is not yet implemented here (returns non-zero -> clean error). */
+int openssl_generate_pem(jwk_key_type_t kty, const char *param, jwt_alg_t alg,
+			 char **pem_out, size_t *pem_len)
+{
+	EVP_PKEY_CTX *ctx = NULL;
+	EVP_PKEY *pkey = NULL;
+	BIO *bio = NULL;
+	char *data;
+	long n;
+	int ret = 1;
+
+	switch (kty) {
+	case JWK_KEY_TYPE_EC: {
+		const char *crv = (param && param[0]) ? param : "P-256";
+		const char *ossl;
+
+		if (!strcmp(crv, "P-256"))		ossl = "prime256v1";
+		else if (!strcmp(crv, "P-384"))		ossl = "secp384r1";
+		else if (!strcmp(crv, "P-521"))		ossl = "secp521r1";
+		else if (!strcmp(crv, "secp256k1"))	ossl = "secp256k1";
+		else return 1;
+
+		ctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL);
+		if (ctx == NULL || EVP_PKEY_keygen_init(ctx) <= 0)
+			goto out; // LCOV_EXCL_LINE
+		if (EVP_PKEY_CTX_set_group_name(ctx, ossl) <= 0)
+			goto out; // LCOV_EXCL_LINE
+		break;
+	}
+	case JWK_KEY_TYPE_OKP: {
+		const char *crv = (param && param[0]) ? param : "Ed25519";
+
+		if (strcmp(crv, "Ed25519") && strcmp(crv, "Ed448") &&
+		    strcmp(crv, "X25519") && strcmp(crv, "X448"))
+			return 1;
+		ctx = EVP_PKEY_CTX_new_from_name(NULL, crv, NULL);
+		if (ctx == NULL || EVP_PKEY_keygen_init(ctx) <= 0)
+			goto out; // LCOV_EXCL_LINE
+		break;
+	}
+	case JWK_KEY_TYPE_RSA: {
+		int is_pss = (alg == JWT_ALG_PS256 || alg == JWT_ALG_PS384 ||
+			      alg == JWT_ALG_PS512);
+		long bits = (param && param[0]) ? strtol(param, NULL, 10) : 2048;
+
+		if (bits < 2048)
+			return 1;
+		ctx = EVP_PKEY_CTX_new_from_name(NULL, is_pss ? "RSA-PSS" : "RSA",
+						 NULL);
+		if (ctx == NULL || EVP_PKEY_keygen_init(ctx) <= 0)
+			goto out; // LCOV_EXCL_LINE
+		if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, (int)bits) <= 0)
+			goto out; // LCOV_EXCL_LINE
+		break;
+	}
+#if defined(LIBJWT_HAVE_ML_DSA) && OPENSSL_VERSION_NUMBER >= 0x30500000L
+	case JWK_KEY_TYPE_AKP: {
+		const char *name = (alg == JWT_ALG_ML_DSA_44) ? "ML-DSA-44" :
+				   (alg == JWT_ALG_ML_DSA_65) ? "ML-DSA-65" :
+				   (alg == JWT_ALG_ML_DSA_87) ? "ML-DSA-87" : NULL;
+
+		if (name == NULL)
+			return 1;
+		ctx = EVP_PKEY_CTX_new_from_name(NULL, name, NULL);
+		if (ctx == NULL || EVP_PKEY_keygen_init(ctx) <= 0)
+			goto out; // LCOV_EXCL_LINE
+		break;
+	}
+#endif
+	default:
+		return 1;
+	}
+
+	if (EVP_PKEY_keygen(ctx, &pkey) <= 0)
+		goto out; // LCOV_EXCL_LINE
+
+	bio = BIO_new(BIO_s_mem());
+	if (bio == NULL)
+		goto out; // LCOV_EXCL_LINE
+	if (!PEM_write_bio_PKCS8PrivateKey(bio, pkey, NULL, NULL, 0, NULL, NULL))
+		goto out; // LCOV_EXCL_LINE
+
+	n = BIO_get_mem_data(bio, &data);
+	if (n <= 0)
+		goto out; // LCOV_EXCL_LINE
+
+	*pem_out = jwt_malloc((size_t)n + 1);
+	if (*pem_out == NULL)
+		goto out; // LCOV_EXCL_LINE
+	memcpy(*pem_out, data, (size_t)n);
+	(*pem_out)[n] = '\0';
+	*pem_len = (size_t)n;
+	ret = 0;
+
+out:
+	if (bio != NULL)
+		BIO_free(bio);
+	if (pkey != NULL)
+		EVP_PKEY_free(pkey);
+	if (ctx != NULL)
+		EVP_PKEY_CTX_free(ctx);
+
+	return ret;
+}

--- a/libjwt/openssl/jwt-openssl.h
+++ b/libjwt/openssl/jwt-openssl.h
@@ -18,6 +18,9 @@ int openssl_process_ec(jwt_json_t *jwk, jwk_item_t *item);
 void openssl_process_item_free(jwk_item_t *item);
 JWT_NO_EXPORT
 int openssl_key2jwk_params(const char *key, size_t len, jwk_export_t *out);
+JWT_NO_EXPORT
+int openssl_generate_pem(jwk_key_type_t kty, const char *param, jwt_alg_t alg,
+			 char **pem_out, size_t *pem_len);
 
 /* JWE (RFC 7516/7518). These are backend internals reached only through the
  * jwt_crypto_ops table, so they must stay out of the shared library's ABI. */

--- a/libjwt/openssl/sign-verify.c
+++ b/libjwt/openssl/sign-verify.c
@@ -492,6 +492,7 @@ struct jwt_crypto_ops jwt_openssl_ops = {
 	.process_ec		= openssl_process_ec,
 	.process_item_free	= openssl_process_item_free,
 	.key2jwk_params		= openssl_key2jwk_params,
+	.generate_pem		= openssl_generate_pem,
 
 	.sha			= openssl_sha,
 

--- a/tests/jwt_generate.c
+++ b/tests/jwt_generate.c
@@ -1,0 +1,175 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* jwks_generate() key generation (issue #311). Runs under each compiled crypto
+ * backend (SET_OPS) and both JSON backends. Backends differ in capability
+ * (MbedTLS has no EdDSA/ML-DSA; GnuTLS no secp256k1/X-curves), so the
+ * "optional" types are probed: a clean error is accepted, a success is verified.
+ */
+
+/* Generate, then (for a signing alg) round-trip sign+verify the new key.
+ * Returns 1 if generated OK, 0 if the backend reported it unsupported. */
+static int gen_check(jwk_key_type_t kty, const char *param, jwt_alg_t alg,
+		     unsigned int flags, int can_sign)
+{
+	jwk_set_t *set;
+	const jwk_item_t *k;
+	int ok;
+
+	set = jwks_create_generate(kty, param, alg, flags);
+	ck_assert_ptr_nonnull(set);
+
+	k = jwks_item_get(set, 0);
+	if (k == NULL || jwks_item_error(k)) {
+		/* Capability-gated on this backend: must be a clean error. */
+		ck_assert(jwks_error(set) || (k && jwks_item_error(k)));
+		jwks_free(set);
+		return 0;
+	}
+
+	ck_assert_int_eq(jwks_item_kty(k), kty);
+	ck_assert_int_eq(jwks_item_is_private(k), 1);
+
+	if (flags & JWK_KEY_GEN_KID)
+		ck_assert_ptr_nonnull(jwks_item_kid(k));
+	else
+		ck_assert_ptr_null(jwks_item_kid(k));
+
+	if (can_sign) {
+		jwt_builder_auto_t *b = jwt_builder_new();
+		jwt_checker_auto_t *c = jwt_checker_new();
+		char_auto *tok = NULL;
+
+		ck_assert_int_eq(jwt_builder_setkey(b, alg, k), 0);
+		tok = jwt_builder_generate(b);
+		ck_assert_ptr_nonnull(tok);
+		ck_assert_int_eq(jwt_checker_setkey(c, alg, k), 0);
+		ck_assert_int_eq(jwt_checker_verify(c, tok), 0);
+	}
+
+	ok = 1;
+	jwks_free(set);
+
+	return ok;
+}
+
+/* Core types every backend must support. */
+START_TEST(test_generate_core)
+{
+	SET_OPS();
+
+	ck_assert_int_eq(gen_check(JWK_KEY_TYPE_EC, "P-256", JWT_ALG_ES256,
+				   JWK_KEY_GEN_KID, 1), 1);
+	ck_assert_int_eq(gen_check(JWK_KEY_TYPE_EC, "P-384", JWT_ALG_ES384,
+				   JWK_KEY_GEN_KID, 1), 1);
+	ck_assert_int_eq(gen_check(JWK_KEY_TYPE_EC, "P-521", JWT_ALG_ES512,
+				   JWK_KEY_GEN_KID, 1), 1);
+	ck_assert_int_eq(gen_check(JWK_KEY_TYPE_RSA, "2048", JWT_ALG_RS256,
+				   JWK_KEY_GEN_KID, 1), 1);
+	ck_assert_int_eq(gen_check(JWK_KEY_TYPE_RSA, "2048", JWT_ALG_PS256,
+				   JWK_KEY_GEN_KID, 1), 1);
+	/* The in-key PEM cannot encode PS384 vs PS256; the override must stick. */
+	ck_assert_int_eq(gen_check(JWK_KEY_TYPE_RSA, "3072", JWT_ALG_PS384,
+				   0, 1), 1);
+	ck_assert_int_eq(gen_check(JWK_KEY_TYPE_OCT, "256", JWT_ALG_HS256,
+				   JWK_KEY_GEN_KID, 1), 1);
+	ck_assert_int_eq(gen_check(JWK_KEY_TYPE_OCT, "512", JWT_ALG_HS512,
+				   0, 1), 1);
+}
+END_TEST
+
+/* Capability-dependent types: a clean error or a verified key, never a crash. */
+START_TEST(test_generate_optional)
+{
+	SET_OPS();
+
+	gen_check(JWK_KEY_TYPE_EC, "secp256k1", JWT_ALG_ES256K, JWK_KEY_GEN_KID, 1);
+	gen_check(JWK_KEY_TYPE_OKP, "Ed25519", JWT_ALG_EDDSA, JWK_KEY_GEN_KID, 1);
+	gen_check(JWK_KEY_TYPE_OKP, "Ed448", JWT_ALG_EDDSA, 0, 1);
+	gen_check(JWK_KEY_TYPE_OKP, "X25519", JWT_ALG_NONE, 0, 0);
+	/* AKP/ML-DSA where a capable backend (OpenSSL >= 3.5 / GnuTLS+leancrypto)
+	 * is present; a clean error elsewhere. */
+	gen_check(JWK_KEY_TYPE_AKP, NULL, JWT_ALG_ML_DSA_44, JWK_KEY_GEN_KID, 1);
+	gen_check(JWK_KEY_TYPE_AKP, NULL, JWT_ALG_ML_DSA_65, 0, 1);
+	gen_check(JWK_KEY_TYPE_AKP, NULL, JWT_ALG_ML_DSA_87, 0, 1);
+}
+END_TEST
+
+/* Bad requests are rejected cleanly (with an error set), never silently. */
+START_TEST(test_generate_errors)
+{
+	struct { jwk_key_type_t kty; const char *param; jwt_alg_t alg; } bad[] = {
+		{ JWK_KEY_TYPE_EC,  "P-256", JWT_ALG_RS256 },	/* alg<->kty */
+		{ JWK_KEY_TYPE_RSA, "1024",  JWT_ALG_RS256 },	/* RSA too small */
+		{ JWK_KEY_TYPE_RSA, "huge",  JWT_ALG_RS256 },	/* non-numeric */
+		{ JWK_KEY_TYPE_EC,  "P-999", JWT_ALG_NONE },	/* unknown curve */
+		{ JWK_KEY_TYPE_OCT, "7",     JWT_ALG_NONE },	/* not multiple of 8 */
+		{ JWK_KEY_TYPE_AKP, NULL,    JWT_ALG_NONE },	/* AKP needs a variant */
+	};
+	size_t i;
+
+	SET_OPS();
+
+	for (i = 0; i < ARRAY_SIZE(bad); i++) {
+		jwk_set_t *set = jwks_create_generate(bad[i].kty, bad[i].param,
+						      bad[i].alg, 0);
+		const jwk_item_t *k;
+
+		ck_assert_ptr_nonnull(set);
+		k = jwks_item_get(set, 0);
+		/* Either a set-level error and no item, or an error item. */
+		ck_assert(jwks_error(set) || (k != NULL && jwks_item_error(k)));
+		ck_assert_int_eq(k == NULL || jwks_item_error(k), 1);
+		jwks_free(set);
+	}
+}
+END_TEST
+
+/* Append to an existing keyring rather than replacing it. */
+START_TEST(test_generate_append)
+{
+	jwk_set_t *set;
+
+	SET_OPS();
+
+	set = jwks_create_generate(JWK_KEY_TYPE_EC, "P-256", JWT_ALG_ES256, 0);
+	ck_assert_ptr_nonnull(set);
+	ck_assert_uint_eq(jwks_item_count(set), 1);
+
+	ck_assert_ptr_eq(jwks_generate(set, JWK_KEY_TYPE_RSA, "2048",
+				       JWT_ALG_RS256, 0), set);
+	ck_assert_uint_eq(jwks_item_count(set), 2);
+
+	jwks_free(set);
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+	tc_core = tcase_create("jwt_generate");
+
+	tcase_add_loop_test(tc_core, test_generate_core, 0, i);
+	tcase_add_loop_test(tc_core, test_generate_optional, 0, i);
+	tcase_add_loop_test(tc_core, test_generate_errors, 0, i);
+	tcase_add_loop_test(tc_core, test_generate_append, 0, i);
+
+	tcase_set_timeout(tc_core, 120);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT key generation (#311)");
+}


### PR DESCRIPTION
Closes #311.

Adds a public key-generation API returning a fresh key as a `jwk_item_t` — the most-cited ergonomic gap for a C JOSE library (peers all expose it). Design settled by a 3-way design panel + synthesis.

```c
jwk_set_t *jwks_generate(jwk_set_t *set, jwk_key_type_t kty,
                         const char *param, jwt_alg_t alg, unsigned int flags);
jwk_set_t *jwks_create_generate(jwk_key_type_t kty, const char *param,
                                jwt_alg_t alg, unsigned int flags);   /* set=NULL */
```

- `@param` = key geometry (curve / RSA-or-oct bits; NULL = default); `@alg` = the JWA discriminator (RSA vs RSA-PSS, ML-DSA variant, oct length); `JWK_KEY_GEN_KID` stamps the RFC 7638 thumbprint `kid`. The key is bound to the active backend — signs/verifies immediately.

### Internals
A new per-backend `generate_pem` crypto-op emits an unencrypted PKCS#8 PEM; common code runs it through the **existing** `jwt_key2jwk` → `jwks_process_array` pipeline (sets `provider_data` + JWK members for free). `oct` is generated in common code via the CSPRNG (`provider=ANY`, every backend).

### Backend coverage (all three, as agreed)
| | OpenSSL | GnuTLS | MbedTLS |
|---|---|---|---|
| EC (P-256/384/521) | ✅ | ✅ | ✅ |
| secp256k1 | ✅ | — | ✅ |
| RSA / RSA-PSS | ✅ | ✅ | ✅ |
| OKP Ed25519/Ed448 | ✅ | ✅ | — |
| OKP X25519/X448 | ✅ | — | — |
| AKP (ML-DSA) | ✅ | ✅ | — |
| oct | ✅ | ✅ | ✅ |

An unsupported `(kty, backend)` pair returns a **clean error** (no crash); the `jwt_alg_required_kty` anti-confusion gate rejects mismatches; RSA floor 2048; the caller's `alg` is recorded so PS384/PS512 and the ML-DSA variant survive.

### Tests — `tests/jwt_generate.c` (both JSON backends, all crypto backends)
Core types (EC/RSA/RSA-PSS/oct) generate + round-trip sign/verify everywhere; optional types probed (verified where supported, clean error otherwise); bad requests rejected; append-to-keyring; kid. **32/32** pass locally (MbedTLS 4.1) and in the CI image (MbedTLS 3.6.6 + leancrypto, so GnuTLS ML-DSA keygen is real); **valgrind-clean**. `@since 3.6.0`; README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
