### PR TITLE
Release v3.6.1

### DIFF
--- a/cmake/LibJWTVersions.cmake
+++ b/cmake/LibJWTVersions.cmake
@@ -4,9 +4,9 @@ set(LIBJWT_PROJECT		"LibJWT")
 set(LIBJWT_DESCRIPTION		"The C JSON Web Token Library +JWK +JWKS")
 set(LIBJWT_HOMEPAGE_URL		"https://libjwt.io")
 
-set(LIBJWT_VERSION_SET		3 6 0)
+set(LIBJWT_VERSION_SET		3 6 1)
 
-set(LIBJWT_SO_CRA		18 0 4)
+set(LIBJWT_SO_CRA		18 1 4)
 # SONAME History
 # v1.12.1      0 => 1
 # v1.15.0      1 => 2


### PR DESCRIPTION
Release v3.6.1.

A test-portability patch release. Bumps `LIBJWT_VERSION_SET` `3 6 0` → `3 6 1` and the libtool SONAME `LIBJWT_SO_CRA` `18:0:4` → `18:1:4` (`revision++`).

The only change since v3.6.0 (commit `b7bb97a`, already on master) is in the jwks-cache test server: it cast `write()` to `(void)` to ignore the result, but glibc marks `write()` `warn_unused_result` and the cast does not suppress it on newer glibc, breaking the `-Werror` build. It now asserts the result with `ck_assert_int_gt(write(...), 0)`.

No library source changed — the exported `jwt*`/`jwk*`/`jwe*` symbol set is identical to v3.6.0 — so per the [libtool rules](http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html) only the SONAME revision advances. The **SONAME stays `libjwt.so.14`**.

`make check` passes.
