### PR TITLE
Release v3.6.0

### DIFF
--- a/cmake/LibJWTVersions.cmake
+++ b/cmake/LibJWTVersions.cmake
@@ -4,9 +4,9 @@ set(LIBJWT_PROJECT		"LibJWT")
 set(LIBJWT_DESCRIPTION		"The C JSON Web Token Library +JWK +JWKS")
 set(LIBJWT_HOMEPAGE_URL		"https://libjwt.io")
 
-set(LIBJWT_VERSION_SET		3 5 0)
+set(LIBJWT_VERSION_SET		3 6 0)
 
-set(LIBJWT_SO_CRA		17 1 3)
+set(LIBJWT_SO_CRA		18 0 4)
 # SONAME History
 # v1.12.1      0 => 1
 # v1.15.0      1 => 2


### PR DESCRIPTION
Release v3.6.0.

Bumps `LIBJWT_VERSION_SET` `3 5 0` → `3 6 0` and the libtool SONAME `LIBJWT_SO_CRA` `17:1:3` → `18:0:4`.

**SONAME rationale** — an `nm` diff of the exported `jwt*`/`jwk*`/`jwe*` symbols between `v3.5.0` and `HEAD` shows **37 symbols added, 0 removed or changed**, which per the [libtool rules](http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html) is `current++, revision=0, age++`. The SONAME major (`current - age`) stays **14**, unchanged across all of 3.x (the resulting shared object is `libjwt.14.4.0`).

The 37 new symbols span this cycle: JWK thumbprints (RFC 7638/9278), `cnf` helpers (RFC 7800), JWS JSON Serialization + multi-signature (RFC 7515 §7.2), unencoded/detached payloads (RFC 7797), `typ` + algorithm allowlist (RFC 8725), key generation, AES-GCM-KW + PBES2 JWE, X.509 JWK params (RFC 7517 §4.7/4.9), the cached remote JWKS source, and the application-profile primitives (RFC 9068 / RFC 9449 / OIDC). New enum values and the ML-DSA macro carry `@since 3.6.0` but are not linker symbols, so they don't move `current`/`age`.

`make check` passes; valgrind-clean.
