### PR TITLE
jwks: cached/refreshing remote JWKS source (TTL/ETag/cooldown, #313)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,6 +427,9 @@ if (CHECK_FOUND)
 	# RFC 7517 X.509 params (x5c/x5t/x5t#S256)
 	list (APPEND UNIT_TESTS jwt_x509)
 
+	# Cached remote JWKS source (TTL/ETag/cooldown)
+	list (APPEND UNIT_TESTS jwt_jwks_cache)
+
 	# ML-DSA (FIPS 204 / RFC 9964). The test is a no-op unless the build
 	# enabled WITH_ML_DSA against a capable backend.
 	list (APPEND UNIT_TESTS jwt_mldsa)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ thumbprint is verified against the leaf certificate at parse time
 Certificate-chain validation and `x5u` fetching are intentionally left to the
 caller for now (chain/trust policy and SSRF are security-critical).
 
+#### Cached remote JWKS (libcurl)
+
+`jwks_load_fromurl_cached()` fetches a JWKS from a URL and reuses the keyring as
+a cache: subsequent calls serve the cached keys without a network request while
+they are fresh (honoring the response `Cache-Control: max-age`, else a
+configurable TTL), and a stale cache is refreshed with a conditional GET
+(`If-None-Match`/`ETag`, so a `304` keeps the keys). `jwks_refresh_fromurl()`
+forces a refresh on an unknown-`kid` (key rotation), rate-limited by a cooldown
+so random `kid` values cannot amplify into a request flood. Only `http`/`https`
+URLs are accepted (an SSRF guard). Requires the `WITH_LIBCURL` build.
+
 #### JWE
 
 LibJWT supports JWE (RFC 7516) in both the Compact Serialization and the JSON

--- a/include/jwt.h
+++ b/include/jwt.h
@@ -2605,6 +2605,65 @@ JWT_EXPORT
 jwk_set_t *jwks_create_fromurl(const char *url, int verify);
 
 /**
+ * @brief Configuration for a cached remote JWKS source
+ *
+ * Passed to jwks_load_fromurl_cached(). All fields may be 0 to take the
+ * defaults. @since 3.6.0
+ */
+typedef struct {
+	int verify;	/**< TLS verification: peer + host (0 = insecure)	*/
+	int ttl;	/**< Fallback cache lifetime in seconds when the
+			 *   server sends no ``Cache-Control: max-age``
+			 *   (<= 0 = a built-in default)			*/
+	int cooldown;	/**< Minimum seconds between forced (kid-miss)
+			 *   refreshes (< 0 = a built-in default)		*/
+} jwks_url_config_t;
+
+/**
+ * @brief Load a JWKS from a URL with caching, TTL, and conditional refresh
+ *
+ * A caching wrapper around the network fetch (only with libcurl). The keyring
+ * @p jwk_set holds the cache: on the first call it is fetched and stored; on a
+ * later call with the same @p jwk_set and @p url the cached keys are returned
+ * without a network request while they are still fresh. Freshness comes from
+ * the response ``Cache-Control: max-age`` if present, otherwise
+ * @ref jwks_url_config_t.ttl. Once stale, a conditional GET (``If-None-Match``
+ * with the stored ``ETag``) refreshes the cache; a ``304 Not Modified`` keeps
+ * the existing keys.
+ *
+ * Only ``http`` and ``https`` URLs are accepted (an SSRF guard; unlike
+ * jwks_load_fromurl(), which also allows ``file://``). On a refresh failure the
+ * previously cached keys are retained and the error is set on the keyring.
+ *
+ * @param jwk_set An existing cached keyring to reuse, or NULL to create one
+ * @param url The JWKS URL (``http``/``https``)
+ * @param config Cache configuration, or NULL for the defaults
+ * @return The keyring (cached or refreshed), or NULL on allocation failure or
+ *  when built without libcurl
+ * @since 3.6.0
+ */
+JWT_EXPORT
+jwk_set_t *jwks_load_fromurl_cached(jwk_set_t *jwk_set, const char *url,
+				    const jwks_url_config_t *config);
+
+/**
+ * @brief Force a refresh of a cached JWKS source (key rotation)
+ *
+ * Intended for an unknown-``kid`` (key rotation) miss: re-fetch the JWKS even if
+ * the cache is still fresh. The refresh is rate-limited by the cooldown
+ * configured in jwks_load_fromurl_cached() — within the cooldown window this is
+ * a no-op, which bounds outbound requests an attacker could trigger by
+ * presenting random ``kid`` values.
+ *
+ * @param jwk_set A keyring previously populated by jwks_load_fromurl_cached()
+ * @return The keyring (possibly refreshed); a keyring with no cache is returned
+ *  unchanged
+ * @since 3.6.0
+ */
+JWT_EXPORT
+jwk_set_t *jwks_refresh_fromurl(jwk_set_t *jwk_set);
+
+/**
  * @brief Flags controlling how a native key is imported into a keyring
  *
  * Used with the jwks_load_fromkey() and jwks_create_fromkey() family. The

--- a/libjwt/jwks-curl.c
+++ b/libjwt/jwks-curl.c
@@ -29,6 +29,10 @@ struct jwks_data {
  * server gives no max-age, and refresh on a kid-miss at most once a minute. */
 #define JWKS_DEFAULT_TTL	300
 #define JWKS_DEFAULT_COOLDOWN	60
+/* Upper bound on a cache lifetime (a server max-age or a configured TTL): caps
+ * how long a key set is trusted without revalidation and guards now + age from
+ * overflowing time_t. One week. */
+#define JWKS_MAX_TTL		(7 * 24 * 60 * 60)
 
 /* A fetch result: the body plus the caching metadata from the response. */
 struct curl_result {
@@ -283,18 +287,41 @@ static char *cache_strdup(const char *s)
 	return d;
 }
 
-/* Apply a completed fetch to the cached set: on a 304 keep the keys, otherwise
- * replace them; refresh the ETag and the expiry (from max-age or the TTL). */
+/* Apply a completed fetch to the cached set. Only a 2xx replaces the keys (and
+ * only when the body is a usable JWKS); a 304 keeps them; any other HTTP status
+ * keeps the previously cached keys and sets an error (so a transient 4xx/5xx or
+ * an unfollowed redirect does not wipe a good cache). On a successful refresh
+ * the ETag and expiry are updated; @last_fetch is stamped by the caller on every
+ * attempt (so a failed attempt still consumes the cooldown). */
 static void cache_apply(jwk_set_t *jwk_set, struct curl_result *r)
 {
 	struct jwks_url_cache *c = jwk_set->cache;
 	time_t now = time(NULL);
 	long age;
 
-	if (r->status != 304) {
+	if (r->status == 304) {
+		/* Not Modified: keep the existing keys. */
+	} else if (r->status >= 200 && r->status < 300) {
+		/* Replace, but only if the new body is a usable JWKS; a 2xx with
+		 * a garbage/empty body must not wipe a previously good cache. */
+		jwk_set_t *tmp = jwks_create(r->body);
+		int ok = (tmp != NULL && !jwks_error(tmp) &&
+			  jwks_item_count(tmp) > 0);
+
+		jwks_free(tmp);
+		if (!ok) {
+			jwt_write_error(jwk_set,
+				"JWKS refresh returned no usable keys");
+			return;	/* keep the previously cached keys */
+		}
 		jwks_item_free_all(jwk_set);
-		if (r->body != NULL)
-			jwks_load_strn(jwk_set, r->body, r->len);
+		jwks_load_strn(jwk_set, r->body, r->len);
+	} else {
+		/* HTTP error (e.g. 4xx/5xx, or an unfollowed 3xx): retain the
+		 * previously cached keys per the documented contract. */
+		jwt_write_error(jwk_set,
+			"JWKS refresh failed (HTTP status %ld)", r->status);
+		return;
 	}
 
 	if (r->etag != NULL) {
@@ -303,9 +330,14 @@ static void cache_apply(jwk_set_t *jwk_set, struct curl_result *r)
 		r->etag = NULL;
 	}
 
+	/* Clamp the (possibly server-controlled) max-age so it cannot pin the
+	 * cache forever or overflow time_t in the expiry computation. */
 	age = (r->max_age >= 0) ? r->max_age : c->ttl;
-	c->expiry = now + (age > 0 ? age : 0);
-	c->last_fetch = now;
+	if (age < 0)
+		age = 0;
+	if (age > JWKS_MAX_TTL)
+		age = JWKS_MAX_TTL;
+	c->expiry = now + age;
 }
 
 jwk_set_t *jwks_load_fromurl_cached(jwk_set_t *jwk_set, const char *url,
@@ -351,6 +383,7 @@ jwk_set_t *jwks_load_fromurl_cached(jwk_set_t *jwk_set, const char *url,
 		c->cooldown = (config && config->cooldown >= 0) ? config->cooldown
 								: JWKS_DEFAULT_COOLDOWN;
 
+		c->last_fetch = time(NULL);
 		if (__curl_fetch(jwk_set, url, c->verify, NULL, &r))
 			return jwk_set;	/* error set; no keys yet */
 		cache_apply(jwk_set, &r);
@@ -364,6 +397,7 @@ jwk_set_t *jwks_load_fromurl_cached(jwk_set_t *jwk_set, const char *url,
 		return jwk_set;
 
 	/* Stale: conditional GET. On failure keep the (stale) keys + set error. */
+	c->last_fetch = time(NULL);
 	if (__curl_fetch(jwk_set, url, c->verify, c->etag, &r))
 		return jwk_set;
 	cache_apply(jwk_set, &r);
@@ -385,10 +419,14 @@ jwk_set_t *jwks_refresh_fromurl(jwk_set_t *jwk_set)
 	c = jwk_set->cache;
 
 	/* @rfc{8725} Cooldown: bound how often a kid-miss can force an outbound
-	 * fetch, so random unknown kids cannot amplify into a request flood. */
+	 * fetch, so random unknown kids cannot amplify into a request flood. The
+	 * attempt is stamped BEFORE the fetch so that a failing/unreachable origin
+	 * still consumes the cooldown window (otherwise the throttle never
+	 * engages while the endpoint is down). */
 	if (time(NULL) - c->last_fetch < c->cooldown)
 		return jwk_set;
 
+	c->last_fetch = time(NULL);
 	if (__curl_fetch(jwk_set, c->url, c->verify, c->etag, &r))
 		return jwk_set;
 	cache_apply(jwk_set, &r);

--- a/libjwt/jwks-curl.c
+++ b/libjwt/jwks-curl.c
@@ -13,6 +13,7 @@
 #include "jwt-private.h"
 
 #ifdef HAVE_LIBCURL
+#include <strings.h>
 #include <curl/curl.h>
 
 struct jwks_data {
@@ -23,6 +24,20 @@ struct jwks_data {
 
 /* Maximum size we will accept for a JWKS response (1 MiB). */
 #define JWKS_MAX_RESPONSE_SIZE	(1024 * 1024)
+
+/* @rfc{7517} Cached-source defaults (issue #313): cache for 5 minutes when the
+ * server gives no max-age, and refresh on a kid-miss at most once a minute. */
+#define JWKS_DEFAULT_TTL	300
+#define JWKS_DEFAULT_COOLDOWN	60
+
+/* A fetch result: the body plus the caching metadata from the response. */
+struct curl_result {
+	char *body;		/* jwt_malloc'd body (or NULL)			*/
+	size_t len;
+	long status;		/* HTTP status code (0 for non-HTTP, e.g. file)	*/
+	long max_age;		/* Cache-Control max-age seconds, or -1		*/
+	char *etag;		/* jwt_malloc'd ETag value, or NULL		*/
+};
 
 /* Grow the response buffer to hold at least need bytes plus a NUL. The caller
  * has already bounded need by JWKS_MAX_RESPONSE_SIZE, so need + 1 cannot
@@ -88,27 +103,91 @@ static size_t write_cb(void *contents, size_t size, size_t nmemb, void *ctx)
 	return total_size;
 }
 
-static char *__curl_get(jwk_set_t *jwk_set, const char *url, size_t *len,
-			int verify)
+/* Case-insensitive search for @needle within @hay[0..hlen). */
+static const char *ci_find(const char *hay, size_t hlen, const char *needle)
 {
-	CURL *curl;
-	CURLcode res;
+	size_t nlen = strlen(needle), i;
+
+	if (nlen == 0 || hlen < nlen)
+		return NULL; // LCOV_EXCL_LINE
+
+	for (i = 0; i + nlen <= hlen; i++)
+		if (!strncasecmp(hay + i, needle, nlen))
+			return hay + i;
+
+	return NULL;
+}
+
+/* Capture "Cache-Control: max-age" and "ETag" from the response headers. */
+static size_t header_cb(char *buf, size_t size, size_t nitems, void *ctx)
+{
+	struct curl_result *out = ctx;
+	size_t len = size * nitems;
+
+	if (len >= 14 && !strncasecmp(buf, "Cache-Control:", 14)) {
+		const char *p = ci_find(buf, len, "max-age=");
+
+		if (p != NULL)
+			out->max_age = strtol(p + 8, NULL, 10);
+	} else if (len >= 5 && !strncasecmp(buf, "ETag:", 5)) {
+		const char *v = buf + 5;
+		size_t vlen;
+
+		while (v < buf + len && (*v == ' ' || *v == '\t'))
+			v++;
+		vlen = (size_t)(buf + len - v);
+		while (vlen > 0 && (v[vlen - 1] == '\r' || v[vlen - 1] == '\n' ||
+				    v[vlen - 1] == ' ' || v[vlen - 1] == '\t'))
+			vlen--;
+
+		if (vlen > 0) {
+			char *e = jwt_malloc(vlen + 1);
+
+			if (e != NULL) {
+				memcpy(e, v, vlen);
+				e[vlen] = '\0';
+				jwt_freemem(out->etag);	/* last wins */
+				out->etag = e;
+			}
+		}
+	}
+
+	return len;
+}
+
+/* Fetch @url, capturing the body and the response's caching metadata. When
+ * @if_none_match is set it is sent as a conditional GET (so a 304 is possible).
+ * Returns 0 on a completed request (out->status carries the HTTP code). */
+static int __curl_fetch(jwk_set_t *jwk_set, const char *url, int verify,
+			const char *if_none_match, struct curl_result *out)
+{
+	static int curl_inited;
+	struct curl_slist *hdrs = NULL;
 	struct jwks_data data;
+	char *inm = NULL;
+	CURLcode res;
+	CURL *curl;
 
 	memset(&data, 0, sizeof(data));
- 
-	curl_global_init(CURL_GLOBAL_DEFAULT);
-	curl = curl_easy_init();
-	if (curl == NULL) {
-		// LCOV_EXCL_START
-		curl_global_cleanup();
-		return NULL;
-		// LCOV_EXCL_STOP
+	memset(out, 0, sizeof(*out));
+	out->max_age = -1;
+
+	/* curl_global_init() must run once. Doing it per request and pairing it
+	 * with curl_global_cleanup() tears down and rebuilds libcurl's global
+	 * state on every cached fetch; init once and let it be released at exit. */
+	if (!curl_inited) {
+		curl_global_init(CURL_GLOBAL_DEFAULT);
+		curl_inited = 1;
 	}
+	curl = curl_easy_init();
+	if (curl == NULL)
+		return 1; // LCOV_EXCL_LINE
 
 	curl_easy_setopt(curl, CURLOPT_URL, url);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&data);
+	curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_cb);
+	curl_easy_setopt(curl, CURLOPT_HEADERDATA, (void *)out);
 
 	/* Belt to the write_cb cap: let libcurl abort early when the server
 	 * advertises an oversized body via Content-Length. */
@@ -116,28 +195,51 @@ static char *__curl_get(jwk_set_t *jwk_set, const char *url, size_t *len,
 			 (long)JWKS_MAX_RESPONSE_SIZE);
 
 	/* Hostname verification is meaningless without peer (CA chain)
-	 * verification: anyone can present a self-signed certificate bearing
-	 * the target hostname, so VERIFYHOST without VERIFYPEER provides no
-	 * protection against an active MITM. Tie the two together: any
-	 * verify >= 1 enables full verification; only verify == 0 (explicitly
-	 * insecure) disables it. */
+	 * verification, so tie the two together: any verify >= 1 enables full
+	 * verification; only verify == 0 (explicitly insecure) disables it. */
 	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, (verify > 0) ? 2L : 0L);
 	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, (verify > 0) ? 1L : 0L);
 
-        res = curl_easy_perform(curl);
+	if (if_none_match != NULL &&
+	    asprintf(&inm, "If-None-Match: %s", if_none_match) > 0) {
+		hdrs = curl_slist_append(NULL, inm);
+		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hdrs);
+	}
 
+	res = curl_easy_perform(curl);
+	curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &out->status);
+
+	if (hdrs != NULL)
+		curl_slist_free_all(hdrs);
+	free(inm);
 	curl_easy_cleanup(curl);
-	curl_global_cleanup();
 
 	if (res != CURLE_OK) {
 		jwt_write_error(jwk_set, "%s", curl_easy_strerror(res));
 		jwt_freemem(data.buf);
-		return NULL;
+		jwt_freemem(out->etag);
+		out->etag = NULL;
+		return 1;
 	}
 
-	*len = data.size;
+	out->body = data.buf;
+	out->len = data.size;
 
-	return data.buf;
+	return 0;
+}
+
+static char *__curl_get(jwk_set_t *jwk_set, const char *url, size_t *len,
+			int verify)
+{
+	struct curl_result r;
+
+	if (__curl_fetch(jwk_set, url, verify, NULL, &r))
+		return NULL;
+
+	jwt_freemem(r.etag);	/* the one-shot loader ignores caching headers */
+	*len = r.len;
+
+	return r.body;
 }
 
 jwk_set_t *jwks_load_fromurl(jwk_set_t *jwk_set, const char *url, int verify)
@@ -162,6 +264,140 @@ jwk_set_t *jwks_load_fromurl(jwk_set_t *jwk_set, const char *url, int verify)
 	return jwk_set;
 }
 
+/* @rfc{8725} Only http(s) is allowed for a cached source, to avoid an SSRF /
+ * local-file-read vector (the one-shot jwks_load_fromurl still allows file://). */
+static int url_scheme_ok(const char *url)
+{
+	return !strncasecmp(url, "http://", 7) ||
+	       !strncasecmp(url, "https://", 8);
+}
+
+static char *cache_strdup(const char *s)
+{
+	size_t n = strlen(s) + 1;
+	char *d = jwt_malloc(n);
+
+	if (d != NULL)
+		memcpy(d, s, n);
+
+	return d;
+}
+
+/* Apply a completed fetch to the cached set: on a 304 keep the keys, otherwise
+ * replace them; refresh the ETag and the expiry (from max-age or the TTL). */
+static void cache_apply(jwk_set_t *jwk_set, struct curl_result *r)
+{
+	struct jwks_url_cache *c = jwk_set->cache;
+	time_t now = time(NULL);
+	long age;
+
+	if (r->status != 304) {
+		jwks_item_free_all(jwk_set);
+		if (r->body != NULL)
+			jwks_load_strn(jwk_set, r->body, r->len);
+	}
+
+	if (r->etag != NULL) {
+		jwt_freemem(c->etag);
+		c->etag = r->etag;
+		r->etag = NULL;
+	}
+
+	age = (r->max_age >= 0) ? r->max_age : c->ttl;
+	c->expiry = now + (age > 0 ? age : 0);
+	c->last_fetch = now;
+}
+
+jwk_set_t *jwks_load_fromurl_cached(jwk_set_t *jwk_set, const char *url,
+				    const jwks_url_config_t *config)
+{
+	struct jwks_url_cache *c;
+	struct curl_result r;
+
+	if (url == NULL)
+		return NULL;
+
+	if (jwk_set == NULL)
+		jwk_set = jwks_create(NULL);
+	if (jwk_set == NULL)
+		return NULL; // LCOV_EXCL_LINE
+
+	if (!url_scheme_ok(url)) {
+		jwt_write_error(jwk_set,
+			"Only http(s) URLs are allowed for a cached JWKS source");
+		return jwk_set;
+	}
+
+	c = jwk_set->cache;
+
+	/* First use, or the URL changed: (re)initialize the cache and fetch. */
+	if (c == NULL || c->url == NULL || strcmp(c->url, url)) {
+		if (c == NULL) {
+			c = jwt_malloc(sizeof(*c));
+			if (c == NULL)
+				return jwk_set; // LCOV_EXCL_LINE
+			memset(c, 0, sizeof(*c));
+			jwk_set->cache = c;
+		} else {
+			jwt_freemem(c->url);
+			jwt_freemem(c->etag);
+			c->etag = NULL;
+			jwks_item_free_all(jwk_set);
+		}
+		c->url = cache_strdup(url);
+		c->verify = config ? config->verify : 1;
+		c->ttl = (config && config->ttl > 0) ? config->ttl
+						     : JWKS_DEFAULT_TTL;
+		c->cooldown = (config && config->cooldown >= 0) ? config->cooldown
+								: JWKS_DEFAULT_COOLDOWN;
+
+		if (__curl_fetch(jwk_set, url, c->verify, NULL, &r))
+			return jwk_set;	/* error set; no keys yet */
+		cache_apply(jwk_set, &r);
+		jwt_freemem(r.body);
+		jwt_freemem(r.etag);
+		return jwk_set;
+	}
+
+	/* Fresh: serve from cache with no network request. */
+	if (time(NULL) < c->expiry)
+		return jwk_set;
+
+	/* Stale: conditional GET. On failure keep the (stale) keys + set error. */
+	if (__curl_fetch(jwk_set, url, c->verify, c->etag, &r))
+		return jwk_set;
+	cache_apply(jwk_set, &r);
+	jwt_freemem(r.body);
+	jwt_freemem(r.etag);
+
+	return jwk_set;
+}
+
+jwk_set_t *jwks_refresh_fromurl(jwk_set_t *jwk_set)
+{
+	struct jwks_url_cache *c;
+	struct curl_result r;
+
+	if (jwk_set == NULL || jwk_set->cache == NULL ||
+	    jwk_set->cache->url == NULL)
+		return jwk_set;
+
+	c = jwk_set->cache;
+
+	/* @rfc{8725} Cooldown: bound how often a kid-miss can force an outbound
+	 * fetch, so random unknown kids cannot amplify into a request flood. */
+	if (time(NULL) - c->last_fetch < c->cooldown)
+		return jwk_set;
+
+	if (__curl_fetch(jwk_set, c->url, c->verify, c->etag, &r))
+		return jwk_set;
+	cache_apply(jwk_set, &r);
+	jwt_freemem(r.body);
+	jwt_freemem(r.etag);
+
+	return jwk_set;
+}
+
 #else
 
 jwk_set_t *jwks_load_fromurl(jwk_set_t *jwk_set, const char *url, int verify)
@@ -170,6 +406,20 @@ jwk_set_t *jwks_load_fromurl(jwk_set_t *jwk_set, const char *url, int verify)
 	(void)url;
 	(void)verify;
 	return NULL;
+}
+
+jwk_set_t *jwks_load_fromurl_cached(jwk_set_t *jwk_set, const char *url,
+				    const jwks_url_config_t *config)
+{
+	(void)jwk_set;
+	(void)url;
+	(void)config;
+	return NULL;
+}
+
+jwk_set_t *jwks_refresh_fromurl(jwk_set_t *jwk_set)
+{
+	return jwk_set;
 }
 
 #endif

