### PR TITLE
jwe: PBES2 password-based key management (RFC 7518 4.8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,8 +430,8 @@ if (CHECK_FOUND)
 
 	# JWE
 	list (APPEND UNIT_TESTS jwe_foundation jwe_keys jwe_gcm jwe_cbc
-		jwe_aeskw jwe_gcmkw jwe_rsa jwe_ecdh jwe_json jwe_aad jwe_multi
-		jwe_json_neg)
+		jwe_aeskw jwe_gcmkw jwe_pbes2 jwe_rsa jwe_ecdh jwe_json jwe_aad
+		jwe_multi jwe_json_neg)
 
 	# Claims
 	list (APPEND UNIT_TESTS jwt_claims jwt_cnf)

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ JWE key management ``alg``    | OpenSSL            | GnuTLS             | MbedTL
 ``dir`` (Direct Encryption)   | :white_check_mark: | :white_check_mark: | :white_check_mark:
 ``A128KW`` ``A192KW`` ``A256KW`` | :white_check_mark: | :white_check_mark: | :white_check_mark:
 ``A128GCMKW`` ``A192GCMKW`` ``A256GCMKW`` | :white_check_mark: | :white_check_mark: | :white_check_mark:
+``PBES2-HS256+A128KW`` ``PBES2-HS384+A192KW`` ``PBES2-HS512+A256KW`` | :white_check_mark: | :white_check_mark: | :white_check_mark:
 ``RSA-OAEP`` (SHA-1)          | :white_check_mark: | :x:                | :white_check_mark:
 ``RSA-OAEP-256``              | :white_check_mark: | :white_check_mark: | :white_check_mark:
 ``ECDH-ES`` (+ ``+A128KW``/``+A192KW``/``+A256KW``) [^okp3813] | :white_check_mark: | :white_check_mark: | :white_check_mark:
@@ -172,6 +173,14 @@ JWE content encryption ``enc`` | OpenSSL            | GnuTLS             | MbedT
 > implements JWE natively. GnuTLS/Nettle cannot perform RSA-OAEP with SHA-1,
 > so the GnuTLS backend does not support plain ``RSA-OAEP`` (``RSA-OAEP-256``
 > is native).
+
+> [!NOTE]
+> ``PBES2-*`` derive a key-wrapping key from a passphrase (the ``oct`` key's
+> octets) with PBKDF2 over a fresh random salt. The iteration count is set with
+> @ref jwe_builder_setpbes2 (a sensible default is used otherwise). On decrypt
+> the ``p2c`` iteration count is attacker-controlled, so libjwt enforces a hard
+> maximum and a minimum salt length and rejects anything outside them before
+> doing any PBKDF2 work — a deliberate DoS guard, like the omission of ``zip``.
 
 ### Optional
 

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -116,6 +116,9 @@ typedef enum {
 	JWE_ALG_A128GCMKW,	/**< Key wrapping with AES GCM using a 128-bit key @since 3.6.0 */
 	JWE_ALG_A192GCMKW,	/**< Key wrapping with AES GCM using a 192-bit key @since 3.6.0 */
 	JWE_ALG_A256GCMKW,	/**< Key wrapping with AES GCM using a 256-bit key @since 3.6.0 */
+	JWE_ALG_PBES2_HS256_A128KW,	/**< PBES2 with HMAC SHA-256 and A128KW wrapping @since 3.6.0 */
+	JWE_ALG_PBES2_HS384_A192KW,	/**< PBES2 with HMAC SHA-384 and A192KW wrapping @since 3.6.0 */
+	JWE_ALG_PBES2_HS512_A256KW,	/**< PBES2 with HMAC SHA-512 and A256KW wrapping @since 3.6.0 */
 	JWE_ALG_INVAL,		/**< An invalid algorithm from the caller or the token */
 } jwe_key_alg_t;
 
