### PR TITLE
jwe: AES-GCM Key Wrap (A128/192/256GCMKW, RFC 7518 4.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,7 +430,7 @@ if (CHECK_FOUND)
 
 	# JWE
 	list (APPEND UNIT_TESTS jwe_foundation jwe_keys jwe_gcm jwe_cbc
-		jwe_aeskw jwe_rsa jwe_ecdh jwe_json jwe_aad jwe_multi
+		jwe_aeskw jwe_gcmkw jwe_rsa jwe_ecdh jwe_json jwe_aad jwe_multi
 		jwe_json_neg)
 
 	# Claims

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ JWE key management ``alg``    | OpenSSL            | GnuTLS             | MbedTL
 :---------------------------- | :----------------- | :----------------- | :-----------------
 ``dir`` (Direct Encryption)   | :white_check_mark: | :white_check_mark: | :white_check_mark:
 ``A128KW`` ``A192KW`` ``A256KW`` | :white_check_mark: | :white_check_mark: | :white_check_mark:
+``A128GCMKW`` ``A192GCMKW`` ``A256GCMKW`` | :white_check_mark: | :white_check_mark: | :white_check_mark:
 ``RSA-OAEP`` (SHA-1)          | :white_check_mark: | :x:                | :white_check_mark:
 ``RSA-OAEP-256``              | :white_check_mark: | :white_check_mark: | :white_check_mark:
 ``ECDH-ES`` (+ ``+A128KW``/``+A192KW``/``+A256KW``) [^okp3813] | :white_check_mark: | :white_check_mark: | :white_check_mark:

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -113,6 +113,9 @@ typedef enum {
 	JWE_ALG_ECDH_ES_A128KW,	/**< ECDH-ES using Concat KDF and CEK wrapped with A128KW */
 	JWE_ALG_ECDH_ES_A192KW,	/**< ECDH-ES using Concat KDF and CEK wrapped with A192KW */
 	JWE_ALG_ECDH_ES_A256KW,	/**< ECDH-ES using Concat KDF and CEK wrapped with A256KW */
+	JWE_ALG_A128GCMKW,	/**< Key wrapping with AES GCM using a 128-bit key @since 3.6.0 */
+	JWE_ALG_A192GCMKW,	/**< Key wrapping with AES GCM using a 192-bit key @since 3.6.0 */
+	JWE_ALG_A256GCMKW,	/**< Key wrapping with AES GCM using a 256-bit key @since 3.6.0 */
 	JWE_ALG_INVAL,		/**< An invalid algorithm from the caller or the token */
 } jwe_key_alg_t;
 

--- a/libjwt/jwe-common.c
+++ b/libjwt/jwe-common.c
@@ -167,7 +167,8 @@ static int jwe_header_name_reserved(const char *key)
 {
 	return !strcmp(key, "alg") || !strcmp(key, "enc") ||
 	       !strcmp(key, "epk") || !strcmp(key, "apu") ||
-	       !strcmp(key, "apv");
+	       !strcmp(key, "apv") || !strcmp(key, "iv") ||
+	       !strcmp(key, "tag");
 }
 
 /* @rfc{7518,4.6.2} Encode apu/apv as base64url into recipient @r. NULL/0 leaves
@@ -619,6 +620,11 @@ static int FUNC(wrap_recipient)(jwe_common_t *__cmd, struct jwe_recipient *r,
 	const unsigned char *k;
 	int ret;
 
+	/* The builder is reusable: drop any Encrypted Key produced by a previous
+	 * jwe_builder_generate() before wrapping this recipient again. */
+	jwt_freemem(r->enckey);
+	r->enckey_len = 0;
+
 	if (jwt_json_obj_set(kmhdr, "alg",
 			     jwt_json_create_str(jwe_alg_str(r->key_alg))))
 		return 1; // LCOV_EXCL_LINE
@@ -677,6 +683,17 @@ static int FUNC(wrap_recipient)(jwe_common_t *__cmd, struct jwe_recipient *r,
 			return 1; // LCOV_EXCL_LINE
 		memcpy(*cek_out, k, klen);
 		*cek_out_len = klen;
+		return 0;
+	}
+
+	/* @rfc{7518,4.7} AES-GCM key wrap: GCM-encrypt the CEK under the oct KEK,
+	 * writing the per-recipient "iv"/"tag" into the key-management header. */
+	if (jwe_alg_is_gcmkw(r->key_alg)) {
+		if (jwe_gcmkw_wrap(r->key_alg, r->key, cek, cek_len, kmhdr,
+				   &r->enckey, &r->enckey_len)) {
+			jwt_write_error(__cmd, "AES-GCM key wrap failed");
+			return 1;
+		}
 		return 0;
 	}
 
@@ -1098,6 +1115,36 @@ static unsigned char *FUNC(recover_and_decrypt)(jwe_common_t *__cmd,
 		if (cek == NULL)
 			goto oom; // LCOV_EXCL_LINE
 		memcpy(cek, k, cek_len);
+	} else if (jwe_alg_is_gcmkw(alg)) {
+		/* @rfc{7518,4.7} The Encrypted Key is the GCM-wrapped CEK; the
+		 * "iv"/"tag" needed to unwrap it live in the effective header. */
+		size_t need = jwe_enc_cek_len(enc);
+		int bad = 0;
+
+		if (!have_ek) {
+			jwt_write_error(__cmd,
+				"AES-GCM key wrap requires an Encrypted Key");
+			return NULL;
+		}
+
+		enckey = jwt_base64uri_decode(ek_b64, &ek_len);
+		if (enckey == NULL || ek_len <= 0)
+			bad = 1;
+		else if (jwe_gcmkw_unwrap(alg, recip->key, eff_hdr, enckey,
+					  ek_len, &cek, &cek_len))
+			bad = 1;
+		else if (cek_len != need)
+			bad = 1; // LCOV_EXCL_LINE
+
+		/* @rfc{7516,11.5} On any failure (incl. a bad key tag) substitute
+		 * a random CEK so the content AEAD fails uniformly. */
+		if (bad) {
+			jwt_scrub_and_free(cek, cek_len);
+			cek = NULL;
+			cek_len = 0;
+			if (jwe_generate_cek(enc, &cek, &cek_len))
+				goto oom; // LCOV_EXCL_LINE
+		}
 	} else {
 		/* A*KW / RSA-OAEP: the Encrypted Key carries the CEK. */
 		size_t need = jwe_enc_cek_len(enc);

--- a/libjwt/jwe-setget.c
+++ b/libjwt/jwe-setget.c
@@ -37,6 +37,12 @@ const char *jwe_alg_str(jwe_key_alg_t alg)
 		return "ECDH-ES+A192KW";
 	case JWE_ALG_ECDH_ES_A256KW:
 		return "ECDH-ES+A256KW";
+	case JWE_ALG_A128GCMKW:
+		return "A128GCMKW";
+	case JWE_ALG_A192GCMKW:
+		return "A192GCMKW";
+	case JWE_ALG_A256GCMKW:
+		return "A256GCMKW";
 	default:
 		return NULL;
 	}
@@ -67,6 +73,12 @@ jwe_key_alg_t jwe_str_alg(const char *alg)
 		return JWE_ALG_ECDH_ES_A192KW;
 	else if (!strcmp(alg, "ECDH-ES+A256KW"))
 		return JWE_ALG_ECDH_ES_A256KW;
+	else if (!strcmp(alg, "A128GCMKW"))
+		return JWE_ALG_A128GCMKW;
+	else if (!strcmp(alg, "A192GCMKW"))
+		return JWE_ALG_A192GCMKW;
+	else if (!strcmp(alg, "A256GCMKW"))
+		return JWE_ALG_A256GCMKW;
 
 	return JWE_ALG_INVAL;
 }