--- a/libjwt/jwks.c
+++ b/libjwt/jwks.c
@@ -578,6 +578,11 @@ void jwks_free(jwk_set_t *jwk_set)
 		return;
 
 	jwks_item_free_all(jwk_set);
+	if (jwk_set->cache != NULL) {
+		jwt_freemem(jwk_set->cache->url);
+		jwt_freemem(jwk_set->cache->etag);
+		jwt_freemem(jwk_set->cache);
+	}
 	jwt_freemem(jwk_set);
 }
 

--- a/libjwt/jwt-private.h
+++ b/libjwt/jwt-private.h
@@ -272,10 +272,23 @@ struct jwt {
 	};
 };
 
+/* @rfc{7517} Remote-fetch cache state for a JWKS URL source (issue #313, only
+ * meaningful with libcurl). Lives on the jwk_set; NULL for a non-URL set. */
+struct jwks_url_cache {
+	char *url;		/* The source URL (http/https)			*/
+	char *etag;		/* Last ETag, for conditional GET (or NULL)	*/
+	int verify;		/* TLS verification (peer+host)			*/
+	int ttl;		/* Fallback cache lifetime if no max-age (s)	*/
+	int cooldown;		/* Min seconds between kid-miss refreshes	*/
+	time_t expiry;		/* Cache valid until this wall-clock time	*/
+	time_t last_fetch;	/* Time of the last network fetch (cooldown)	*/
+};
+
 struct jwk_set {
 	ll_t head;
 	int error;
 	char error_msg[JWT_ERR_LEN];
+	struct jwks_url_cache *cache;	/* @rfc{7517} URL cache, or NULL	*/
 };
 
 /**

--- a/tests/jwt_jwks_cache.c
+++ b/tests/jwt_jwks_cache.c
@@ -1,0 +1,308 @@
+/* Public domain, no copyright. Use at your own risk. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jwt_tests.h"
+
+/* @rfc{7517} Cached remote JWKS source: TTL, Cache-Control/ETag conditional
+ * refresh (304), kid-miss refresh + cooldown, and the http(s) SSRF guard
+ * (issue #313). Only meaningful with libcurl; a tiny in-process HTTP server
+ * serves the JWKS with caching headers and counts requests. */
+
+#ifdef HAVE_LIBCURL
+#include <pthread.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+/* A minimal one-key JWKS the test server returns. */
+static const char JWKS_BODY[] =
+	"{\"keys\":[{\"kty\":\"EC\",\"crv\":\"P-256\","
+	"\"x\":\"Y--DdSpCZ5oF3j__h-SdNJIwvB5aI4AXzpRErGUjWrM\","
+	"\"y\":\"_bSTCXlDeU-pZZbOKDUVLANspSIeuKZfTM8rtXFG_RU\"}]}";
+
+static struct {
+	int listen_fd;
+	int port;
+	int requests;		/* total GETs served			*/
+	int conditional;	/* GETs that carried If-None-Match	*/
+	int max_age;		/* Cache-Control: max-age to advertise	*/
+	pthread_t thread;
+	pthread_mutex_t lock;
+	volatile int stop;
+} srv;
+
+static void *server_thread(void *arg)
+{
+	(void)arg;
+
+	for (;;) {
+		char req[4096];
+		int fd = accept(srv.listen_fd, NULL, NULL);
+		ssize_t n;
+		int cond;
+
+		if (fd < 0)
+			break;	/* listen socket closed -> shut down */
+
+		n = read(fd, req, sizeof(req) - 1);
+		if (n <= 0) {
+			close(fd);
+			continue;
+		}
+		req[n] = '\0';
+
+		cond = (strstr(req, "If-None-Match: \"v1\"") != NULL);
+
+		pthread_mutex_lock(&srv.lock);
+		srv.requests++;
+		if (cond)
+			srv.conditional++;
+		pthread_mutex_unlock(&srv.lock);
+
+		if (cond) {
+			char hdr[256];
+			int hlen = snprintf(hdr, sizeof(hdr),
+				"HTTP/1.1 304 Not Modified\r\n"
+				"ETag: \"v1\"\r\n"
+				"Cache-Control: max-age=%d\r\n"
+				"\r\n", srv.max_age);
+			(void)write(fd, hdr, hlen);
+		} else {
+			char hdr[256];
+			int hlen = snprintf(hdr, sizeof(hdr),
+				"HTTP/1.1 200 OK\r\n"
+				"Content-Type: application/json\r\n"
+				"ETag: \"v1\"\r\n"
+				"Cache-Control: max-age=%d\r\n"
+				"Content-Length: %zu\r\n"
+				"\r\n", srv.max_age, strlen(JWKS_BODY));
+			(void)write(fd, hdr, hlen);
+			(void)write(fd, JWKS_BODY, strlen(JWKS_BODY));
+		}
+
+		close(fd);
+	}
+
+	return NULL;
+}
+
+static int server_start(void)
+{
+	struct sockaddr_in addr;
+	socklen_t alen = sizeof(addr);
+
+	memset(&srv, 0, sizeof(srv));
+	pthread_mutex_init(&srv.lock, NULL);
+
+	srv.listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (srv.listen_fd < 0)
+		return -1;
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	addr.sin_port = 0;	/* ephemeral */
+
+	if (bind(srv.listen_fd, (struct sockaddr *)&addr, sizeof(addr)) ||
+	    listen(srv.listen_fd, 8) ||
+	    getsockname(srv.listen_fd, (struct sockaddr *)&addr, &alen))
+		return -1;
+
+	srv.port = ntohs(addr.sin_port);
+
+	return pthread_create(&srv.thread, NULL, server_thread, NULL);
+}
+
+static void server_stop(void)
+{
+	shutdown(srv.listen_fd, SHUT_RDWR);
+	close(srv.listen_fd);
+	pthread_join(srv.thread, NULL);
+	pthread_mutex_destroy(&srv.lock);
+}
+
+static int req_count(void)
+{
+	int n;
+
+	pthread_mutex_lock(&srv.lock);
+	n = srv.requests;
+	pthread_mutex_unlock(&srv.lock);
+
+	return n;
+}
+
+static void req_reset(void)
+{
+	pthread_mutex_lock(&srv.lock);
+	srv.requests = 0;
+	srv.conditional = 0;
+	pthread_mutex_unlock(&srv.lock);
+}
+
+static char *make_url(void)
+{
+	char *url = NULL;
+
+	ck_assert_int_gt(asprintf(&url, "http://127.0.0.1:%d/jwks", srv.port), 0);
+
+	return url;
+}
+
+/* A second call within the TTL is served from cache: no new request. */
+START_TEST(test_cache_hit)
+{
+	jwk_set_t *set = NULL;
+	jwks_url_config_t cfg = { .verify = 0, .ttl = 0, .cooldown = 2 };
+	char *url = make_url();
+
+	srv.max_age = 300;	/* fresh well past the test duration */
+	req_reset();
+
+	set = jwks_load_fromurl_cached(NULL, url, &cfg);
+	ck_assert_int_eq(req_count(), 1);
+	ck_assert_int_gt(jwks_item_count(set), 0);
+
+	jwks_load_fromurl_cached(set, url, &cfg);
+	jwks_load_fromurl_cached(set, url, &cfg);
+	ck_assert_int_eq(req_count(), 1);	/* still cached */
+
+	jwks_free(set);
+	free(url);
+}
+END_TEST
+
+/* TTL cache hit; stale -> conditional GET (304) keeps the keys. */
+START_TEST(test_cache_ttl)
+{
+	jwk_set_t *set = NULL;
+	jwks_url_config_t cfg = { .verify = 0, .ttl = 1, .cooldown = 2 };
+	char *url = make_url();
+
+	srv.max_age = 1;
+	req_reset();
+
+	/* First call fetches; one request. */
+	set = jwks_load_fromurl_cached(NULL, url, &cfg);
+	ck_assert_ptr_nonnull(set);
+	ck_assert_int_eq(jwks_error(set), 0);
+	ck_assert_int_gt(jwks_item_count(set), 0);
+	ck_assert_int_eq(req_count(), 1);
+
+	/* After TTL (max-age=1): a conditional GET; the 304 keeps the keys. */
+	sleep(2);
+	jwks_load_fromurl_cached(set, url, &cfg);
+	ck_assert_int_eq(req_count(), 2);
+	ck_assert_int_eq(srv.conditional, 1);
+	ck_assert_int_gt(jwks_item_count(set), 0);
+	ck_assert_int_eq(jwks_error(set), 0);
+
+	jwks_free(set);
+	free(url);
+}
+END_TEST
+
+/* A kid-miss refresh is bounded by the cooldown. */
+START_TEST(test_cooldown)
+{
+	jwk_set_t *set = NULL;
+	jwks_url_config_t cfg = { .verify = 0, .ttl = 100, .cooldown = 2 };
+	char *url = make_url();
+
+	srv.max_age = 300;
+	req_reset();
+
+	set = jwks_load_fromurl_cached(NULL, url, &cfg);
+	ck_assert_int_eq(req_count(), 1);
+
+	/* Immediately forcing a refresh is within the cooldown: no request. */
+	jwks_refresh_fromurl(set);
+	ck_assert_int_eq(req_count(), 1);
+
+	/* After the cooldown elapses, a forced refresh does fetch. */
+	sleep(2);
+	jwks_refresh_fromurl(set);
+	ck_assert_int_eq(req_count(), 2);
+
+	jwks_free(set);
+	free(url);
+}
+END_TEST
+
+/* Only http(s) is accepted; file:// is rejected (SSRF guard). */
+START_TEST(test_scheme_guard)
+{
+	jwk_set_t *set = NULL;
+
+	set = jwks_load_fromurl_cached(NULL, "file:///etc/passwd", NULL);
+	ck_assert_ptr_nonnull(set);
+	ck_assert_int_ne(jwks_error(set), 0);
+	ck_assert_int_eq(jwks_item_count(set), 0);
+
+	jwks_free(set);
+}
+END_TEST
+
+#else  /* !HAVE_LIBCURL */
+
+START_TEST(test_no_libcurl)
+{
+	ck_assert_ptr_null(jwks_load_fromurl_cached(NULL, "https://x/", NULL));
+}
+END_TEST
+
+#endif
+
+static Suite *libjwt_suite(const char *title)
+{
+	Suite *s;
+	TCase *tc_core;
+
+	s = suite_create(title);
+	tc_core = tcase_create("jwt_jwks_cache");
+
+#ifdef HAVE_LIBCURL
+	tcase_add_test(tc_core, test_cache_hit);
+	tcase_add_test(tc_core, test_cache_ttl);
+	tcase_add_test(tc_core, test_cooldown);
+	tcase_add_test(tc_core, test_scheme_guard);
+#else
+	tcase_add_test(tc_core, test_no_libcurl);
+#endif
+
+	tcase_set_timeout(tc_core, 30);
+	suite_add_tcase(s, tc_core);
+
+	return s;
+}
+
+int main(void)
+{
+	int failed;
+	SRunner *sr;
+
+#ifdef HAVE_LIBCURL
+	if (server_start() != 0) {
+		fprintf(stderr, "could not start the test HTTP server\n");
+		return EXIT_FAILURE;
+	}
+#endif
+
+	sr = srunner_create(libjwt_suite("LibJWT cached remote JWKS (#313)"));
+	/* The server thread + request counters live in this process; run the
+	 * tests here too (no fork) so they observe the same state. */
+	srunner_set_fork_status(sr, CK_NOFORK);
+	srunner_run_all(sr, CK_VERBOSE);
+	failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+#ifdef HAVE_LIBCURL
+	server_stop();
+#endif
+
+	return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/jwt_jwks_cache.c
+++ b/tests/jwt_jwks_cache.c
@@ -30,6 +30,7 @@ static struct {
 	int requests;		/* total GETs served			*/
 	int conditional;	/* GETs that carried If-None-Match	*/
 	int max_age;		/* Cache-Control: max-age to advertise	*/
+	int fail;		/* when set, respond 500			*/
 	pthread_t thread;
 	pthread_mutex_t lock;
 	volatile int stop;
@@ -63,7 +64,11 @@ static void *server_thread(void *arg)
 			srv.conditional++;
 		pthread_mutex_unlock(&srv.lock);
 
-		if (cond) {
+		if (srv.fail) {
+			const char *e = "HTTP/1.1 500 Internal Server Error\r\n"
+					"Content-Length: 0\r\n\r\n";
+			(void)write(fd, e, strlen(e));
+		} else if (cond) {
 			char hdr[256];
 			int hlen = snprintf(hdr, sizeof(hdr),
 				"HTTP/1.1 304 Not Modified\r\n"
@@ -233,6 +238,35 @@ START_TEST(test_cooldown)
 }
 END_TEST
 
+/* On an HTTP error during refresh, the previously cached keys are retained
+ * (a transient 5xx must not wipe a good cache). */
+START_TEST(test_refresh_keeps_keys_on_error)
+{
+	jwk_set_t *set = NULL;
+	jwks_url_config_t cfg = { .verify = 0, .ttl = 100, .cooldown = 0 };
+	char *url = make_url();
+	int n;
+
+	srv.max_age = 300;
+	srv.fail = 0;
+	req_reset();
+
+	set = jwks_load_fromurl_cached(NULL, url, &cfg);
+	n = (int)jwks_item_count(set);
+	ck_assert_int_gt(n, 0);
+
+	/* The origin now errors; a forced refresh must keep the cached keys. */
+	srv.fail = 1;
+	jwks_refresh_fromurl(set);
+	ck_assert_int_ne(jwks_error(set), 0);
+	ck_assert_int_eq((int)jwks_item_count(set), n);
+	srv.fail = 0;
+
+	jwks_free(set);
+	free(url);
+}
+END_TEST
+
 /* Only http(s) is accepted; file:// is rejected (SSRF guard). */
 START_TEST(test_scheme_guard)
 {
@@ -269,6 +303,7 @@ static Suite *libjwt_suite(const char *title)
 	tcase_add_test(tc_core, test_cache_hit);
 	tcase_add_test(tc_core, test_cache_ttl);
 	tcase_add_test(tc_core, test_cooldown);
+	tcase_add_test(tc_core, test_refresh_keeps_keys_on_error);
 	tcase_add_test(tc_core, test_scheme_guard);
 #else
 	tcase_add_test(tc_core, test_no_libcurl);


### PR DESCRIPTION
Closes #313.

Turns the one-shot `jwks_load_fromurl()` into a reusable, cached JWKS source (libcurl):

- **`jwks_load_fromurl_cached(set, url, config)`** — serves cached keys with **no network request** while fresh (freshness from `Cache-Control: max-age`, else a configurable TTL); once stale, a **conditional GET** (`If-None-Match`/`ETag`) refreshes, and a **`304`** keeps the existing keys.
- **`jwks_refresh_fromurl(set)`** — forces a refresh for an unknown-`kid` (key rotation), **rate-limited by a cooldown** so random `kid`s can't amplify into an outbound request flood (the load-bearing anti-DoS piece).
- **SSRF guard**: the cached path accepts only `http`/`https` (the one-shot loader still allows `file://`).

The fetch path now parses `Cache-Control`/`ETag` and HTTP status and sends conditional requests; `curl_global_init()` runs once rather than per request. The cache lives on the `jwk_set` and is freed with it. Without libcurl the two calls are clean no-ops.

### Tests — `tests/jwt_jwks_cache.c` (in-process threaded HTTP server)
A tiny request-counting server (serving `Cache-Control`/`ETag`/`304`) verifies: cache hit = no request; TTL-stale → conditional GET → `304` keeps keys; cooldown bounds a kid-miss refresh; `file://` rejected. Gated on `WITH_LIBCURL` (clean skip otherwise). **36/36** suites pass under both JSON backends and in the CI image (with `-DWITH_LIBCURL=YES`); **valgrind-clean**. `@since 3.6.0`; README updated.

> Phase 2 — `jku`/`x5u` fetching sharing this `http(s)` allowlist — remains future (ties in with #314 phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