@@ -2218,6 +2221,24 @@ int jwe_builder_add_unprotected_json(jwe_builder_t *builder, const char *key,
 JWT_EXPORT
 int jwe_builder_set_aad(jwe_builder_t *builder, const unsigned char *aad,
 			size_t aad_len);
+
+/**
+ * @brief Set the PBES2 iteration count
+ *
+ * Sets the PBKDF2 iteration count (the ``p2c`` header parameter) used by the
+ * ``PBES2-*`` password-based key-management algorithms. Pass 0 to use the
+ * library default. A higher count increases resistance to password guessing at
+ * the cost of more work per encrypt/decrypt; it has no effect on non-PBES2
+ * algorithms. On decrypt the library enforces a hard maximum on an
+ * attacker-supplied ``p2c`` regardless of this setting.
+ *
+ * @param builder Pointer to a JWE builder object
+ * @param p2c The PBKDF2 iteration count, or 0 for the library default
+ * @return 0 on success, non-zero otherwise
+ * @since 3.6.0
+ */
+JWT_EXPORT
+int jwe_builder_setpbes2(jwe_builder_t *builder, unsigned int p2c);
 
 /**
  * @brief Encrypt a plaintext into a JWE

--- a/libjwt/gnutls/sign-verify.c
+++ b/libjwt/gnutls/sign-verify.c
@@ -482,6 +482,39 @@ static int gnutls_sha(int sha_bits, const unsigned char *in, size_t in_len,
 	return 0;
 }
 
+/* Named _op to avoid colliding with the library function gnutls_pbkdf2(). */
+static int gnutls_pbkdf2_op(int sha_bits, const unsigned char *pw, size_t pw_len,
+			    const unsigned char *salt, size_t salt_len,
+			    unsigned int iter, unsigned char *out, size_t dk_len)
+{
+	gnutls_datum_t key, slt;
+	gnutls_mac_algorithm_t mac;
+
+	switch (sha_bits) {
+	case 256:
+		mac = GNUTLS_MAC_SHA256;
+		break;
+	case 384:
+		mac = GNUTLS_MAC_SHA384;
+		break;
+	case 512:
+		mac = GNUTLS_MAC_SHA512;
+		break;
+	default:
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	key.data = (unsigned char *)pw;
+	key.size = (unsigned int)pw_len;
+	slt.data = (unsigned char *)salt;
+	slt.size = (unsigned int)salt_len;
+
+	if (gnutls_pbkdf2(mac, &key, &slt, iter, out, dk_len))
+		return 1; // LCOV_EXCL_LINE
+
+	return 0;
+}
+
 /* Export our ops */
 struct jwt_crypto_ops jwt_gnutls_ops = {
 	.name			= "gnutls",
@@ -505,6 +538,7 @@ struct jwt_crypto_ops jwt_gnutls_ops = {
 	.generate_pem		= gnutls_generate_pem,
 
 	.sha			= gnutls_sha,
+	.pbkdf2			= gnutls_pbkdf2_op,
 
 	.jwe_implemented	= 1,
 	.rng			= gnutls_rng,

--- a/libjwt/jwe-common.c
+++ b/libjwt/jwe-common.c
@@ -484,6 +484,18 @@ oom:
 	return 1;
 	// LCOV_EXCL_STOP
 }
+
+/* @rfc{7518,4.8} Set the PBES2 PBKDF2 iteration count (the "p2c" header). 0
+ * selects the library default. Only affects PBES2-* key management algorithms. */
+int FUNC(setpbes2)(jwe_common_t *__cmd, unsigned int p2c)
+{
+	if (__cmd == NULL)
+		return 1;
+
+	__cmd->c.pbes2_p2c = p2c;
+
+	return 0;
+}
 #endif
 
 #ifdef JWE_BUILDER
@@ -692,6 +704,18 @@ static int FUNC(wrap_recipient)(jwe_common_t *__cmd, struct jwe_recipient *r,
 		if (jwe_gcmkw_wrap(r->key_alg, r->key, cek, cek_len, kmhdr,
 				   &r->enckey, &r->enckey_len)) {
 			jwt_write_error(__cmd, "AES-GCM key wrap failed");
+			return 1;
+		}
+		return 0;
+	}
+
+	/* @rfc{7518,4.8} PBES2: PBKDF2-derive a KEK from the password and AES-KW
+	 * wrap the CEK, writing "p2s"/"p2c" into the key-management header. */
+	if (jwe_alg_is_pbes2(r->key_alg)) {
+		if (jwe_pbes2_wrap(r->key_alg, r->key, cek, cek_len,
+				   __cmd->c.pbes2_p2c, kmhdr, &r->enckey,
+				   &r->enckey_len)) {
+			jwt_write_error(__cmd, "PBES2 key wrap failed");
 			return 1;
 		}
 		return 0;
@@ -1138,6 +1162,37 @@ static unsigned char *FUNC(recover_and_decrypt)(jwe_common_t *__cmd,
 
 		/* @rfc{7516,11.5} On any failure (incl. a bad key tag) substitute
 		 * a random CEK so the content AEAD fails uniformly. */
+		if (bad) {
+			jwt_scrub_and_free(cek, cek_len);
+			cek = NULL;
+			cek_len = 0;
+			if (jwe_generate_cek(enc, &cek, &cek_len))
+				goto oom; // LCOV_EXCL_LINE
+		}
+	} else if (jwe_alg_is_pbes2(alg)) {
+		/* @rfc{7518,4.8} PBKDF2-derive the KEK (p2s/p2c from the effective
+		 * header; the cap is enforced inside jwe_pbes2_unwrap) and AES-KW
+		 * unwrap the Encrypted Key. */
+		size_t need = jwe_enc_cek_len(enc);
+		int bad = 0;
+
+		if (!have_ek) {
+			jwt_write_error(__cmd,
+				"PBES2 requires an Encrypted Key");
+			return NULL;
+		}
+
+		enckey = jwt_base64uri_decode(ek_b64, &ek_len);
+		if (enckey == NULL || ek_len <= 0)
+			bad = 1;
+		else if (jwe_pbes2_unwrap(alg, recip->key, eff_hdr, enckey,
+					  ek_len, &cek, &cek_len))
+			bad = 1;
+		else if (cek_len != need)
+			bad = 1; // LCOV_EXCL_LINE
+
+		/* @rfc{7516,11.5} Bad password / over-cap p2c / short salt: random
+		 * CEK so the content AEAD fails uniformly. */
 		if (bad) {
 			jwt_scrub_and_free(cek, cek_len);
 			cek = NULL;

--- a/libjwt/jwe-setget.c
+++ b/libjwt/jwe-setget.c
@@ -43,6 +43,12 @@ const char *jwe_alg_str(jwe_key_alg_t alg)
 		return "A192GCMKW";
 	case JWE_ALG_A256GCMKW:
 		return "A256GCMKW";
+	case JWE_ALG_PBES2_HS256_A128KW:
+		return "PBES2-HS256+A128KW";
+	case JWE_ALG_PBES2_HS384_A192KW:
+		return "PBES2-HS384+A192KW";
+	case JWE_ALG_PBES2_HS512_A256KW:
+		return "PBES2-HS512+A256KW";
 	default:
 		return NULL;
 	}
@@ -79,6 +85,12 @@ jwe_key_alg_t jwe_str_alg(const char *alg)
 		return JWE_ALG_A192GCMKW;
 	else if (!strcmp(alg, "A256GCMKW"))
 		return JWE_ALG_A256GCMKW;
+	else if (!strcmp(alg, "PBES2-HS256+A128KW"))
+		return JWE_ALG_PBES2_HS256_A128KW;
+	else if (!strcmp(alg, "PBES2-HS384+A192KW"))
+		return JWE_ALG_PBES2_HS384_A192KW;
+	else if (!strcmp(alg, "PBES2-HS512+A256KW"))
+		return JWE_ALG_PBES2_HS512_A256KW;
 
 	return JWE_ALG_INVAL;
 }

--- a/libjwt/jwe.c
+++ b/libjwt/jwe.c
@@ -416,6 +416,179 @@ out:
 	return ret;
 }
 
+/* @rfc{7518,4.8} PBES2 password-based key management. */
+#define PBES2_SALT_LEN		16	/* p2s octets generated on encrypt */
+#define PBES2_SALT_MIN		8	/* @rfc{7518,4.8.1.1} minimum p2s octets */
+#define PBES2_DEFAULT_P2C	310000	/* iterations when the builder sets none */
+#define PBES2_MAX_P2C		1000000	/* hard cap on decrypt (attacker DoS guard) */
+
+int jwe_alg_is_pbes2(jwe_key_alg_t alg)
+{
+	return alg == JWE_ALG_PBES2_HS256_A128KW ||
+	       alg == JWE_ALG_PBES2_HS384_A192KW ||
+	       alg == JWE_ALG_PBES2_HS512_A256KW;
+}
+
+/* The PBKDF2 hash size and derived/KEK length (= the AES-KW key size). */
+static void pbes2_params(jwe_key_alg_t alg, int *sha_bits, size_t *kek_len)
+{
+	switch (alg) {
+	case JWE_ALG_PBES2_HS256_A128KW:
+		*sha_bits = 256;
+		*kek_len = 16;
+		break;
+	case JWE_ALG_PBES2_HS384_A192KW:
+		*sha_bits = 384;
+		*kek_len = 24;
+		break;
+	case JWE_ALG_PBES2_HS512_A256KW:
+		*sha_bits = 512;
+		*kek_len = 32;
+		break;
+	// LCOV_EXCL_START
+	default:
+		*sha_bits = 0;
+		*kek_len = 0;
+		break;
+	// LCOV_EXCL_STOP
+	}
+}
+
+/* @rfc{7518,4.8.1.1} Derive the KEK: PBKDF2 over the salt input
+ * (UTF8(alg) || 0x00 || p2s). Returns 0 on success, dk holds @kek_len octets. */
+static int pbes2_derive(jwe_key_alg_t alg, int sha_bits, size_t kek_len,
+			const unsigned char *pw, size_t pw_len,
+			const unsigned char *p2s, size_t p2s_len,
+			unsigned int p2c, unsigned char *dk)
+{
+	const char *alg_name = jwe_alg_str(alg);
+	size_t alg_len = strlen(alg_name);
+	size_t salt_len = alg_len + 1 + p2s_len;
+	unsigned char *salt;
+	int ret;
+
+	if (jwt_ops->pbkdf2 == NULL)
+		return 1;
+
+	salt = jwt_malloc(salt_len);
+	if (salt == NULL)
+		return 1; // LCOV_EXCL_LINE
+	memcpy(salt, alg_name, alg_len);
+	salt[alg_len] = 0x00;
+	memcpy(salt + alg_len + 1, p2s, p2s_len);
+
+	ret = jwt_ops->pbkdf2(sha_bits, pw, pw_len, salt, salt_len, p2c, dk,
+			      kek_len);
+	jwt_freemem(salt);
+
+	return ret;
+}
+
+/* @rfc{7518,4.8} Wrap the CEK to a password: derive a KEK with PBKDF2 over a
+ * fresh salt and AES-KW-wrap the CEK, writing "p2s"/"p2c" into @hdr. The salt is
+ * generated here (never caller-supplied). Returns 0 on success. */
+int jwe_pbes2_wrap(jwe_key_alg_t alg, const jwk_item_t *key,
+		   const unsigned char *cek, size_t cek_len, unsigned int p2c,
+		   jwt_json_t *hdr, unsigned char **out, size_t *out_len)
+{
+	unsigned char p2s[PBES2_SALT_LEN], dk[32];
+	const unsigned char *pw;
+	char *p2s_b64 = NULL;
+	size_t pw_len = 0, kek_len;
+	int sha_bits, ret = 1;
+
+	pbes2_params(alg, &sha_bits, &kek_len);
+
+	/* The password is the oct key's octets. */
+	if (jwks_item_key_oct(key, &pw, &pw_len) || pw == NULL || pw_len == 0)
+		return 1;
+
+	if (p2c == 0)
+		p2c = PBES2_DEFAULT_P2C;
+
+	if (jwt_ops->rng == NULL || jwt_ops->rng(p2s, sizeof(p2s)))
+		return 1; // LCOV_EXCL_LINE
+
+	if (pbes2_derive(alg, sha_bits, kek_len, pw, pw_len, p2s, sizeof(p2s),
+			 p2c, dk))
+		goto out; // LCOV_EXCL_LINE
+
+	if (jwe_aeskw_wrap_raw(dk, kek_len, cek, cek_len, out, out_len))
+		goto out; // LCOV_EXCL_LINE
+
+	if (jwt_base64uri_encode(&p2s_b64, (char *)p2s, (int)sizeof(p2s)) <= 0)
+		goto out; // LCOV_EXCL_LINE
+
+	if (jwt_json_obj_set(hdr, "p2s", jwt_json_create_str(p2s_b64)) ||
+	    jwt_json_obj_set(hdr, "p2c", jwt_json_create_int((jwt_json_int_t)p2c)))
+		goto out; // LCOV_EXCL_LINE
+
+	ret = 0;
+
+out:
+	jwt_cleanse(dk, sizeof(dk));
+	jwt_freemem(p2s_b64);
+	if (ret) {
+		// LCOV_EXCL_START
+		jwt_freemem(*out);
+		*out_len = 0;
+		// LCOV_EXCL_STOP
+	}
+
+	return ret;
+}
+
+/* @rfc{7518,4.8} Recover the CEK from a password: read "p2s"/"p2c" from @hdr,
+ * enforce the iteration cap and minimum salt, derive the KEK and AES-KW-unwrap.
+ * A wrong password / bad wrap fails here; the caller substitutes a random CEK. */
+int jwe_pbes2_unwrap(jwe_key_alg_t alg, const jwk_item_t *key, jwt_json_t *hdr,
+		     const unsigned char *in, size_t in_len,
+		     unsigned char **cek, size_t *cek_len)
+{
+	unsigned char dk[32], *p2s = NULL;
+	const unsigned char *pw;
+	jwt_json_t *jp2s, *jp2c;
+	size_t pw_len = 0, kek_len;
+	jwt_json_int_t p2c;
+	int sha_bits, p2s_len = 0, ret = 1;
+
+	pbes2_params(alg, &sha_bits, &kek_len);
+
+	if (jwks_item_key_oct(key, &pw, &pw_len) || pw == NULL || pw_len == 0)
+		return 1;
+
+	jp2s = jwt_json_obj_get(hdr, "p2s");
+	jp2c = jwt_json_obj_get(hdr, "p2c");
+	if (jp2s == NULL || !jwt_json_is_string(jp2s) ||
+	    jp2c == NULL || !jwt_json_is_int(jp2c))
+		return 1;
+
+	/* @rfc{7518,4.8.1.2} The iteration count is attacker-controlled: cap it
+	 * (DoS) and require a sufficiently long salt BEFORE doing any PBKDF2. */
+	p2c = jwt_json_int_val(jp2c);
+	if (p2c < 1 || p2c > PBES2_MAX_P2C)
+		return 1;
+
+	p2s = jwt_base64uri_decode(jwt_json_str_val(jp2s), &p2s_len);
+	if (p2s == NULL || p2s_len < PBES2_SALT_MIN)
+		goto out;
+
+	if (pbes2_derive(alg, sha_bits, kek_len, pw, pw_len, p2s,
+			 (size_t)p2s_len, (unsigned int)p2c, dk))
+		goto out; // LCOV_EXCL_LINE
+
+	if (jwe_aeskw_unwrap_raw(dk, kek_len, in, in_len, cek, cek_len))
+		goto out;
+
+	ret = 0;
+
+out:
+	jwt_cleanse(dk, sizeof(dk));
+	jwt_freemem(p2s);
+
+	return ret;
+}
+
 /* @rfc{7516,11.4} @rfc{7517,4.2,4.3} Gate a JWK against a JWE key management
  * algorithm. */
 const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
@@ -472,6 +645,9 @@ const char *jwe_key_usage_check(const jwk_item_t *key, jwe_key_alg_t alg,
 		case JWE_ALG_A128GCMKW:
 		case JWE_ALG_A192GCMKW:
 		case JWE_ALG_A256GCMKW:
+		case JWE_ALG_PBES2_HS256_A128KW:
+		case JWE_ALG_PBES2_HS384_A192KW:
+		case JWE_ALG_PBES2_HS512_A256KW:
 			want = for_encrypt ? JWK_KEY_OP_WRAP : JWK_KEY_OP_UNWRAP;
 			break;
 		case JWE_ALG_RSA_OAEP:

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -207,6 +207,10 @@ struct jwe_common {
 	/* @rfc{7516,4.1.4} Serialization to emit (builder). */
 	jwe_serialization_t format;
 
+	/* @rfc{7518,4.8} PBES2 iteration count for the builder; 0 = the library
+	 * default. Set via jwe_builder_setpbes2(). */
+	unsigned int pbes2_p2c;
+
 	/* @rfc{7516,5.1} step 14 The application-supplied JWE AAD (the "aad"
 	 * member of the JSON serializations). @aad_b64 is its base64url form,
 	 * which is also what is concatenated into the AEAD AAD. */
@@ -386,6 +390,14 @@ struct jwt_crypto_ops {
 	 * every backend provides it (it is not gated by jwe_implemented). */
 	int (*sha)(int sha_bits, const unsigned char *in, size_t in_len,
 		   unsigned char *out, unsigned int *out_len);
+
+	/* @rfc{8018} PBKDF2-HMAC-SHA{256,384,512}: derive @dk_len octets into
+	 * @out from the password @pw and @salt over @iter iterations. Used by the
+	 * PBES2 (RFC 7518 4.8) JWE key-management algorithms. Returns 0 on
+	 * success. NULL on a backend that cannot derive (PBES2 then fails cleanly). */
+	int (*pbkdf2)(int sha_bits, const unsigned char *pw, size_t pw_len,
+		      const unsigned char *salt, size_t salt_len,
+		      unsigned int iter, unsigned char *out, size_t dk_len);
 
 	/* JWE (RFC 7516/7518). A backend may implement JWE crypto ops even if
 	 * it does not parse JWKs (JWK parsing always falls back to OpenSSL).
@@ -742,6 +754,9 @@ static inline jwk_key_type_t jwe_alg_required_kty(jwe_key_alg_t alg)
 	case JWE_ALG_A128GCMKW:
 	case JWE_ALG_A192GCMKW:
 	case JWE_ALG_A256GCMKW:
+	case JWE_ALG_PBES2_HS256_A128KW:
+	case JWE_ALG_PBES2_HS384_A192KW:
+	case JWE_ALG_PBES2_HS512_A256KW:
 		return JWK_KEY_TYPE_OCT;
 
 	case JWE_ALG_RSA_OAEP:
@@ -806,6 +821,21 @@ int jwe_gcmkw_wrap(jwe_key_alg_t alg, const jwk_item_t *key,
 		   jwt_json_t *hdr, unsigned char **out, size_t *out_len);
 JWT_NO_EXPORT
 int jwe_gcmkw_unwrap(jwe_key_alg_t alg, const jwk_item_t *key, jwt_json_t *hdr,
+		     const unsigned char *in, size_t in_len,
+		     unsigned char **cek, size_t *cek_len);
+
+/* PBES2 password-based key management (RFC 7518 4.8). PBKDF2 (over a fresh salt)
+ * derives a KEK from the oct key's octets (the password); the CEK is AES-KW
+ * wrapped. "p2s" (salt) and "p2c" (iterations) ride in the per-recipient header;
+ * @p2c on wrap is 0 for the default. The decrypt side caps p2c and the salt. */
+JWT_NO_EXPORT
+int jwe_alg_is_pbes2(jwe_key_alg_t alg);
+JWT_NO_EXPORT
+int jwe_pbes2_wrap(jwe_key_alg_t alg, const jwk_item_t *key,
+		   const unsigned char *cek, size_t cek_len, unsigned int p2c,
+		   jwt_json_t *hdr, unsigned char **out, size_t *out_len);
+JWT_NO_EXPORT
+int jwe_pbes2_unwrap(jwe_key_alg_t alg, const jwk_item_t *key, jwt_json_t *hdr,
 		     const unsigned char *in, size_t in_len,
 		     unsigned char **cek, size_t *cek_len);
 

--- a/libjwt/mbedtls/sign-verify.c
+++ b/libjwt/mbedtls/sign-verify.c
@@ -6,8 +6,17 @@
    License, v. 2.0. If a copy of the MPL was not distributed with this
    file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <mbedtls/build_info.h>	/* MBEDTLS_VERSION_MAJOR */
 #include <psa/crypto.h>
 #include <string.h>
+
+/* PBKDF2: MbedTLS 4.x exposes it only via PSA; the 3.6.x PSA build in our CI
+ * image does not enable PSA PBKDF2 at runtime, so use the public PKCS#5 API
+ * there (mbedtls/pkcs5.h is public in 3.6.x but private in 4.x). */
+#if MBEDTLS_VERSION_MAJOR < 4
+#include <mbedtls/pkcs5.h>
+#include <mbedtls/md.h>
+#endif
 
 #include <jwt.h>
 
@@ -255,6 +264,84 @@ static int mbedtls_sha(int sha_bits, const unsigned char *in, size_t in_len,
 	return 0;
 }
 
+#if MBEDTLS_VERSION_MAJOR >= 4
+static int mbedtls_pbkdf2(int sha_bits, const unsigned char *pw, size_t pw_len,
+			  const unsigned char *salt, size_t salt_len,
+			  unsigned int iter, unsigned char *out, size_t dk_len)
+{
+	psa_key_derivation_operation_t op = PSA_KEY_DERIVATION_OPERATION_INIT;
+	psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+	mbedtls_svc_key_id_t pwkey = MBEDTLS_SVC_KEY_ID_INIT;
+	psa_algorithm_t alg;
+	int ret = 1;
+
+	switch (sha_bits) {
+	case 256:
+		alg = PSA_ALG_PBKDF2_HMAC(PSA_ALG_SHA_256);
+		break;
+	case 384:
+		alg = PSA_ALG_PBKDF2_HMAC(PSA_ALG_SHA_384);
+		break;
+	case 512:
+		alg = PSA_ALG_PBKDF2_HMAC(PSA_ALG_SHA_512);
+		break;
+	default:
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	if (psa_crypto_init() != PSA_SUCCESS)
+		return 1; // LCOV_EXCL_LINE
+
+	/* The PBKDF2 password is imported as a PSA key (PSA_KEY_TYPE_PASSWORD);
+	 * MbedTLS requires the PASSWORD input via a key, not raw bytes. */
+	psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_DERIVE);
+	psa_set_key_algorithm(&attr, alg);
+	psa_set_key_type(&attr, PSA_KEY_TYPE_PASSWORD);
+	if (psa_import_key(&attr, pw, pw_len, &pwkey) != PSA_SUCCESS)
+		return 1; // LCOV_EXCL_LINE
+
+	/* PSA PBKDF2 input order: cost, salt, password. */
+	if (psa_key_derivation_setup(&op, alg) == PSA_SUCCESS &&
+	    psa_key_derivation_input_integer(&op, PSA_KEY_DERIVATION_INPUT_COST,
+					     iter) == PSA_SUCCESS &&
+	    psa_key_derivation_input_bytes(&op, PSA_KEY_DERIVATION_INPUT_SALT,
+					   salt, salt_len) == PSA_SUCCESS &&
+	    psa_key_derivation_input_key(&op, PSA_KEY_DERIVATION_INPUT_PASSWORD,
+					 pwkey) == PSA_SUCCESS &&
+	    psa_key_derivation_output_bytes(&op, out, dk_len) == PSA_SUCCESS)
+		ret = 0;
+
+	psa_key_derivation_abort(&op);
+	psa_destroy_key(pwkey);
+
+	return ret;
+}
+#else
+static int mbedtls_pbkdf2(int sha_bits, const unsigned char *pw, size_t pw_len,
+			  const unsigned char *salt, size_t salt_len,
+			  unsigned int iter, unsigned char *out, size_t dk_len)
+{
+	mbedtls_md_type_t md;
+
+	switch (sha_bits) {
+	case 256:
+		md = MBEDTLS_MD_SHA256;
+		break;
+	case 384:
+		md = MBEDTLS_MD_SHA384;
+		break;
+	case 512:
+		md = MBEDTLS_MD_SHA512;
+		break;
+	default:
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	return mbedtls_pkcs5_pbkdf2_hmac_ext(md, pw, pw_len, salt, salt_len,
+					     iter, (uint32_t)dk_len, out) ? 1 : 0;
+}
+#endif
+
 /* Export our ops */
 struct jwt_crypto_ops jwt_mbedtls_ops = {
 	.name			= "mbedtls",
@@ -263,6 +350,7 @@ struct jwt_crypto_ops jwt_mbedtls_ops = {
 	.sign_sha_hmac		= mbedtls_sign_sha_hmac,
 	.sign_sha_pem		= mbedtls_sign_sha_pem,
 	.verify_sha_pem		= mbedtls_verify_sha_pem,
+	.pbkdf2			= mbedtls_pbkdf2,
 
 	.jwk_implemented	= 1,
 	.process_eddsa		= mbedtls_process_eddsa,

--- a/libjwt/openssl/sign-verify.c
+++ b/libjwt/openssl/sign-verify.c
@@ -474,6 +474,33 @@ static int openssl_sha(int sha_bits, const unsigned char *in, size_t in_len,
 	return 0;
 }
 
+static int openssl_pbkdf2(int sha_bits, const unsigned char *pw, size_t pw_len,
+			  const unsigned char *salt, size_t salt_len,
+			  unsigned int iter, unsigned char *out, size_t dk_len)
+{
+	const EVP_MD *md;
+
+	switch (sha_bits) {
+	case 256:
+		md = EVP_sha256();
+		break;
+	case 384:
+		md = EVP_sha384();
+		break;
+	case 512:
+		md = EVP_sha512();
+		break;
+	default:
+		return 1; // LCOV_EXCL_LINE
+	}
+
+	if (PKCS5_PBKDF2_HMAC((const char *)pw, (int)pw_len, salt, (int)salt_len,
+			      (int)iter, md, (int)dk_len, out) != 1)
+		return 1; // LCOV_EXCL_LINE
+
+	return 0;
+}
+
 /* Export our ops */
 struct jwt_crypto_ops jwt_openssl_ops = {
 	.name			= "openssl",
@@ -495,6 +522,7 @@ struct jwt_crypto_ops jwt_openssl_ops = {
 	.generate_pem		= openssl_generate_pem,
 
 	.sha			= openssl_sha,
+	.pbkdf2			= openssl_pbkdf2,
 
 	.jwe_implemented	= 1,
 	.rng			= openssl_rng,

--- a/tests/jwe_pbes2.c
+++ b/tests/jwe_pbes2.c
@@ -1,0 +1,258 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* @rfc{7518,4.8} PBES2 password-based key management
+ * (PBES2-HS256+A128KW / HS384+A192KW / HS512+A256KW), issue #310. The oct key's
+ * octets are the password. Runs under each crypto backend (SET_OPS) and both
+ * JSON backends. A low p2c keeps the tests fast; the security checks (p2c cap,
+ * short salt, wrong password) do not depend on it. */
+
+static const char PT[] = "{\"sub\":\"1234567890\"}";
+#define TEST_P2C 2048
+
+/* Build a PBES2 token (JSON Flattened so p2s/p2c are plaintext-inspectable). */
+static char *gen(const jwk_item_t *key, jwe_key_alg_t alg)
+{
+	jwe_builder_auto_t *b = jwe_builder_new();
+
+	if (jwe_builder_setkey(b, alg, JWE_ENC_A256GCM, key) ||
+	    jwe_builder_set_format(b, JWE_FORMAT_JSON_FLAT) ||
+	    jwe_builder_setpbes2(b, TEST_P2C))
+		return NULL;
+
+	return jwe_builder_generate(b, (const unsigned char *)PT, strlen(PT));
+}
+
+static void roundtrip(jwe_key_alg_t alg)
+{
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	read_json("oct_key_256_enc.json");
+
+	tok = gen(g_item, alg);
+	ck_assert_ptr_nonnull(tok);
+	ck_assert_ptr_nonnull(strstr(tok, "\"p2s\":"));
+	ck_assert_ptr_nonnull(strstr(tok, "\"p2c\":"));
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, alg, JWE_ENC_A256GCM,
+					    g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_int_eq(pt_len, strlen(PT));
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	free(pt);
+	free_key();
+}
+
+START_TEST(rt_hs256)
+{
+	SET_OPS();
+	roundtrip(JWE_ALG_PBES2_HS256_A128KW);
+}
+END_TEST
+
+START_TEST(rt_hs384)
+{
+	SET_OPS();
+	roundtrip(JWE_ALG_PBES2_HS384_A192KW);
+}
+END_TEST
+
+START_TEST(rt_hs512)
+{
+	SET_OPS();
+	roundtrip(JWE_ALG_PBES2_HS512_A256KW);
+}
+END_TEST
+
+/* Compact Serialization carries p2s/p2c in the protected header. */
+START_TEST(rt_compact)
+{
+	jwe_builder_auto_t *builder = NULL;
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+
+	builder = jwe_builder_new();
+	ck_assert_int_eq(jwe_builder_setkey(builder, JWE_ALG_PBES2_HS256_A128KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	ck_assert_int_eq(jwe_builder_setpbes2(builder, TEST_P2C), 0);
+	tok = jwe_builder_generate(builder, (const unsigned char *)PT,
+				   strlen(PT));
+	ck_assert_ptr_nonnull(tok);
+	ck_assert_int_eq(tok[0] == '{', 0);	/* dotted compact, not JSON */
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_PBES2_HS256_A128KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt(checker, tok, &pt_len);
+	ck_assert_ptr_nonnull(pt);
+	ck_assert_mem_eq(pt, PT, pt_len);
+
+	free(pt);
+	free_key();
+}
+END_TEST
+
+/* Replace the "p2c":N value in a JSON token with @repl and assert decrypt
+ * fails (the cap / floor rejects before any PBKDF2 work). */
+static void reject_with_p2c(const char *repl)
+{
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	char *mangled, *p;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+	char find[32];
+
+	read_json("oct_key_256_enc.json");
+	tok = gen(g_item, JWE_ALG_PBES2_HS256_A128KW);
+	ck_assert_ptr_nonnull(tok);
+
+	snprintf(find, sizeof(find), "\"p2c\":%d", TEST_P2C);
+	p = strstr(tok, find);
+	ck_assert_ptr_nonnull(p);
+
+	mangled = malloc(strlen(tok) + strlen(repl) + 1);
+	ck_assert_ptr_nonnull(mangled);
+	memcpy(mangled, tok, p - tok);
+	mangled[p - tok] = '\0';
+	strcat(mangled, repl);
+	strcat(mangled, p + strlen(find));
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_PBES2_HS256_A128KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, mangled, &pt_len);
+	ck_assert_ptr_null(pt);
+
+	free(pt);
+	free(mangled);
+	free_key();
+}
+
+/* An over-cap p2c is rejected (DoS guard) without running PBKDF2. */
+START_TEST(p2c_over_cap_rejected)
+{
+	SET_OPS();
+	reject_with_p2c("\"p2c\":2000000000");
+}
+END_TEST
+
+/* A zero p2c is rejected. */
+START_TEST(p2c_zero_rejected)
+{
+	SET_OPS();
+	reject_with_p2c("\"p2c\":0");
+}
+END_TEST
+
+/* A too-short p2s (salt) is rejected (RFC 7518 4.8.1.1 requires >= 8 octets).
+ * "AAAA" base64url-decodes to 3 octets. */
+START_TEST(short_salt_rejected)
+{
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	char *mangled, *p, *q;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+	tok = gen(g_item, JWE_ALG_PBES2_HS256_A128KW);
+	ck_assert_ptr_nonnull(tok);
+
+	/* Replace the "p2s":"...." value with a 3-octet salt. */
+	p = strstr(tok, "\"p2s\":\"");
+	ck_assert_ptr_nonnull(p);
+	q = strchr(p + 7, '"');		/* closing quote of the p2s value */
+	ck_assert_ptr_nonnull(q);
+
+	mangled = malloc(strlen(tok) + 16);
+	ck_assert_ptr_nonnull(mangled);
+	memcpy(mangled, tok, p - tok);
+	mangled[p - tok] = '\0';
+	strcat(mangled, "\"p2s\":\"AAAA\"");
+	strcat(mangled, q + 1);
+
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_PBES2_HS256_A128KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, mangled, &pt_len);
+	ck_assert_ptr_null(pt);
+
+	free(pt);
+	free(mangled);
+	free_key();
+}
+END_TEST
+
+/* A wrong password (different oct key) fails to decrypt. */
+START_TEST(wrong_password)
+{
+	jwe_checker_auto_t *checker = NULL;
+	char_auto *tok = NULL;
+	unsigned char *pt = NULL;
+	size_t pt_len = 0;
+
+	SET_OPS();
+	read_json("oct_key_256_enc.json");
+	tok = gen(g_item, JWE_ALG_PBES2_HS256_A128KW);
+	ck_assert_ptr_nonnull(tok);
+	free_key();
+
+	/* A different oct key (password) must not decrypt. */
+	read_json("oct_dir_256.json");
+	checker = jwe_checker_new();
+	ck_assert_int_eq(jwe_checker_setkey(checker, JWE_ALG_PBES2_HS256_A128KW,
+					    JWE_ENC_A256GCM, g_item), 0);
+	pt = jwe_checker_decrypt_all(checker, tok, &pt_len);
+	ck_assert_ptr_null(pt);
+
+	free(pt);
+	free_key();
+}
+END_TEST
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+	int i = ARRAY_SIZE(jwt_test_ops);
+
+	s = suite_create(title);
+	tc_core = tcase_create("jwe_pbes2");
+
+	tcase_add_loop_test(tc_core, rt_hs256, 0, i);
+	tcase_add_loop_test(tc_core, rt_hs384, 0, i);
+	tcase_add_loop_test(tc_core, rt_hs512, 0, i);
+	tcase_add_loop_test(tc_core, rt_compact, 0, i);
+	tcase_add_loop_test(tc_core, p2c_over_cap_rejected, 0, i);
+	tcase_add_loop_test(tc_core, p2c_zero_rejected, 0, i);
+	tcase_add_loop_test(tc_core, short_salt_rejected, 0, i);
+	tcase_add_loop_test(tc_core, wrong_password, 0, i);
+
+	tcase_set_timeout(tc_core, 60);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	JWT_TEST_MAIN("LibJWT PBES2 password-based key management (#310)");
+}


### PR DESCRIPTION
Closes #310.

Adds **`PBES2-HS256+A128KW` / `PBES2-HS384+A192KW` / `PBES2-HS512+A256KW`** — password-based JWE key management. A key-wrapping key is derived from a passphrase (the `oct` key's octets) with PBKDF2 over a fresh random salt, then AES-KW wraps the CEK. `p2s` (salt) / `p2c` (iterations) ride in the per-recipient header (protected header for Compact), threaded like the GCM-KW `iv`/`tag` and ECDH-ES `epk`.

### New PBKDF2 crypto op (there was none)
- **OpenSSL** `PKCS5_PBKDF2_HMAC`, **GnuTLS** `gnutls_pbkdf2`.
- **MbedTLS**: PSA on 4.x; the **public** PKCS#5 API on 3.6.x — gated on `MBEDTLS_VERSION_MAJOR`. (The 3.6.x PSA build in the CI image doesn't enable PSA PBKDF2 at runtime, and `mbedtls/pkcs5.h` is public in 3.6.x but private in 4.x, so each version uses its supported public API.)

Salt input follows RFC 7518 §4.8.1.1: `UTF8(alg) || 0x00 || p2s`. `jwe_builder_setpbes2()` sets the iteration count (0 = a strong default).

### Security (load-bearing, RFC 7518 §8.8)
- The salt is generated **internally** per wrap, never caller-supplied.
- On decrypt the attacker-controlled `p2c` is **capped** (hard maximum) and the salt length **floored** (≥ 8 octets) **before any PBKDF2 work** — blocking a CPU-exhaustion DoS, the same reasoning that keeps `zip` out.
- Bad password / over-cap `p2c` / short salt funnels to a random CEK so the content AEAD fails uniformly (RFC 7516 §11.5).

### Tests — `tests/jwe_pbes2.c` (both JSON backends, all crypto backends)
Round-trip all three variants (Compact + JSON), over-cap `p2c` rejected, zero `p2c` rejected, short salt rejected, wrong password rejected. **34/34** suites pass locally (MbedTLS 4.1, PSA path) and in the CI image (MbedTLS 3.6.6, PKCS#5 path); valgrind-clean. `@since 3.6.0`; README JWE matrix + `p2c`-cap note added.

This completes the JWE key-management matrix (#309 GCM-KW + #310 PBES2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