--- a/libjwt/jwe.c
+++ b/libjwt/jwe.c
@@ -280,6 +280,142 @@ int jwe_decrypt_content(jwe_enc_t enc, const unsigned char *cek,
 		aad, aad_len, ct, ct_len, tag, tag_len, pt, pt_len);
 }
 
+/* @rfc{7518,4.7} Is this an AES-GCM key-wrap algorithm? */
+int jwe_alg_is_gcmkw(jwe_key_alg_t alg)
+{
+	return alg == JWE_ALG_A128GCMKW || alg == JWE_ALG_A192GCMKW ||
+	       alg == JWE_ALG_A256GCMKW;
+}
+
+/* @rfc{7518,4.7} The KEK oct length a GCM-KW alg requires. */
+static size_t gcmkw_kek_len(jwe_key_alg_t alg)
+{
+	switch (alg) {
+	case JWE_ALG_A128GCMKW:
+		return 16;
+	case JWE_ALG_A192GCMKW:
+		return 24;
+	case JWE_ALG_A256GCMKW:
+		return 32;
+	// LCOV_EXCL_START
+	default:
+		return 0;
+	// LCOV_EXCL_STOP
+	}
+}
+
+/* The GCM content-encryption "enc" whose AES key size matches a GCM-KW alg, so
+ * the existing GCM code can wrap/unwrap the CEK. */
+static jwe_enc_t gcmkw_to_enc(jwe_key_alg_t alg)
+{
+	switch (alg) {
+	case JWE_ALG_A128GCMKW:
+		return JWE_ENC_A128GCM;
+	case JWE_ALG_A192GCMKW:
+		return JWE_ENC_A192GCM;
+	case JWE_ALG_A256GCMKW:
+		return JWE_ENC_A256GCM;
+	// LCOV_EXCL_START
+	default:
+		return JWE_ENC_INVAL;
+	// LCOV_EXCL_STOP
+	}
+}
+
+/* @rfc{7518,4.7} AES-GCM key wrap: GCM-encrypt the CEK under the oct KEK with a
+ * FRESH 96-bit IV and an empty AAD. The wrapped CEK is the Encrypted Key (@out);
+ * the 96-bit IV and 128-bit tag are written base64url into @hdr as "iv"/"tag".
+ * A fresh CSPRNG IV per wrap is mandatory (RFC 7518 8.7: nonce reuse under the
+ * same KEK is a catastrophic GCM break) — the IV is generated here and is never
+ * caller-supplied. Returns 0 on success. */
+int jwe_gcmkw_wrap(jwe_key_alg_t alg, const jwk_item_t *key,
+		   const unsigned char *cek, size_t cek_len,
+		   jwt_json_t *hdr, unsigned char **out, size_t *out_len)
+{
+	jwe_enc_t enc = gcmkw_to_enc(alg);
+	const unsigned char *k;
+	unsigned char iv[12], *tag = NULL;
+	char *iv_b64 = NULL, *tag_b64 = NULL;
+	size_t klen = 0, tag_len = 0;
+	int ret = 1;
+
+	if (jwks_item_key_oct(key, &k, &klen) || klen != gcmkw_kek_len(alg))
+		return 1;
+
+	if (jwt_ops->rng == NULL || jwt_ops->rng(iv, sizeof(iv)))
+		return 1; // LCOV_EXCL_LINE
+
+	if (jwe_encrypt_content(enc, k, klen, iv, sizeof(iv), NULL, 0,
+				cek, cek_len, out, out_len, &tag, &tag_len))
+		goto out; // LCOV_EXCL_LINE
+
+	if (jwt_base64uri_encode(&iv_b64, (char *)iv, (int)sizeof(iv)) <= 0 ||
+	    jwt_base64uri_encode(&tag_b64, (char *)tag, (int)tag_len) <= 0)
+		goto out; // LCOV_EXCL_LINE
+
+	if (jwt_json_obj_set(hdr, "iv", jwt_json_create_str(iv_b64)) ||
+	    jwt_json_obj_set(hdr, "tag", jwt_json_create_str(tag_b64)))
+		goto out; // LCOV_EXCL_LINE
+
+	ret = 0;
+
+out:
+	jwt_freemem(tag);
+	jwt_freemem(iv_b64);
+	jwt_freemem(tag_b64);
+	if (ret) {
+		// LCOV_EXCL_START
+		jwt_freemem(*out);
+		*out_len = 0;
+		// LCOV_EXCL_STOP
+	}
+
+	return ret;
+}
+
+/* @rfc{7518,4.7} AES-GCM key unwrap: read the "iv"/"tag" from @hdr and
+ * GCM-decrypt the Encrypted Key under the oct KEK (empty AAD) to recover the
+ * CEK. jwe_decrypt_content enforces the 96-bit IV and verifies the tag, so a
+ * bad tag fails here; per RFC 7516 11.5 the caller then substitutes a random
+ * CEK. Returns 0 on success. */
+int jwe_gcmkw_unwrap(jwe_key_alg_t alg, const jwk_item_t *key, jwt_json_t *hdr,
+		     const unsigned char *in, size_t in_len,
+		     unsigned char **cek, size_t *cek_len)
+{
+	jwe_enc_t enc = gcmkw_to_enc(alg);
+	jwt_json_t *jiv, *jtag;
+	const unsigned char *k;
+	unsigned char *iv = NULL, *tag = NULL;
+	size_t klen = 0;
+	int iv_len = 0, tag_len = 0, ret = 1;
+
+	if (jwks_item_key_oct(key, &k, &klen) || klen != gcmkw_kek_len(alg))
+		return 1;
+
+	jiv = jwt_json_obj_get(hdr, "iv");
+	jtag = jwt_json_obj_get(hdr, "tag");
+	if (jiv == NULL || !jwt_json_is_string(jiv) ||
+	    jtag == NULL || !jwt_json_is_string(jtag))
+		return 1;
+
+	iv = jwt_base64uri_decode(jwt_json_str_val(jiv), &iv_len);
+	tag = jwt_base64uri_decode(jwt_json_str_val(jtag), &tag_len);
+	if (iv == NULL || tag == NULL || iv_len <= 0 || tag_len <= 0)
+		goto out;
+
+	if (jwe_decrypt_content(enc, k, klen, iv, iv_len, NULL, 0,
+				in, in_len, tag, tag_len, cek, cek_len))
+		goto out;
+
+	ret = 0;
+
+out:
+	jwt_freemem(iv);
+	jwt_freemem(tag);
+
+	return ret;
+}
+
 /* @rfc{7516,11.4} @rfc{7517,4.2,4.3} Gate a JWK against a JWE key management
  * algorithm. */
 const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
@@ -333,6 +469,9 @@ const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
 		case JWE_ALG_A128KW:
 		case JWE_ALG_A192KW:
 		case JWE_ALG_A256KW:
+		case JWE_ALG_A128GCMKW:
+		case JWE_ALG_A192GCMKW:
+		case JWE_ALG_A256GCMKW:
 			want = for_encrypt ? JWK_KEY_OP_WRAP : JWK_KEY_OP_UNWRAP;
 			break;
 		case JWE_ALG_RSA_OAEP:

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -739,6 +739,9 @@ static inline jwk_key_type_t jwe_alg_required_kty(jwe_key_alg_t alg)
 	case JWE_ALG_A128KW:
 	case JWE_ALG_A192KW:
 	case JWE_ALG_A256KW:
+	case JWE_ALG_A128GCMKW:
+	case JWE_ALG_A192GCMKW:
+	case JWE_ALG_A256GCMKW:
 		return JWK_KEY_TYPE_OCT;
 
 	case JWE_ALG_RSA_OAEP:
@@ -791,6 +794,20 @@ JWT_NO_EXPORT
 int jwe_decrypt_cek(jwe_key_alg_t alg, const jwk_item_t *key,
 		    const unsigned char *in, size_t in_len,
 		    unsigned char **cek, size_t *cek_len);
+
+/* AES-GCM Key Wrap (RFC 7518 4.7). Wrap/unwrap the CEK by GCM-encrypting it
+ * under the oct KEK with a fresh 96-bit IV (mandatory) and empty AAD; the IV
+ * and tag are carried in the per-recipient header (@hdr) as "iv"/"tag". */
+JWT_NO_EXPORT
+int jwe_alg_is_gcmkw(jwe_key_alg_t alg);
+JWT_NO_EXPORT
+int jwe_gcmkw_wrap(jwe_key_alg_t alg, const jwk_item_t *key,
+		   const unsigned char *cek, size_t cek_len,
+		   jwt_json_t *hdr, unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
+int jwe_gcmkw_unwrap(jwe_key_alg_t alg, const jwk_item_t *key, jwt_json_t *hdr,
+		     const unsigned char *in, size_t in_len,
+		     unsigned char **cek, size_t *cek_len);
 
 /* ECDH-ES (RFC 7518 4.6). Direct mode derives the CEK directly. */
 JWT_NO_EXPORT

--- a/tests/jwe_gcmkw.c
+++ b/tests/jwe_gcmkw.c
@@ -1,0 +1,246 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* @rfc{7518,4.7} AES-GCM Key Wrap (A128/192/256GCMKW), issue #309. Runs under
+ * each crypto backend (SET_OPS) and both JSON backends. The per-recipient
+ * "iv"/"tag" header params are produced/consumed by the library; a fresh IV per
+ * wrap is mandatory. */
+
+static const char PT[] = "{\"sub\":\"1234567890\",\"name\":\"Jane Doe\"}";
+
+static int count_dots(const char *s)
+{
+	int n = 0;
+
+	for (; *s; s++)
+		if (*s == '.')
+			n++;
+
+	return n;
+}
+
+/* Compact round-trip; the wrapped CEK is non-empty and the protected header
+ * carries the GCM-KW "iv"/"tag". */
+static void roundtrip(const char *keyfile, jwe_key_alg_t alg, jwe_enc_t enc)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	read_json(keyfile);
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, alg, enc, g_item), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	/* Five parts, non-empty Encrypted Key (the wrapped CEK). */
+	ck_assert_int_eq(count_dots(tok), 4);
+	ck_assert_ptr_null(strstr(tok, ".."));
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, alg, enc, g_item), 0);
+	pt = jwe_checker_decrypt(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_int_eq(pt_len, strlen(PT));
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	free(pt);
+	free_key();
+}
+
+START_TEST(rt_128)
+{
+	SET_OPS();
+	roundtrip("oct_dir_128.json", JWE_ALG_A128GCMKW, JWE_ENC_A256GCM);
+}
+END_TEST
+
+START_TEST(rt_192)
+{
+	SET_OPS();
+	roundtrip("oct_dir_192.json", JWE_ALG_A192GCMKW, JWE_ENC_A256GCM);
+}
+END_TEST
+
+START_TEST(rt_256)
+{
+	SET_OPS();
+	roundtrip("oct_dir_256.json", JWE_ALG_A256GCMKW, JWE_ENC_A256GCM);
+}
+END_TEST
+
+START_TEST(rt_256_cbc)
+{
+	/* GCM-KW wrapping a 64-byte CBC-HMAC CEK. */
+	SET_OPS();
+	roundtrip("oct_dir_256.json", JWE_ALG_A256GCMKW, JWE_ENC_A256CBC_HS512);
+}
+END_TEST
+
+/* Two wraps of the same key must use different IVs (fresh CSPRNG IV per wrap).
+ * Reuses one builder for both generates, which must not leak (the builder is
+ * reusable). */
+START_TEST(fresh_iv)
+{
+	jwe_builder_auto_t *builder = NULL;
+	char_auto *t1 = NULL, *t2 = NULL;
+
+	SET_OPS();
+	read_json("oct_dir_256.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256GCMKW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	t1 = jwe_builder_generate(builder, (const unsigned char *)PT, strlen(PT));
+	t2 = jwe_builder_generate(builder, (const unsigned char *)PT, strlen(PT));
+	ck_assert_ptr_nonnull(t1);
+	ck_assert_ptr_nonnull(t2);
+	/* Different IV (and CEK) => the protected header + Encrypted Key differ. */
+	ck_assert_str_ne(t1, t2);
+
+	free_key();
+}
+END_TEST
+
+/* JSON serialization: the "iv"/"tag" ride in the per-recipient header. */
+static void roundtrip_json(jwe_serialization_t fmt)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	read_json("oct_dir_256.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256GCMKW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_set_format(builder, fmt), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+	ck_assert_ptr_nonnull(strstr(tok, "\"iv\""));
+	ck_assert_ptr_nonnull(strstr(tok, "\"tag\""));
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256GCMKW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_int_eq(pt_len, strlen(PT));
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	free(pt);
+	free_key();
+}
+
+START_TEST(rt_json_flat)
+{
+	SET_OPS();
+	roundtrip_json(JWE_FORMAT_JSON_FLAT);
+}
+END_TEST
+
+START_TEST(rt_json_general)
+{
+	SET_OPS();
+	roundtrip_json(JWE_FORMAT_JSON_GENERAL);
+}
+END_TEST
+
+/* A corrupted Encrypted Key (the wrapped CEK) must fail the GCM key-unwrap tag,
+ * funnel to a random CEK, and reject the token. */
+START_TEST(tamper_ek)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+	char *ek;
+
+	SET_OPS();
+	read_json("oct_dir_256.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256GCMKW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+
+	ek = strchr(tok, '.') + 1;
+	ck_assert_int_ne(*ek, '.');
+	*ek = (*ek == 'Q') ? 'R' : 'Q';
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_A256GCMKW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt(checker, tok, &pt_len);
+	ck_assert_ptr_null(pt);
+	ck_assert_int_eq(jwe_checker_error(checker), 1);
+
+	free_key();
+}
+END_TEST
+
+/* A KEK whose length does not match the alg is rejected (at wrap time). */
+START_TEST(wrong_kek_len)
+{
+	jwe_builder_auto_t *builder = NULL;
+	char_auto *tok = NULL;
+
+	SET_OPS();
+	read_json("oct_dir_128.json");	/* 128-bit KEK */
+
+	builder = jwe_builder_new();
+	/* A256GCMKW needs a 256-bit KEK; the mismatch fails the wrap. */
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_A256GCMKW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_null(tok);
+
+	free_key();
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+	tc_core = tcase_create("jwe_gcmkw");
+
+	tcase_add_loop_test(tc_core, rt_128, 0, i);
+	tcase_add_loop_test(tc_core, rt_192, 0, i);
+	tcase_add_loop_test(tc_core, rt_256, 0, i);
+	tcase_add_loop_test(tc_core, rt_256_cbc, 0, i);
+	tcase_add_loop_test(tc_core, fresh_iv, 0, i);
+	tcase_add_loop_test(tc_core, rt_json_flat, 0, i);
+	tcase_add_loop_test(tc_core, rt_json_general, 0, i);
+	tcase_add_loop_test(tc_core, tamper_ek, 0, i);
+	tcase_add_loop_test(tc_core, wrong_kek_len, 0, i);
+
+	tcase_set_timeout(tc_core, 30);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT AES-GCM Key Wrap (#309)");
+}


### PR DESCRIPTION
Closes #309.

Adds the GCM-based key-management algorithms **`A128GCMKW`/`A192GCMKW`/`A256GCMKW`** (RFC 7518 §4.7) — the GCM analog of the AES-KW primitives already present, and supported by every full peer.

### How
The CEK is wrapped by AES-GCM under the `oct` KEK with a **fresh 96-bit IV** and empty AAD; the IV and tag ride as the per-recipient `"iv"`/`"tag"` header params.

**No new backend code** — the wrap/unwrap reuse the existing content-encryption GCM ops (`A128GCMKW`→`A128GCM`, by KEK size). `jwe_gcmkw_wrap`/`unwrap` (`jwe.c`) generate the IV and write/read `iv`/`tag` through the key-management header, which `jwe-common.c` already routes to the protected header (Compact) or the per-recipient header (JSON) — exactly as it threads the ECDH-ES `epk`.

### Security
- A fresh CSPRNG IV per wrap is generated **internally** and is never caller-supplied (RFC 7518 §8.7 — nonce reuse under one KEK is a catastrophic GCM break).
- On decrypt, a bad key-unwrap tag funnels to a random CEK so the content AEAD fails uniformly (RFC 7516 §11.5).
- `iv`/`tag` join the reserved header names — an application cannot override them.

### Also: builder reuse fix
Fixes a **pre-existing** leak so the JWE builder is reusable (you raised this): `wrap_recipient` now frees any Encrypted Key left from a previous `jwe_builder_generate()` before wrapping again. This affected **every** wrapping alg (A*KW/RSA/GCM-KW), not just GCM-KW.

### Tests — `tests/jwe_gcmkw.c` (both JSON backends, all crypto backends)
Round-trip all three sizes (Compact + Flattened + General JSON), GCM-KW wrapping a CBC-HMAC CEK, fresh-IV-on-reuse (reuses one builder, exercising the fix), tamper→reject, wrong KEK length→reject. **33/33** pass locally (MbedTLS 4.1) and in the CI image (MbedTLS 3.6.6); valgrind-clean. `@since 3.6.0`; README JWE matrix updated.

> Note: an unrelated **pre-existing** leak in `tests/jwe_multi.c`'s `read_json` test harness (present on master, ~5 KB) is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
